### PR TITLE
Use common runner interface for component runners

### DIFF
--- a/glassflow-api/internal/constants.go
+++ b/glassflow-api/internal/constants.go
@@ -137,4 +137,8 @@ const (
 
 	// Join constants
 	MaxStreamsSupportedWithJoin = 2
+
+	// RunnersWatcher constants
+	RunnerWatcherInterval = 5 * time.Second
+	RunnerRestartDelay   = 2 * time.Second
 )

--- a/glassflow-api/internal/service/runner.go
+++ b/glassflow-api/internal/service/runner.go
@@ -1,0 +1,9 @@
+package service
+
+import "context"
+
+type Runner interface {
+	Start(ctx context.Context) error
+	Shutdown()
+	Done() <-chan struct{}
+}


### PR DESCRIPTION
## Added Changes
- a common interface for component runners.
- updated the Docker orchestrator to use the runner interface.
- refactored separate application logic to utilize the common interface.
- component runner watcher which will be able to restart failed runner on local docker installation.