### PR TITLE
ETL 176: Persist http clickhouse port in pipeline configuration

### DIFF
--- a/glassflow-api/internal/api/pipeline.go
+++ b/glassflow-api/internal/api/pipeline.go
@@ -225,7 +225,8 @@ type clickhouseSink struct {
 	Kind string `json:"type"`
 	// Add validation for null/empty values
 	Host     string                    `json:"host"`
-	Port     string                    `json:"port"`
+	Port     string                    `json:"port"`      // native port used in BE connection
+	HttpPort string                    `json:"http_port"` // http port used by UI for FE connection
 	Database string                    `json:"database"`
 	Username string                    `json:"username"`
 	Password string                    `json:"password"`
@@ -308,6 +309,7 @@ func (p pipelineJSON) toModel() (zero models.PipelineConfig, _ error) {
 	sc, err = models.NewClickhouseSinkOperator(models.ClickhouseSinkArgs{
 		Host:                 p.Sink.Host,
 		Port:                 p.Sink.Port,
+		HttpPort:             p.Sink.HttpPort,
 		DB:                   p.Sink.Database,
 		User:                 p.Sink.Username,
 		Password:             p.Sink.Password,
@@ -475,6 +477,7 @@ func toPipelineJSON(p models.PipelineConfig) pipelineJSON {
 			Kind:                        models.ClickHouseSinkType,
 			Host:                        p.Sink.ClickHouseConnectionParams.Host,
 			Port:                        p.Sink.ClickHouseConnectionParams.Port,
+			HttpPort:                    p.Sink.ClickHouseConnectionParams.HttpPort,
 			Database:                    p.Sink.ClickHouseConnectionParams.Database,
 			Username:                    p.Sink.ClickHouseConnectionParams.Username,
 			Password:                    p.Sink.ClickHouseConnectionParams.Password,

--- a/glassflow-api/internal/models/configs.go
+++ b/glassflow-api/internal/models/configs.go
@@ -240,7 +240,8 @@ func NewJoinOperatorConfig(kind string, sources []JoinSourceConfig) (zero JoinOp
 
 type ClickHouseConnectionParamsConfig struct {
 	Host                 string `json:"host"`
-	Port                 string `json:"port"`
+	Port                 string `json:"port"`      // native port used in BE connection
+	HttpPort             string `json:"http_port"` // http port used by UI for FE connection
 	Database             string `json:"database"`
 	Username             string `json:"username"`
 	Password             string `json:"password"`
@@ -264,6 +265,7 @@ type SinkOperatorConfig struct {
 type ClickhouseSinkArgs struct {
 	Host                 string
 	Port                 string
+	HttpPort             string
 	DB                   string
 	User                 string
 	Password             string
@@ -312,6 +314,7 @@ func NewClickhouseSinkOperator(args ClickhouseSinkArgs) (zero SinkOperatorConfig
 		ClickHouseConnectionParams: ClickHouseConnectionParamsConfig{
 			Host:                 args.Host,
 			Port:                 args.Port,
+			HttpPort:             args.HttpPort,
 			Database:             args.DB,
 			Username:             args.User,
 			Password:             args.Password,


### PR DESCRIPTION
BE: create pipeline request (with sink http_port)
```sh
curl 'http://localhost:8085/api/v1/pipeline' -X 'POST' --data-raw '{"pipeline_id": "6ed22a3f-efd2-49d8-a3b2-430f1008b909", "source": {"type": "kafka", "provider": "custom", "connection_params": {"brokers": ["kafka:9093"], "protocol": "PLAINTEXT", "skip_auth": true}, "topics": [{"consumer_group_initial_offset": "latest", "name": "users", "id": "users", "schema": {"type": "json", "fields": [{"name": "event_id", "type": "string"}, {"name": "user", "type": "string"}, {"name": "created_at", "type": "string"}, {"name": "tags", "type": "array"}]}, "deduplication": {"enabled": false}}]}, "sink": {"type": "clickhouse", "provider": "custom", "host": "clickhouse", "port": "9000", "http_port": "8123", "database": "default", "username": "default", "password": "c2VjcmV0", "secure": false, "skip_certificate_verification": true, "max_batch_size": 1, "max_delay_time": "10s", "table": "users_dedup", "table_mapping": [{"source_id": "users", "field_name": "event_id", "column_name": "event_id", "column_type": "UUID"}, {"source_id": "users", "field_name": "event_id", "column_name": "user_id", "column_type": "UUID"}, {"source_id": "users", "field_name": "event_id", "column_name": "name", "column_type": "String"}, {"source_id": "users", "field_name": "event_id", "column_name": "email", "column_type": "String"}, {"source_id": "users", "field_name": "created_at", "column_name": "created_at", "column_type": "DateTime"}, {"source_id": "users", "field_name": "tags", "column_name": "tags", "column_type": "Array(String)"}]}}'
```

BE: get pipeline request 
``` sh
curl 'http://app:8080/api/v1/pipeline/6ed22a3f-efd2-49d8-a3b2-430f1008b909'
```

BE: get pipeline response with http_port 
``` json
{
  "pipeline_id": "6ed22a3f-efd2-49d8-a3b2-430f1008b909",
  "name": "",
  "source": {
    "type": "kafka",
    "provider": "custom",
    "connection_params": {
      "brokers": [
        "kafka:9093"
      ],
      "skip_auth": true,
      "protocol": "PLAINTEXT",
      "mechanism": "",
      "username": "",
      "password": "",
      "root_ca": ""
    },
    "topics": [
      {
        "name": "users",
        "id": "users",
        "schema": {
          "type": "json",
          "fields": [
            {
              "name": "event_id",
              "type": "string"
            },
            {
              "name": "user",
              "type": "string"
            },
            {
              "name": "created_at",
              "type": "string"
            },
            {
              "name": "tags",
              "type": "array"
            }
          ]
        },
        "consumer_group_initial_offset": "latest",
        "deduplication": {
          "enabled": false,
          "id_field": "",
          "id_field_type": "",
          "time_window": "0s"
        }
      }
    ]
  },
  "join": {
    "type": "temporal",
    "enabled": false,
    "sources": null
  },
  "sink": {
    "type": "clickhouse",
    "host": "clickhouse",
    "port": "9000",
    "http_port": "8123",
    "database": "default",
    "username": "default",
    "password": "c2VjcmV0",
    "table": "users_dedup",
    "secure": false,
    "table_mapping": [
      {
        "source_id": "users",
        "field_name": "event_id",
        "column_name": "event_id",
        "column_type": "UUID"
      },
      {
        "source_id": "users",
        "field_name": "event_id",
        "column_name": "user_id",
        "column_type": "UUID"
      },
      {
        "source_id": "users",
        "field_name": "event_id",
        "column_name": "name",
        "column_type": "String"
      },
      {
        "source_id": "users",
        "field_name": "event_id",
        "column_name": "email",
        "column_type": "String"
      },
      {
        "source_id": "users",
        "field_name": "created_at",
        "column_name": "created_at",
        "column_type": "DateTime"
      },
      {
        "source_id": "users",
        "field_name": "tags",
        "column_name": "tags",
        "column_type": "Array(String)"
      }
    ],
    "max_batch_size": 1,
    "max_delay_time": "10s",
    "skip_certificate_verification": true
  }
}
```