### PR TITLE
ETL-1: pipelines show error when no pipeline

### DIFF
--- a/ui/src/app/home/page.tsx
+++ b/ui/src/app/home/page.tsx
@@ -23,6 +23,7 @@ import {
   DialogFooter,
 } from '@/src/components/ui/dialog'
 import { AlertTriangleIcon } from 'lucide-react'
+import { getPipelineStatus } from '@/src/api/pipeline'
 
 import { InfoModal, ModalResult } from '@/src/components/common/Modal'
 import { SavedConfigurations } from '@/src/components/shared/SavedConfigurations'
@@ -56,6 +57,23 @@ function HomePageClient() {
   const { getIsTopicDirty } = topicsStore
   const { getIsJoinDirty } = joinStore
   const { getIsClickhouseConnectionDirty, getClickhouseMappingDirty } = clickhouseStore
+
+  // Check for running pipeline and redirect to pipeline page if one exists
+  useEffect(() => {
+    const checkRunningPipeline = async () => {
+      try {
+        const response = await getPipelineStatus()
+        if (response.pipeline_id) {
+          // There is a running pipeline, redirect to pipeline page
+          router.push('/pipelines')
+        }
+      } catch (err) {
+        // No pipeline running, stay on home page
+      }
+    }
+
+    checkRunningPipeline()
+  }, [router])
 
   // Track page view when component loads
   useEffect(() => {

--- a/ui/src/modules/pipelines/PipelineDeployer.tsx
+++ b/ui/src/modules/pipelines/PipelineDeployer.tsx
@@ -114,13 +114,8 @@ export function PipelineDeployer() {
             // We have a valid config and no running pipeline - we can deploy
             deployPipeline()
           } else {
-            // No config and no pipeline - redirect to home
-            setStatus('no_configuration')
-            setError('No pipeline configuration found. Redirecting to home page...')
-            setIsRedirecting(true)
-            setTimeout(() => {
-              router.push('/home')
-            }, 7000)
+            // No config and no pipeline - redirect to home immediately
+            router.push('/home')
           }
         }
       } catch (err: any) {
@@ -129,12 +124,8 @@ export function PipelineDeployer() {
           if (isValidApiConfig(apiConfig)) {
             deployPipeline()
           } else {
-            setStatus('no_configuration')
-            setError('No pipeline configuration found. Redirecting to home page...')
-            setIsRedirecting(true)
-            setTimeout(() => {
-              router.push('/home')
-            }, 7000)
+            // No config and no pipeline - redirect to home immediately
+            router.push('/home')
           }
         } else {
           setStatus('deploy_failed')


### PR DESCRIPTION
* add check to home is there a running pipeline and redirect to /pipelines if there is
* immediately redirect to home from /pipelines if no valid config present and no running pipeline