### PR TITLE
Increase stream consumer timeout

### DIFF
--- a/glassflow-api/internal/core/stream/consumer.go
+++ b/glassflow-api/internal/core/stream/consumer.go
@@ -23,8 +23,8 @@ type Consumer struct {
 }
 
 const (
-	ConsumerRetries      = 4
-	ConsumerRetryBackoff = 20 * time.Millisecond
+	ConsumerRetries      = 5
+	ConsumerRetryBackoff = 30 * time.Millisecond
 )
 
 func NewConsumer(ctx context.Context, js jetstream.JetStream, cfg ConsumerConfig) (*Consumer, error) {


### PR DESCRIPTION
Increases the timeout for stream consumers to give ample time for the bridge to start.

Temporary change until:
either all stream creation logic is moved to pipeline service before starting operators
or a reconciliation manager is added (in form of cluster operator or via a custom manager pattern)