### PR TITLE
feat: pipeline health endpoint

### DIFF
--- a/glassflow-api/docs/pipeline-status.md
+++ b/glassflow-api/docs/pipeline-status.md
@@ -1,0 +1,55 @@
+# Pipeline Status Feature
+
+This document describes the pipeline status feature that allows tracking the health and status of pipeline components in real-time.
+
+## Pipeline Statuses
+
+### Overall Pipeline Status
+- **Created**: Pipeline creation request has been successfully sent to the Kubernetes operator
+- **Running**: All components are running successfully
+- **Terminating**: Pipeline termination request has been sent to the Kubernetes operator
+- **Terminated**: All components have been terminated
+- **Failed**: One or more components have failed (To be discussed)
+
+### Component Statuses
+For now, this is not added. TBD
+
+## API Endpoints
+
+### Get Pipeline Health
+```
+GET /api/v1/pipeline/{id}/health
+```
+
+Returns the current health status of a pipeline including:
+- Overall pipeline status
+
+**Response Example:**
+```json
+{
+  "pipeline_id": "my-pipeline",
+  "pipeline_name": "My Pipeline",
+  "overall_status": "Running",
+  "created_at": "2024-01-15T10:00:00Z",
+  "updated_at": "2024-01-15T10:30:00Z"
+}
+```
+
+**Valid Statuses:**
+- `Created`
+- `Running`
+- `Terminating`
+- `Terminated`
+- `Failed`
+
+## Integration with Kubernetes Operator
+
+The Kubernetes operator is responsible for:
+- Setting component status to `Running` when deployments are ready
+- Setting component status to `Terminated` when deployments are deleted
+
+The API automatically:
+- Sets status to `Created` when pipeline creation is successful
+- Sets status to `Terminating` when pipeline termination is requested
+
+

--- a/glassflow-api/internal/api/router.go
+++ b/glassflow-api/internal/api/router.go
@@ -30,6 +30,7 @@ func NewRouter(log *slog.Logger, pSvc service.PipelineManager, dlqSvc service.DL
 	r.HandleFunc("/api/v1/pipeline/{id}", h.getPipeline).Methods("GET")
 	r.HandleFunc("/api/v1/pipeline/{id}", h.updatePipelineName).Methods("PATCH")
 	r.HandleFunc("/api/v1/pipeline", h.getPipelines).Methods("GET")
+	r.HandleFunc("/api/v1/pipeline/{id}/health", h.getPipelineHealth).Methods("GET")
 	r.HandleFunc("/api/v1/pipeline/{id}/dlq/consume", h.consumeDLQ).
 		Queries("batch_size", "{batchSize}").
 		Methods("GET")

--- a/glassflow-api/internal/models/configs_test.go
+++ b/glassflow-api/internal/models/configs_test.go
@@ -1,0 +1,52 @@
+package models
+
+import (
+	"testing"
+)
+
+func TestNewPipelineHealth(t *testing.T) {
+	pipelineID := "test-pipeline"
+	pipelineName := "Test Pipeline"
+
+	health := NewPipelineHealth(pipelineID, pipelineName)
+
+	if health.PipelineID != pipelineID {
+		t.Errorf("Expected PipelineID %s, got %s", pipelineID, health.PipelineID)
+	}
+
+	if health.PipelineName != pipelineName {
+		t.Errorf("Expected PipelineName %s, got %s", pipelineName, health.PipelineName)
+	}
+
+	if health.OverallStatus != PipelineStatusCreated {
+		t.Errorf("Expected OverallStatus %s, got %s", PipelineStatusCreated, health.OverallStatus)
+	}
+
+}
+
+func TestNewPipelineConfig(t *testing.T) {
+	id := "test-pipeline"
+	name := "Test Pipeline"
+	mapper := MapperConfig{Type: SchemaMapperJSONToCHType}
+	ingestor := IngestorOperatorConfig{Type: KafkaIngestorType}
+	join := JoinOperatorConfig{Type: TemporalJoinType}
+	sink := SinkOperatorConfig{Type: ClickHouseSinkType}
+
+	config := NewPipelineConfig(id, name, mapper, ingestor, join, sink)
+
+	if config.ID != id {
+		t.Errorf("Expected ID %s, got %s", id, config.ID)
+	}
+
+	if config.Name != name {
+		t.Errorf("Expected Name %s, got %s", name, config.Name)
+	}
+
+	if config.Status.PipelineID != id {
+		t.Errorf("Expected Status.PipelineID %s, got %s", id, config.Status.PipelineID)
+	}
+
+	if config.Status.OverallStatus != PipelineStatusCreated {
+		t.Errorf("Expected Status.OverallStatus %s, got %s", PipelineStatusCreated, config.Status.OverallStatus)
+	}
+}


### PR DESCRIPTION
# Pipeline Status Feature

This document describes the pipeline status feature that allows tracking the health and status of pipeline components in real-time.

## Pipeline Statuses

### Overall Pipeline Status
- **Created**: Pipeline creation request has been successfully sent to the Kubernetes operator
- **Running**: All components are running successfully
- **Terminating**: Pipeline termination request has been sent to the Kubernetes operator
- **Terminated**: All components have been terminated
- **Failed**: One or more components have failed (To be discussed)

### Component Statuses
For now, this is not added. TBD

## API Endpoints

### Get Pipeline Health
```
GET /api/v1/pipeline/{id}/health
```

Returns the current health status of a pipeline including:
- Overall pipeline status

**Response Example:**
```json
{
  "pipeline_id": "my-pipeline",
  "pipeline_name": "My Pipeline",
  "overall_status": "Running",
  "created_at": "2024-01-15T10:00:00Z",
  "updated_at": "2024-01-15T10:30:00Z"
}
```

**Valid Statuses:**
- `Created`
- `Running`
- `Terminating`
- `Terminated`
- `Failed`

## Integration with Kubernetes Operator

The Kubernetes operator is responsible for:
- Setting component status to `Running` when deployments are ready
- Setting component status to `Terminated` when deployments are deleted

The API automatically:
- Sets status to `Created` when pipeline creation is successful
- Sets status to `Terminating` when pipeline termination is requested

