### PR TITLE
fix: NATS stream issues

### DIFF
--- a/glassflow-api/cmd/glassflow/main.go
+++ b/glassflow-api/cmd/glassflow/main.go
@@ -349,7 +349,6 @@ func mainIngestor(ctx context.Context, nc *client.NATSClient, cfg *config, log *
 			return ingestorRunner.Start(
 				ctx,
 				cfg.IngestorTopic,
-				cfg.OutputStreamName,
 				pipelineCfg,
 				schemaMapper,
 			)

--- a/glassflow-api/internal/api/pipeline.go
+++ b/glassflow-api/internal/api/pipeline.go
@@ -237,7 +237,8 @@ type pipelineJSON struct {
 
 		Sources []joinSource `json:"sources"`
 	} `json:"join"`
-	Sink clickhouseSink `json:"sink"`
+	Sink   clickhouseSink        `json:"sink"`
+	Status models.PipelineStatus `json:"status"`
 }
 
 type sourceConnectionParams struct {
@@ -550,5 +551,6 @@ func toPipelineJSON(p models.PipelineConfig) pipelineJSON {
 			MaxDelayTime:                p.Sink.Batch.MaxDelayTime,
 			SkipCertificateVerification: p.Sink.ClickHouseConnectionParams.SkipCertificateCheck,
 		},
+		Status: p.Status.OverallStatus,
 	}
 }

--- a/glassflow-api/internal/models/configs.go
+++ b/glassflow-api/internal/models/configs.go
@@ -12,6 +12,8 @@ const (
 	GFJoinStream  = "gf-stream-joined"
 	GFJoinSubject = "merged"
 
+	DefaultSubjectName = ".input"
+
 	KafkaIngestorType        = "kafka"
 	TemporalJoinType         = "temporal"
 	SchemaMapperJSONToCHType = "jsonToClickhouse"
@@ -484,4 +486,8 @@ func NewPipelineHealth(pipelineID, pipelineName string) PipelineHealth {
 		CreatedAt:     now,
 		UpdatedAt:     now,
 	}
+}
+
+func GetNATSSubjectName(streamName string) string {
+	return fmt.Sprintf("%s.%s", streamName, DefaultSubjectName)
 }

--- a/glassflow-api/internal/models/configs.go
+++ b/glassflow-api/internal/models/configs.go
@@ -11,9 +11,6 @@ import (
 )
 
 const (
-	GFJoinStream  = "gf-stream-joined"
-	GFJoinSubject = "merged"
-
 	DefaultSubjectName = "input"
 
 	KafkaIngestorType        = "kafka"

--- a/glassflow-api/internal/models/configs_test.go
+++ b/glassflow-api/internal/models/configs_test.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -48,5 +49,173 @@ func TestNewPipelineConfig(t *testing.T) {
 
 	if config.Status.OverallStatus != PipelineStatusCreated {
 		t.Errorf("Expected Status.OverallStatus %s, got %s", PipelineStatusCreated, config.Status.OverallStatus)
+	}
+}
+
+func TestSanitizeNATSSubject(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no dots",
+			input:    "my-topic",
+			expected: "my-topic",
+		},
+		{
+			name:     "single dot",
+			input:    "my.topic",
+			expected: "my_topic",
+		},
+		{
+			name:     "multiple dots",
+			input:    "my.topic.name",
+			expected: "my_topic_name",
+		},
+		{
+			name:     "dots at start and end",
+			input:    ".my.topic.",
+			expected: "_my_topic_",
+		},
+		{
+			name:     "consecutive dots",
+			input:    "my..topic",
+			expected: "my__topic",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SanitizeNATSSubject(tt.input)
+			if result != tt.expected {
+				t.Errorf("SanitizeNATSSubject(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGenerateStreamHash(t *testing.T) {
+	// Test that the same pipeline ID always generates the same hash
+	pipelineID := "test-pipeline-123"
+	hash1 := GenerateStreamHash(pipelineID)
+	hash2 := GenerateStreamHash(pipelineID)
+
+	if hash1 != hash2 {
+		t.Errorf("GenerateStreamHash should be deterministic, got %q and %q", hash1, hash2)
+	}
+
+	// Test that different pipeline IDs generate different hashes
+	hash3 := GenerateStreamHash("different-pipeline-456")
+	if hash1 == hash3 {
+		t.Errorf("Different pipeline IDs should generate different hashes")
+	}
+
+	// Test that hash is always 8 characters
+	if len(hash1) != 8 {
+		t.Errorf("Hash should be 8 characters, got %d", len(hash1))
+	}
+}
+
+func TestGetPipelineStreamName(t *testing.T) {
+	pipelineID := "test-pipeline-123"
+
+	tests := []struct {
+		name     string
+		topic    string
+		expected string
+	}{
+		{
+			name:     "simple topic",
+			topic:    "my-topic",
+			expected: "gf-", // Will be followed by hash and topic
+		},
+		{
+			name:     "topic with dots",
+			topic:    "my.topic.name",
+			expected: "gf-", // Will be followed by hash and sanitized topic
+		},
+		{
+			name:     "very long topic name",
+			topic:    strings.Repeat("a", 50),
+			expected: "gf-", // Should be truncated
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetPipelineStreamName(pipelineID, tt.topic)
+
+			// Check that it starts with the expected prefix
+			if !strings.HasPrefix(result, tt.expected) {
+				t.Errorf("GetPipelineStreamName(%q, %q) = %q, should start with %q",
+					pipelineID, tt.topic, result, tt.expected)
+			}
+
+			// Check that it doesn't exceed max length
+			if len(result) > MaxStreamNameLength {
+				t.Errorf("GetPipelineStreamName(%q, %q) = %q, length %d exceeds max %d",
+					pipelineID, tt.topic, result, len(result), MaxStreamNameLength)
+			}
+
+			// Check that it contains the hash
+			hash := GenerateStreamHash(pipelineID)
+			if !strings.Contains(result, hash) {
+				t.Errorf("GetPipelineStreamName(%q, %q) = %q, should contain hash %q",
+					pipelineID, tt.topic, result, hash)
+			}
+		})
+	}
+}
+
+func TestGetPipelineNATSSubject(t *testing.T) {
+	pipelineID := "test-pipeline-123"
+	topic := "my.topic"
+
+	result := GetPipelineNATSSubject(pipelineID, topic)
+
+	// Should end with .input
+	if !strings.HasSuffix(result, DefaultSubjectName) {
+		t.Errorf("GetPipelineNATSSubject(%q, %q) = %q, should end with %q",
+			pipelineID, topic, result, DefaultSubjectName)
+	}
+
+	// Should contain the stream name
+	streamName := GetPipelineStreamName(pipelineID, topic)
+	if !strings.HasPrefix(result, streamName) {
+		t.Errorf("GetPipelineNATSSubject(%q, %q) = %q, should start with stream name %q",
+			pipelineID, topic, result, streamName)
+	}
+}
+
+func TestGetDLQStreamName(t *testing.T) {
+	pipelineID := "test-pipeline-123"
+	result := GetDLQStreamName(pipelineID)
+
+	// Should contain the hash
+	hash := GenerateStreamHash(pipelineID)
+	if !strings.Contains(result, hash) {
+		t.Errorf("GetDLQStreamName(%q) = %q, should contain hash %q", pipelineID, result, hash)
+	}
+
+	// Should end with DLQ
+	if !strings.HasSuffix(result, DLQSuffix) {
+		t.Errorf("GetDLQStreamName(%q) = %q, should end with %q", pipelineID, result, DLQSuffix)
+	}
+}
+
+func TestGetJoinedStreamName(t *testing.T) {
+	pipelineID := "test-pipeline-123"
+	result := GetJoinedStreamName(pipelineID)
+
+	// Should contain the hash
+	hash := GenerateStreamHash(pipelineID)
+	if !strings.Contains(result, hash) {
+		t.Errorf("GetJoinedStreamName(%q) = %q, should contain hash %q", pipelineID, result, hash)
+	}
+
+	// Should end with joined
+	if !strings.HasSuffix(result, "joined") {
+		t.Errorf("GetJoinedStreamName(%q) = %q, should end with 'joined'", pipelineID, result)
 	}
 }

--- a/glassflow-api/internal/models/dlq.go
+++ b/glassflow-api/internal/models/dlq.go
@@ -11,12 +11,16 @@ const (
 	DLQSuffix       = "DLQ"
 )
 
+// GetDLQStreamName generates a unique DLQ stream name for a pipeline
 func GetDLQStreamName(pipelineID string) string {
-	return fmt.Sprintf("%s-%s", pipelineID, DLQSuffix)
+	hash := GenerateStreamHash(pipelineID)
+	return fmt.Sprintf("%s-%s-%s", PipelineStreamPrefix, hash, DLQSuffix)
 }
 
+// GetDLQStreamSubjectName generates a NATS subject name for the DLQ stream
 func GetDLQStreamSubjectName(pipelineID string) string {
-	return GetDLQStreamName(pipelineID) + ".failed"
+	streamName := GetDLQStreamName(pipelineID)
+	return streamName + ".failed"
 }
 
 type DLQMessage struct {

--- a/glassflow-api/internal/orchestrator/docker.go
+++ b/glassflow-api/internal/orchestrator/docker.go
@@ -110,7 +110,7 @@ func (d *LocalOrchestrator) SetupPipeline(ctx context.Context, pi *models.Pipeli
 
 		d.log.Debug("create ingestor for the topic", slog.String("topic", t.Name))
 		err = d.ingestorRunner.Start(
-			ctx, t.Name, sinkConsumerStream, *pi,
+			ctx, t.Name, *pi,
 			schemaMapper,
 		)
 		if err != nil {

--- a/glassflow-api/internal/orchestrator/docker.go
+++ b/glassflow-api/internal/orchestrator/docker.go
@@ -105,11 +105,10 @@ func (d *LocalOrchestrator) SetupPipeline(ctx context.Context, pi *models.Pipeli
 
 	for _, t := range pi.Ingestor.KafkaTopics {
 		sinkConsumerStream = t.Name
-		sinkConsumerSubject = t.Name + ".input"
 
 		d.log.Debug("create ingestor for the topic", slog.String("topic", t.Name))
 		err = d.ingestorRunner.Start(
-			ctx, t.Name, *pi,
+			ctx, t.Name, sinkConsumerStream, *pi,
 			schemaMapper,
 		)
 		if err != nil {

--- a/glassflow-api/internal/orchestrator/k8s.go
+++ b/glassflow-api/internal/orchestrator/k8s.go
@@ -71,7 +71,7 @@ func (k *K8sOrchestrator) SetupPipeline(ctx context.Context, cfg *models.Pipelin
 	for _, s := range cfg.Ingestor.KafkaTopics {
 		src = append(src, operator.SourceStream{
 			TopicName:    s.Name,
-			OutputStream: s.Name,
+			OutputStream: models.GetPipelineStreamName(cfg.ID, s.Name),
 			DedupWindow:  s.Deduplication.Window.Duration(),
 		})
 	}

--- a/glassflow-api/internal/service/ingestor_runner.go
+++ b/glassflow-api/internal/service/ingestor_runner.go
@@ -39,7 +39,7 @@ func (i *IngestorRunner) Start(ctx context.Context, topicName string, natsStream
 	streamPublisher := stream.NewNATSPublisher(
 		i.nc.JetStream(),
 		stream.PublisherConfig{
-			Subject: natsStreamName + ".input",
+			Subject: models.GetPipelineNATSSubject(pipelineCfg.ID, topicName),
 		},
 	)
 

--- a/glassflow-api/internal/service/ingestor_runner.go
+++ b/glassflow-api/internal/service/ingestor_runner.go
@@ -31,7 +31,7 @@ func NewIngestorRunner(log *slog.Logger, nc *client.NATSClient) *IngestorRunner 
 	}
 }
 
-func (i *IngestorRunner) Start(ctx context.Context, topicName string, natsStreamName string, pipelineCfg models.PipelineConfig, schemaMapper schema.Mapper) error {
+func (i *IngestorRunner) Start(ctx context.Context, topicName string, pipelineCfg models.PipelineConfig, schemaMapper schema.Mapper) error {
 	if topicName == "" {
 		return fmt.Errorf("topic name cannot be empty")
 	}

--- a/glassflow-api/internal/service/sink_runner.go
+++ b/glassflow-api/internal/service/sink_runner.go
@@ -30,12 +30,12 @@ func NewSinkRunner(log *slog.Logger, nc *client.NATSClient) *SinkRunner {
 	}
 }
 
-func (s *SinkRunner) Start(ctx context.Context, consumerStream, consumerSubject string, cfg models.SinkOperatorConfig, schemaMapper schema.Mapper) error {
+func (s *SinkRunner) Start(ctx context.Context, inputNatsStream string, cfg models.SinkOperatorConfig, schemaMapper schema.Mapper) error {
 	//nolint: exhaustruct // optional config
 	consumer, err := stream.NewNATSConsumer(ctx, s.nc.JetStream(), stream.ConsumerConfig{
-		NatsStream:   consumerStream,
+		NatsStream:   inputNatsStream,
 		NatsConsumer: "clickhouse-consumer",
-		NatsSubject:  consumerSubject,
+		NatsSubject:  models.GetNATSSubjectName(inputNatsStream),
 	})
 	if err != nil {
 		return fmt.Errorf("create clickhouse consumer: %w", err)

--- a/glassflow-api/tests/steps/ingestor_steps.go
+++ b/glassflow-api/tests/steps/ingestor_steps.go
@@ -257,7 +257,7 @@ func (s *IngestorTestSuite) aRunningIngestorOperator() error {
 	streamConsumer := stream.NewNATSPublisher(
 		nc.JetStream(),
 		stream.PublisherConfig{
-			Subject: s.streamCfg.Stream + "." + s.streamCfg.Subject,
+			Subject: s.streamCfg.Subject,
 		},
 	)
 


### PR DESCRIPTION
1. Kakfa topic names were used as stream names, this can causes issues 
   1. topic names can be too long, NATS has a recommended limit on stream name length
      1. Handled by limiting stream names to 32 chars
      2. Format gf-<8-char-hash>-<topic_name> truncated at 32 chars
   4. topic names can have dots and underscore, this collides with NATS subject name format, since it uses dot to separate stream and subject
      5. Handled by converting dots to underscore
2. Uniform stream names per pipeline

```sh
kiran@kirans-MacBook-Pro clickhouse-etl % nats stream list     
╭─────────────────────────────────────────────────────────────────────────────────────────────╮
│                                           Streams                                           │
├─────────────────────┬─────────────┬─────────────────────┬──────────┬─────────┬──────────────┤
│ Name                │ Description │ Created             │ Messages │ Size    │ Last Message │
├─────────────────────┼─────────────┼─────────────────────┼──────────┼─────────┼──────────────┤
│ gf-8ef2c54b-DLQ     │             │ 2025-08-27 12:16:59 │ 0        │ 0 B     │ never        │
│ gf-8ef2c54b-users   │             │ 2025-08-27 12:16:59 │ 4        │ 1.3 KiB │ 28.56s       │
│ gf-8ef2c54b-users_2 │             │ 2025-08-27 12:16:59 │ 4        │ 1.3 KiB │ 23.71s       │
│ gf-8ef2c54b-joined  │             │ 2025-08-27 12:16:59 │ 3        │ 1.6 KiB │ 23.72s       │
╰─────────────────────┴─────────────┴─────────────────────┴──────────┴─────────┴──────────────╯


kiran@kirans-MacBook-Pro clickhouse-etl % nats kv list         
╭────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                Key-Value Buckets                                               │
├─────────────────────┬───────────────────────────────────┬─────────────────────┬─────────┬────────┬─────────────┤
│ Bucket              │ Description                       │ Created             │ Size    │ Values │ Last Update │
├─────────────────────┼───────────────────────────────────┼─────────────────────┼─────────┼────────┼─────────────┤
│ gf-8ef2c54b-users   │                                   │ 2025-08-27 12:16:59 │ 0 B     │ 0      │ 2m24s       │
│ gf-8ef2c54b-users_2 │                                   │ 2025-08-27 12:16:59 │ 605 B   │ 2      │ 26.38s      │
│ glassflow-pipelines │ Store for all glassflow pipelines │ 2025-08-27 12:14:39 │ 3.0 KiB │ 1      │ 5m54s       │
╰─────────────────────┴───────────────────────────────────┴─────────────────────┴─────────┴────────┴─────────────╯
```


Tested following:
1. Ingestor only
2. Ingestor + Dedup
3. Ingestor + Dedup + Join
   1. Select data from left topic in sink config
   2. Select data from both left and right topic in sink config


Data sent to topic:
```sh
echo "adding data in topic users"
echo '{"event_id": "49a6fdd6f305428881f3436eb498fc9d", "user": {"id": "8db09a6aa33a46f6bdabe4683a34ac4d", "name": "John Doe", "email": "john@example.com"}, "created_at": "2024-03-20T10:00:00Z", "tags": ["tag1", "tag222"]}
{"event_id": "49a6fdd6f305428881f3436eb498fc9d", "user": {"id": "8db09a6aa33a46f6bdabe4683a34ac4d", "name": "John Doe", "email": "john@example.com"}, "created_at": "2024-03-20T10:01:00Z", "tags": ["tag1", "tag222"]}
{"event_id": "f0ed455046a543459d9a51502cdc756d", "user": {"id": "a7f93b87e29c4978848731e204e47e97", "name": "Jane Smith", "email": "jane@example.com"}, "created_at": "2024-03-20T10:03:00Z", "tags": ["tag13", "tag324"]}'|
docker compose -f "$DOCKER_COMPOSE_FILE" exec -T kafka kafka-console-producer \
    --topic users \
    --bootstrap-server localhost:9092



echo "adding data in topic users.2"
echo '{"event_id": "49a6fdd6f305428881f3436eb498fc9d", "user": {"id": "8db09a6aa33a46f6bdabe4683a34ac4d", "name": "John Doe", "email": "john@example.com"}, "created_at": "2024-03-20T10:00:00Z", "tags": ["tag1", "tag222"]}
{"event_id": "49a6fdd6f305428881f3436eb498fc9d", "user": {"id": "8db09a6aa33a46f6bdabe4683a34ac4d", "name": "John Doe", "email": "john@example.com"}, "created_at": "2024-03-20T10:01:00Z", "tags": ["tag1", "tag222"]}
{"event_id": "f0ed455046a543459d9a51502cdc756d", "user": {"id": "a7f93b87e29c4978848731e204e47e97", "name": "Jane Smith", "email": "jane@example.com"}, "created_at": "2024-03-20T10:03:00Z", "tags": ["tag13", "tag324"]}'|
docker compose -f "$DOCKER_COMPOSE_FILE" exec -T kafka kafka-console-producer \
    --topic users.2 \
```


Data in sink:
```sh
SELECT *
FROM users_dedup

Query id: ef611e4b-1fcb-4d2e-ba52-4821e44c573a

   ┌─event_id─────────────────────────────┬─user_id──────────────────────────────┬─name───────┬─email────────────┬──────────created_at─┬─tags───────────────┐
1. │ 49a6fdd6-f305-4288-81f3-436eb498fc9d │ 8db09a6a-a33a-46f6-bdab-e4683a34ac4d │ John Doe   │ john@example.com │ 2024-03-20 10:00:00 │ ['tag1','tag222']  │
2. │ f0ed4550-46a5-4345-9d9a-51502cdc756d │ a7f93b87-e29c-4978-8487-31e204e47e97 │ Jane Smith │ jane@example.com │ 2024-03-20 10:03:00 │ ['tag13','tag324'] │
   └──────────────────────────────────────┴──────────────────────────────────────┴────────────┴──────────────────┴─────────────────────┴────────────────────┘
```