### PR TITLE
fix: ingestor o/p stream names are same as kafka topic names

### DIFF
--- a/glassflow-api/cmd/glassflow/main.go
+++ b/glassflow-api/cmd/glassflow/main.go
@@ -255,8 +255,9 @@ func mainSink(ctx context.Context, nc *client.NATSClient, cfg *config, log *slog
 		if len(pipelineCfg.Ingestor.KafkaTopics) == 0 {
 			return fmt.Errorf("no Kafka topics configured")
 		}
-		streamName = pipelineCfg.Ingestor.KafkaTopics[0].Name
-		streamSubject = streamName + ".input"
+
+		streamName = models.GetIngestionStreamName(pipelineCfg.ID, pipelineCfg.Ingestor.KafkaTopics[0].Name)
+		streamSubject = models.GetIngestionStreamSubjectName(pipelineCfg.ID, pipelineCfg.Ingestor.KafkaTopics[0].Name)
 	}
 
 	sinkRunner := service.NewSinkRunner(log, nc)

--- a/glassflow-api/internal/core/operator/ingestor.go
+++ b/glassflow-api/internal/core/operator/ingestor.go
@@ -28,6 +28,7 @@ type IngestorOperator struct {
 func NewIngestorOperator(
 	config models.IngestorOperatorConfig,
 	topicName string,
+	streamName string,
 	natsStreamSubject string,
 	dlqStreamSubject string,
 	nc *client.NATSClient,
@@ -60,12 +61,12 @@ func NewIngestorOperator(
 		},
 	)
 
-	ingestor, err := ingestor.NewKafkaIngestor(config, topicName, streamPublisher, dlqStreamPublisher, schemaMapper, log)
+	op, err := ingestor.NewKafkaIngestor(config, topicName, streamName, streamPublisher, dlqStreamPublisher, schemaMapper, log)
 	if err != nil {
 		return nil, fmt.Errorf("error creating kafka source ingestor: %w", err)
 	}
 	return &IngestorOperator{
-		ingestor: ingestor,
+		ingestor: op,
 		log:      log,
 		wg:       sync.WaitGroup{},
 	}, nil

--- a/glassflow-api/internal/models/configs.go
+++ b/glassflow-api/internal/models/configs.go
@@ -474,6 +474,14 @@ func GetJoinedStreamName(pipelineID string) string {
 	return fmt.Sprintf("%s-%s", GFJoinStream, pipelineID)
 }
 
+func GetIngestionStreamName(pipelineID, topicName string) string {
+	return fmt.Sprintf("%s-%s-%s", "gf-ingest", pipelineID, topicName)
+}
+
+func GetIngestionStreamSubjectName(pipelineID, topicName string) string {
+	return GetIngestionStreamName(pipelineID, topicName) + ".input"
+}
+
 // NewPipelineHealth creates a new pipeline health status
 func NewPipelineHealth(pipelineID, pipelineName string) PipelineHealth {
 	now := time.Now().UTC()

--- a/glassflow-api/internal/models/configs_test.go
+++ b/glassflow-api/internal/models/configs_test.go
@@ -50,3 +50,102 @@ func TestNewPipelineConfig(t *testing.T) {
 		t.Errorf("Expected Status.OverallStatus %s, got %s", PipelineStatusCreated, config.Status.OverallStatus)
 	}
 }
+
+func TestGetIngestionStreamName(t *testing.T) {
+	tests := []struct {
+		name       string
+		pipelineID string
+		topicName  string
+		expected   string
+	}{
+		{
+			name:       "basic stream name",
+			pipelineID: "pipeline-123",
+			topicName:  "users",
+			expected:   "gf-ingest-pipeline-123-users",
+		},
+		{
+			name:       "different pipeline same topic",
+			pipelineID: "pipeline-456",
+			topicName:  "users",
+			expected:   "gf-ingest-pipeline-456-users",
+		},
+		{
+			name:       "same pipeline different topic",
+			pipelineID: "pipeline-123",
+			topicName:  "orders",
+			expected:   "gf-ingest-pipeline-123-orders",
+		},
+		{
+			name:       "special characters in names",
+			pipelineID: "pipeline_with_underscores",
+			topicName:  "topic-with-dashes",
+			expected:   "gf-ingest-pipeline_with_underscores-topic-with-dashes",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetIngestionStreamName(tt.pipelineID, tt.topicName)
+			if result != tt.expected {
+				t.Errorf("GetIngestionStreamName(%s, %s) = %s, want %s", tt.pipelineID, tt.topicName, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetIngestionStreamSubjectName(t *testing.T) {
+	tests := []struct {
+		name       string
+		pipelineID string
+		topicName  string
+		expected   string
+	}{
+		{
+			name:       "basic subject name",
+			pipelineID: "pipeline-123",
+			topicName:  "users",
+			expected:   "gf-ingest-pipeline-123-users.input",
+		},
+		{
+			name:       "different pipeline same topic",
+			pipelineID: "pipeline-456",
+			topicName:  "users",
+			expected:   "gf-ingest-pipeline-456-users.input",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetIngestionStreamSubjectName(tt.pipelineID, tt.topicName)
+			if result != tt.expected {
+				t.Errorf("GetIngestionStreamSubjectName(%s, %s) = %s, want %s", tt.pipelineID, tt.topicName, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestStreamNameUniqueness(t *testing.T) {
+	// Test that different pipelines with the same topic get different stream names
+	pipeline1 := "pipeline-123"
+	pipeline2 := "pipeline-456"
+	topic := "users"
+
+	stream1 := GetIngestionStreamName(pipeline1, topic)
+	stream2 := GetIngestionStreamName(pipeline2, topic)
+
+	if stream1 == stream2 {
+		t.Errorf("Stream names should be unique for different pipelines: %s == %s", stream1, stream2)
+	}
+
+	// Test that the same pipeline with different topics get different stream names
+	topic1 := "users"
+	topic2 := "orders"
+
+	stream3 := GetIngestionStreamName(pipeline1, topic1)
+	stream4 := GetIngestionStreamName(pipeline1, topic2)
+
+	if stream3 == stream4 {
+		t.Errorf("Stream names should be unique for different topics: %s == %s", stream3, stream4)
+	}
+}

--- a/glassflow-api/internal/orchestrator/k8s.go
+++ b/glassflow-api/internal/orchestrator/k8s.go
@@ -71,7 +71,7 @@ func (k *K8sOrchestrator) SetupPipeline(ctx context.Context, cfg *models.Pipelin
 	for _, s := range cfg.Ingestor.KafkaTopics {
 		src = append(src, operator.SourceStream{
 			TopicName:    s.Name,
-			OutputStream: s.Name,
+			OutputStream: models.GetIngestionStreamName(cfg.ID, s.Name),
 			DedupWindow:  s.Deduplication.Window.Duration(),
 		})
 	}

--- a/glassflow-api/internal/service/ingestor_runner.go
+++ b/glassflow-api/internal/service/ingestor_runner.go
@@ -31,10 +31,12 @@ func NewIngestorRunner(log *slog.Logger, nc *client.NATSClient) *IngestorRunner 
 }
 
 func (i *IngestorRunner) Start(ctx context.Context, topicName string, pipelineCfg models.PipelineConfig, schemaMapper schema.Mapper) error {
+	streamName := models.GetIngestionStreamName(pipelineCfg.ID, topicName)
 	ingestorOperator, err := operator.NewIngestorOperator(
 		pipelineCfg.Ingestor,
 		topicName,
-		topicName+".input",
+		streamName,
+		models.GetIngestionStreamSubjectName(pipelineCfg.ID, topicName),
 		models.GetDLQStreamSubjectName(pipelineCfg.ID),
 		i.nc,
 		schemaMapper,

--- a/glassflow-api/tests/features/ingestor/ingestor.feature
+++ b/glassflow-api/tests/features/ingestor/ingestor.feature
@@ -5,8 +5,8 @@ Feature: Kafka Ingestor
         Given the NATS stream config:
             """json
             {
-                "stream": "ingestor_stream",
-                "subject": "ingestor_subject",
+                "stream": "gf-ingest-test-pipeline-test_topic",
+                "subject": "gf-ingest-test-pipeline-test_topic.input",
                 "consumer": "ingestor_consumer"
             }
             """
@@ -18,7 +18,7 @@ Feature: Kafka Ingestor
             {
                 "type": "jsonToClickhouse",
                 "streams": {
-                    "test_topic": {
+                    "gf-ingest-test-pipeline-test_topic": {
                         "fields": [
                             {
                                 "field_name": "id",
@@ -35,13 +35,13 @@ Feature: Kafka Ingestor
                     {
                         "column_name": "id",
                         "field_name": "id",
-                        "stream_name": "test_topic",
+                        "stream_name": "gf-ingest-test-pipeline-test_topic",
                         "column_type": "string"
                     },
                     {
                         "column_name": "name",
                         "field_name": "name",
-                        "stream_name": "test_topic",
+                        "stream_name": "gf-ingest-test-pipeline-test_topic",
                         "column_type": "String"
                     }
                 ]
@@ -98,7 +98,7 @@ Feature: Kafka Ingestor
             {
                 "type": "jsonToClickhouse",
                 "streams": {
-                    "test_topic": {
+                    "gf-ingest-test-pipeline-test_topic": {
                         "fields": [
                             {
                                 "field_name": "id",
@@ -115,13 +115,13 @@ Feature: Kafka Ingestor
                     {
                         "column_name": "id",
                         "field_name": "id",
-                        "stream_name": "test_topic",
+                        "stream_name": "gf-ingest-test-pipeline-test_topic",
                         "column_type": "string"
                     },
                     {
                         "column_name": "name",
                         "field_name": "name",
-                        "stream_name": "test_topic",
+                        "stream_name": "gf-ingest-test-pipeline-test_topic",
                         "column_type": "String"
                     }
                 ]
@@ -176,7 +176,7 @@ Feature: Kafka Ingestor
             {
                 "type": "jsonToClickhouse",
                 "streams": {
-                    "test_topic": {
+                    "gf-ingest-test-pipeline-test_topic": {
                         "fields": [
                             {
                                 "field_name": "id",
@@ -193,13 +193,13 @@ Feature: Kafka Ingestor
                     {
                         "column_name": "id",
                         "field_name": "id",
-                        "stream_name": "test_topic",
+                        "stream_name": "gf-ingest-test-pipeline-test_topic",
                         "column_type": "string"
                     },
                     {
                         "column_name": "name",
                         "field_name": "name",
-                        "stream_name": "test_topic",
+                        "stream_name": "gf-ingest-test-pipeline-test_topic",
                         "column_type": "String"
                     }
                 ]
@@ -256,7 +256,7 @@ Feature: Kafka Ingestor
             {
                 "type": "jsonToClickhouse",
                 "streams": {
-                    "test_topic": {
+                    "gf-ingest-test-pipeline-test_topic": {
                         "fields": [
                             {
                                 "field_name": "id",
@@ -273,13 +273,13 @@ Feature: Kafka Ingestor
                     {
                         "column_name": "id",
                         "field_name": "id",
-                        "stream_name": "test_topic",
+                        "stream_name": "gf-ingest-test-pipeline-test_topic",
                         "column_type": "string"
                     },
                     {
                         "column_name": "name",
                         "field_name": "name",
-                        "stream_name": "test_topic",
+                        "stream_name": "gf-ingest-test-pipeline-test_topic",
                         "column_type": "String"
                     }
                 ]

--- a/glassflow-api/tests/features/pipeline/pipeline.feature
+++ b/glassflow-api/tests/features/pipeline/pipeline.feature
@@ -22,7 +22,7 @@ Feature: Kafka to CH pipeline
                 "mapper": {
                     "type": "jsonToClickhouse",
                     "streams": {
-                        "test_topic": {
+                        "gf-ingest-kafka-to-clickhouse-pipeline-b00001-test_topic": {
                             "fields": [
                                 {
                                     "field_name": "id",
@@ -37,13 +37,13 @@ Feature: Kafka to CH pipeline
                     },
                     "sink_mapping": [
                         {
-                            "stream_name": "test_topic",
+                            "stream_name": "gf-ingest-kafka-to-clickhouse-pipeline-b00001-test_topic",
                             "field_name": "id",
                             "column_name": "id",
                             "column_type": "String"
                         },
                         {
-                            "stream_name": "test_topic",
+                            "stream_name": "gf-ingest-kafka-to-clickhouse-pipeline-b00001-test_topic",
                             "field_name": "name",
                             "column_name": "name",
                             "column_type": "String"
@@ -116,7 +116,7 @@ Feature: Kafka to CH pipeline
                 "mapper": {
                     "type": "jsonToClickhouse",
                     "streams": {
-                        "test_users": {
+                        "gf-ingest-kafka-to-clickhouse-pipeline-b00002-test_users": {
                             "fields": [
                                 {
                                     "field_name": "id",
@@ -131,7 +131,7 @@ Feature: Kafka to CH pipeline
                             "join_window": "1h",
                             "join_orientation": "right"
                         },
-                        "test_emails": {
+                        "gf-ingest-kafka-to-clickhouse-pipeline-b00002-test_emails": {
                             "fields": [
                                 {
                                     "field_name": "user_id",
@@ -149,13 +149,13 @@ Feature: Kafka to CH pipeline
                     },
                     "sink_mapping": [
                         {
-                            "stream_name": "test_users",
+                            "stream_name": "gf-ingest-kafka-to-clickhouse-pipeline-b00002-test_users",
                             "field_name": "name",
                             "column_name": "name",
                             "column_type": "String"
                         },
                         {
-                            "stream_name": "test_emails",
+                            "stream_name": "gf-ingest-kafka-to-clickhouse-pipeline-b00002-test_emails",
                             "field_name": "email",
                             "column_name": "email",
                             "column_type": "String"
@@ -257,7 +257,7 @@ Feature: Kafka to CH pipeline
                 "mapper": {
                     "type": "jsonToClickhouse",
                     "streams": {
-                        "test_users": {
+                        "gf-ingest-kafka-to-clickhouse-pipeline-b00003-test_users": {
                             "fields": [
                                 {
                                     "field_name": "id",
@@ -272,7 +272,7 @@ Feature: Kafka to CH pipeline
                             "join_window": "1h",
                             "join_orientation": "right"
                         },
-                        "test_emails": {
+                        "gf-ingest-kafka-to-clickhouse-pipeline-b00003-test_emails": {
                             "fields": [
                                 {
                                     "field_name": "user_id",
@@ -290,13 +290,13 @@ Feature: Kafka to CH pipeline
                     },
                     "sink_mapping": [
                         {
-                            "stream_name": "test_users",
+                            "stream_name": "gf-ingest-kafka-to-clickhouse-pipeline-b00003-test_users",
                             "field_name": "name",
                             "column_name": "name",
                             "column_type": "String"
                         },
                         {
-                            "stream_name": "test_emails",
+                            "stream_name": "gf-ingest-kafka-to-clickhouse-pipeline-b00003-test_emails",
                             "field_name": "email",
                             "column_name": "email",
                             "column_type": "String"
@@ -411,7 +411,7 @@ Feature: Kafka to CH pipeline
                 "mapper": {
                     "type": "jsonToClickhouse",
                     "streams": {
-                        "test_topic": {
+                        "gf-ingest-kafka-to-clickhouse-pipeline-b00004-test_topic": {
                             "fields": [
                                 {
                                     "field_name": "id",
@@ -426,13 +426,13 @@ Feature: Kafka to CH pipeline
                     },
                     "sink_mapping": [
                         {
-                            "stream_name": "test_topic",
+                            "stream_name": "gf-ingest-kafka-to-clickhouse-pipeline-b00004-test_topic",
                             "field_name": "id",
                             "column_name": "id",
                             "column_type": "String"
                         },
                         {
-                            "stream_name": "test_topic",
+                            "stream_name": "gf-ingest-kafka-to-clickhouse-pipeline-b00004-test_topic",
                             "field_name": "name",
                             "column_name": "name",
                             "column_type": "String"
@@ -504,7 +504,7 @@ Feature: Kafka to CH pipeline
                 "mapper": {
                     "type": "jsonToClickhouse",
                     "streams": {
-                        "test_measurments": {
+                        "gf-ingest-kafka-to-clickhouse-pipeline-b00005-test_measurments": {
                             "fields": [
                                 {
                                     "field_name": "id",
@@ -519,13 +519,13 @@ Feature: Kafka to CH pipeline
                     },
                     "sink_mapping": [
                         {
-                            "stream_name": "test_measurments",
+                            "stream_name": "gf-ingest-kafka-to-clickhouse-pipeline-b00005-test_measurments",
                             "field_name": "id",
                             "column_name": "id",
                             "column_type": "String"
                         },
                         {
-                            "stream_name": "test_measurments",
+                            "stream_name": "gf-ingest-kafka-to-clickhouse-pipeline-b00005-test_measurments",
                             "field_name": "measurment",
                             "column_name": "measurment",
                             "column_type": "String"

--- a/glassflow-api/tests/steps/ingestor_steps.go
+++ b/glassflow-api/tests/steps/ingestor_steps.go
@@ -256,6 +256,7 @@ func (s *IngestorTestSuite) aRunningIngestorOperator() error {
 	ingestor, err := operator.NewIngestorOperator(
 		s.ingestorCfg,
 		s.topicName,
+		s.streamCfg.Stream,
 		s.streamCfg.Subject,
 		s.dlqStreamCfg.Subject,
 		nc,


### PR DESCRIPTION
Purpose: The Ingestor output stream name was set to kafka topic name
In k8s version where we can have multiple pipelines, this causes issue where two pipelines write to the same stream if reading from same topic.

Changes:
1. Added utility fn to build ingestor output stream & subject names
2. In main sink runner, if running without join, this util fn is used to determine stream name
3. In Ingestor runner, use new output stream naming 
4. In pipeline configuration replaced output stream to use this utility fn
5. Update kafka stream validator to use new stream name instead of topic name to identify stream
6. Added config test to check if stream names are generated correctly as per pipeline ID (also subject names)
7. Added stream name changes in docker (Necessary until we have separate e2e tests for k8s ETL, else current tests don't pass / need changes in CI)
8. Update e2e tests for ingestor and pipeline to use new stream naming


Tested on docker version, to test in k8s needs merging and testing on cluster with new images