### PR TITLE
Build binary before e2e test

### DIFF
--- a/.github/workflows/build_binary.yaml
+++ b/.github/workflows/build_binary.yaml
@@ -1,0 +1,39 @@
+name: Release
+
+on:
+  workflow_call:
+
+jobs:
+  build-api-binary:
+    name: Build API binaries
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        module: [glassflow-api, nats-kafka-bridge]
+        platform:
+          - os: linux
+            arch: amd64
+          - os: linux
+            arch: arm64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: './${{ matrix.module }}/go.mod'
+          cache-dependency-path: './${{ matrix.module }}/go.mod'
+      - name: Build binary
+        working-directory: ${{ matrix.module }}
+        run: make build
+        env:
+          GOOS: ${{ matrix.platform.os }}
+          GOARCH: ${{ matrix.platform.arch }}
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          retention-days: 1
+          name: ${{ matrix.module }}-${{ matrix.platform.os }}-${{ matrix.platform.arch }}
+          path: ${{ matrix.module }}/bin

--- a/.github/workflows/build_image.yaml
+++ b/.github/workflows/build_image.yaml
@@ -1,5 +1,3 @@
-name: Release
-
 on:
   workflow_call:
     inputs:
@@ -8,44 +6,9 @@ on:
         description: push to dockerhub
 
 jobs:
-  build-api-binary:
-    name: Build API binaries
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    strategy:
-      matrix:
-        module: [glassflow-api, nats-kafka-bridge]
-        platform:
-          - os: linux
-            arch: amd64
-          - os: linux
-            arch: arm64
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: './${{ matrix.module }}/go.mod'
-          cache-dependency-path: './${{ matrix.module }}/go.mod'
-      - name: Build binary
-        working-directory: ${{ matrix.module }}
-        run: make build
-        env:
-          GOOS: ${{ matrix.platform.os }}
-          GOARCH: ${{ matrix.platform.arch }}
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          retention-days: 1
-          name: ${{ matrix.module }}-${{ matrix.platform.os }}-${{ matrix.platform.arch }}
-          path: ${{ matrix.module }}/bin
-
   build-docker-image:
     name: Build API Image
     runs-on: ubuntu-latest
-    needs: build-api-binary
     outputs:
       amd64_digest: ${{ steps.gen-output.outputs.amd64_digest }}
       arm64_digest: ${{ steps.gen-output.outputs.arm64_digest }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,12 +6,16 @@ on:
       - main
 
 jobs:
+  build-binary:
+    uses: ./.github/workflows/build_binary.yaml
   test:
+    needs:
+      - build-binary
     uses: ./.github/workflows/test.yaml
   build:
     needs:
       - test
-    uses: ./.github/workflows/build.yaml
+    uses: ./.github/workflows/build_image.yaml
     with:
       push: true
     secrets: inherit

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -3,6 +3,17 @@ on:
   pull_request
 
 jobs:
+  build-binary:
+    uses: ./.github/workflows/build_binary.yaml
   test:
+    needs:
+      - build-binary
     uses: ./.github/workflows/test.yaml
+  build:
+    needs:
+      - test
+    uses: ./.github/workflows/build_image.yaml
+    with:
+      push: false
+    secrets: inherit
 

--- a/.github/workflows/push_image.yaml
+++ b/.github/workflows/push_image.yaml
@@ -1,0 +1,11 @@
+name: Push Image
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-and-push-image:
+    uses: ./.github/workflows/build.yaml
+    with:
+      push: true
+    secrets: inherit

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -1,13 +1,18 @@
 name: Push Tag
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - v*
 
 jobs:
+  build-binary:
+    uses: ./.github/workflows/build_binary.yaml
   build-and-release:
-    uses: ./.github/workflows/build.yaml
+    needs:
+      - build-binary
+    uses: ./.github/workflows/build_image.yaml
     with:
       push: true
     secrets: inherit

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,26 @@ jobs:
       - name: Run test
         working-directory: './glassflow-api'
         run: make run-test
-      - name: Run E2E test
+
+  test-e2e:
+    name: test e2e
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: './glassflow-api/go.mod'
+          cache-dependency-path: './glassflow-api/go.mod'
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: nats-kafka-bridge-linux-amd64
+          path: nats-kafka-bridge/bin
+      - name: Make artifact executable
+        run: chmod +x nats-kafka-bridge/bin/* && echo "$PWD/nats-kafka-bridge/bin" >> "$GITHUB_PATH"
+      - name: run e2e test
         working-directory: './glassflow-api'
         run: make run-e2e-test
 


### PR DESCRIPTION
Ensures binaries are created separately and are used for e2e testing, only then image from these binaries is created and pushed.