### PR TITLE
fix: GET DLQ returns 404 if batch_size not sent, added default

### DIFF
--- a/glassflow-api/internal/api/router.go
+++ b/glassflow-api/internal/api/router.go
@@ -31,9 +31,7 @@ func NewRouter(log *slog.Logger, pSvc service.PipelineManager, dlqSvc service.DL
 	r.HandleFunc("/api/v1/pipeline/{id}", h.updatePipelineName).Methods("PATCH")
 	r.HandleFunc("/api/v1/pipeline", h.getPipelines).Methods("GET")
 	r.HandleFunc("/api/v1/pipeline/{id}/health", h.getPipelineHealth).Methods("GET")
-	r.HandleFunc("/api/v1/pipeline/{id}/dlq/consume", h.consumeDLQ).
-		Queries("batch_size", "{batchSize}").
-		Methods("GET")
+	r.HandleFunc("/api/v1/pipeline/{id}/dlq/consume", h.consumeDLQ).Methods("GET")
 	r.HandleFunc("/api/v1/pipeline/{id}/dlq/state", h.getDLQState).Methods("GET")
 	r.HandleFunc("/api/v1/pipeline/{id}", h.shutdownPipeline).Methods("DELETE")
 	r.HandleFunc("/api/v1/pipeline/{id}/terminate", h.terminatePipeline).Methods("DELETE")

--- a/glassflow-api/internal/service/dlq.go
+++ b/glassflow-api/internal/service/dlq.go
@@ -8,6 +8,7 @@ import (
 )
 
 const DLQSuffix = "DLQ"
+const DLQDefaultBatchSize = 1
 
 type DLQ interface {
 	ConsumeDLQ(ctx context.Context, pid string, batchSize models.DLQBatchSize) ([]models.DLQMessage, error)


### PR DESCRIPTION
We need to set default batch size for messages on the backend side, because by default without that it return 404 error:

```sh
(venv) root@ubuntu:/# curl -X GET http://glassflow-etl-api.glassflow-test.svc.cluster.local:8080/api/v1/pipeline/deduplication-demo-pipeline/dlq/consume
 404 page not found
```

But with parameter batch_size - works fine:
```sh
(venv) root@ubuntu:/# curl -X GET http://glassflow-etl-api.glassflow-test.svc.cluster.local:8080/api/v1/pipeline/deduplication-demo-pipeline/dlq/consume?batch_size=10
```
```json
[{"component":"ingestor","error":"failed to validate data","original_message":""},{"component":"ingestor","error":"failed to validate data","original_message":""},{"component":"ingestor","error":"failed to validate data","original_message":""},{"component":"ingestor","error":"failed to validate data","original_message":""},{"component":"ingestor","error":"failed to validate data","original_message":""},{"component":"ingestor","error":"failed to validate data","original_message":""},{"component":"ingestor","error":"failed to validate data","original_message":""},{"component":"ingestor","error":"failed to validate data","original_message":""},{"component":"ingestor","error":"failed to validate data","original_message":""},{"component":"ingestor","error":"failed to validate data","original_message":""}]
```

Proposal is to have default value, at least 1.