### PR TITLE
feat: GET /platform API

### DIFF
--- a/glassflow-api/internal/api/platform.go
+++ b/glassflow-api/internal/api/platform.go
@@ -1,0 +1,34 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type PlatformResponse struct {
+	Orchestrator string `json:"orchestrator"`
+	APIVersion   string `json:"api_version,omitempty"`
+}
+
+// platform returns information about the platform and orchestrator being used
+func (h *handler) platform(w http.ResponseWriter, _ *http.Request) {
+	// Get orchestrator type from the pipeline manager
+	orchType := "unknown"
+	if h.pipelineManager != nil {
+		orchType = h.pipelineManager.GetOrchestratorType()
+	}
+
+	response := PlatformResponse{
+		Orchestrator: orchType,
+		// API version is not currently available, so we'll skip it
+		// APIVersion: "v1",
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		h.log.Error("failed to encode platform response", "error", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+	}
+}

--- a/glassflow-api/internal/api/platform_test.go
+++ b/glassflow-api/internal/api/platform_test.go
@@ -1,0 +1,167 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/models"
+)
+
+// MockPipelineManager is a mock implementation of service.PipelineManager
+type MockPipelineManager struct {
+	mock.Mock
+}
+
+func (m *MockPipelineManager) CreatePipeline(ctx context.Context, cfg *models.PipelineConfig) error {
+	args := m.Called(ctx, cfg)
+	return args.Error(0)
+}
+
+func (m *MockPipelineManager) DeletePipeline(ctx context.Context, pid string) error {
+	args := m.Called(ctx, pid)
+	return args.Error(0)
+}
+
+func (m *MockPipelineManager) TerminatePipeline(ctx context.Context, pid string) error {
+	args := m.Called(ctx, pid)
+	return args.Error(0)
+}
+
+func (m *MockPipelineManager) GetPipeline(ctx context.Context, pid string) (models.PipelineConfig, error) {
+	args := m.Called(ctx, pid)
+	return args.Get(0).(models.PipelineConfig), args.Error(1)
+}
+
+func (m *MockPipelineManager) GetPipelines(ctx context.Context) ([]models.ListPipelineConfig, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]models.ListPipelineConfig), args.Error(1)
+}
+
+func (m *MockPipelineManager) UpdatePipelineName(ctx context.Context, id string, name string) error {
+	args := m.Called(ctx, id, name)
+	return args.Error(0)
+}
+
+func (m *MockPipelineManager) GetPipelineHealth(ctx context.Context, pid string) (models.PipelineHealth, error) {
+	args := m.Called(ctx, pid)
+	return args.Get(0).(models.PipelineHealth), args.Error(1)
+}
+
+func (m *MockPipelineManager) GetOrchestratorType() string {
+	args := m.Called()
+	return args.String(0)
+}
+
+// MockDLQ is a mock implementation of service.DLQ
+type MockDLQ struct {
+	mock.Mock
+}
+
+func (m *MockDLQ) ConsumeDLQ(ctx context.Context, pid string, batchSize models.DLQBatchSize) ([]models.DLQMessage, error) {
+	args := m.Called(ctx, pid, batchSize)
+	return args.Get(0).([]models.DLQMessage), args.Error(1)
+}
+
+func (m *MockDLQ) GetDLQState(ctx context.Context, pid string) (models.DLQState, error) {
+	args := m.Called(ctx, pid)
+	return args.Get(0).(models.DLQState), args.Error(1)
+}
+
+func TestPlatformHandler(t *testing.T) {
+	tests := []struct {
+		name             string
+		orchestratorType string
+		expectedStatus   int
+		expectedResponse PlatformResponse
+	}{
+		{
+			name:             "local orchestrator",
+			orchestratorType: "local",
+			expectedStatus:   http.StatusOK,
+			expectedResponse: PlatformResponse{
+				Orchestrator: "local",
+			},
+		},
+		{
+			name:             "k8s orchestrator",
+			orchestratorType: "k8s",
+			expectedStatus:   http.StatusOK,
+			expectedResponse: PlatformResponse{
+				Orchestrator: "k8s",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create mock pipeline manager
+			mockPipelineManager := &MockPipelineManager{}
+			mockPipelineManager.On("GetOrchestratorType").Return(tt.orchestratorType)
+
+			// Create mock DLQ service
+			mockDLQ := &MockDLQ{}
+
+			// Create handler
+			h := &handler{
+				pipelineManager: mockPipelineManager,
+				dlqSvc:          mockDLQ,
+			}
+
+			// Create request
+			req := httptest.NewRequest("GET", "/api/v1/platform", nil)
+			w := httptest.NewRecorder()
+
+			// Call handler
+			h.platform(w, req)
+
+			// Assert status code
+			assert.Equal(t, tt.expectedStatus, w.Code)
+
+			// Parse response
+			var response PlatformResponse
+			err := json.NewDecoder(w.Body).Decode(&response)
+			require.NoError(t, err)
+
+			// Assert response
+			assert.Equal(t, tt.expectedResponse.Orchestrator, response.Orchestrator)
+			assert.Equal(t, tt.expectedResponse.APIVersion, response.APIVersion)
+
+			// Verify mock expectations
+			mockPipelineManager.AssertExpectations(t)
+		})
+	}
+}
+
+func TestPlatformHandlerWithNilPipelineManager(t *testing.T) {
+	// Create handler with nil pipeline manager
+	h := &handler{
+		pipelineManager: nil,
+		dlqSvc:          &MockDLQ{},
+	}
+
+	// Create request
+	req := httptest.NewRequest("GET", "/api/v1/platform", nil)
+	w := httptest.NewRecorder()
+
+	// Call handler
+	h.platform(w, req)
+
+	// Assert status code
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Parse response
+	var response PlatformResponse
+	err := json.NewDecoder(w.Body).Decode(&response)
+	require.NoError(t, err)
+
+	// Assert response
+	assert.Equal(t, "unknown", response.Orchestrator)
+	assert.Equal(t, "", response.APIVersion)
+}

--- a/glassflow-api/internal/api/router.go
+++ b/glassflow-api/internal/api/router.go
@@ -26,6 +26,7 @@ func NewRouter(log *slog.Logger, pSvc service.PipelineManager, dlqSvc service.DL
 	}
 
 	r.HandleFunc("/api/v1/healthz", h.healthz).Methods("GET")
+	r.HandleFunc("/api/v1/platform", h.platform).Methods("GET")
 	r.HandleFunc("/api/v1/pipeline", h.createPipeline).Methods("POST")
 	r.HandleFunc("/api/v1/pipeline/{id}", h.getPipeline).Methods("GET")
 	r.HandleFunc("/api/v1/pipeline/{id}", h.updatePipelineName).Methods("PATCH")

--- a/glassflow-api/internal/service/pipeline.go
+++ b/glassflow-api/internal/service/pipeline.go
@@ -33,6 +33,7 @@ type PipelineManager interface {
 	GetPipelines(ctx context.Context) ([]models.ListPipelineConfig, error)
 	UpdatePipelineName(ctx context.Context, id string, name string) error
 	GetPipelineHealth(ctx context.Context, pid string) (models.PipelineHealth, error)
+	GetOrchestratorType() string
 }
 
 type PipelineManagerImpl struct {
@@ -205,4 +206,9 @@ func (p *PipelineManagerImpl) UpdatePipelineStatus(ctx context.Context, pid stri
 	}
 
 	return nil
+}
+
+// GetOrchestratorType implements PipelineManager.
+func (p *PipelineManagerImpl) GetOrchestratorType() string {
+	return p.orchestrator.GetType()
 }

--- a/glassflow-api/tests/features/platform/platform.feature
+++ b/glassflow-api/tests/features/platform/platform.feature
@@ -1,0 +1,29 @@
+@platform
+Feature: Platform Information
+
+    Scenario: Get platform information for local orchestrator
+        Given a running glassflow API server with local orchestrator
+        When I send a GET request to "/api/v1/platform"
+        Then the response status should be 200
+        And the response should contain JSON:
+            """
+            {
+                "orchestrator": "local"
+            }
+            """
+
+    Scenario: Get platform information for k8s orchestrator
+        Given a running glassflow API server with k8s orchestrator
+        When I send a GET request to "/api/v1/platform"
+        Then the response status should be 200
+        And the response should contain JSON:
+            """
+            {
+                "orchestrator": "k8s"
+            }
+            """
+
+    Scenario: Platform endpoint returns correct content type
+        Given a running glassflow API server with local orchestrator
+        When I send a GET request to "/api/v1/platform"
+        Then the response should have content type "application/json"

--- a/glassflow-api/tests/main_test.go
+++ b/glassflow-api/tests/main_test.go
@@ -119,6 +119,18 @@ func testIngetorFeatures(t *testing.T) {
 	runSingleSuite(t, "ingestor", ingestorSuite, config)
 }
 
+func testPlatformFeatures(t *testing.T) {
+	platformSuite := steps.NewPlatformSteps()
+
+	config := TestConfig{
+		FeaturePaths: []string{filepath.Join("features", "platform")},
+		Tags:         "@platform",
+		Format:       "pretty",
+	}
+
+	runSingleSuite(t, "platform", platformSuite, config)
+}
+
 // TestFeatures runs all feature tests but in separate contexts
 func TestFeatures(t *testing.T) {
 	// Run tests in subtests to isolate them
@@ -126,4 +138,5 @@ func TestFeatures(t *testing.T) {
 	t.Run("JoinComponentFeatures", testJoinFeatures)
 	t.Run("PipelineFeatures", testPipelineFeatures)
 	t.Run("IngestorFeatures", testIngetorFeatures)
+	t.Run("PlatformFeatures", testPlatformFeatures)
 }

--- a/glassflow-api/tests/steps/platform_steps.go
+++ b/glassflow-api/tests/steps/platform_steps.go
@@ -1,0 +1,186 @@
+package steps
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/cucumber/godog"
+
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/api"
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/models"
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/orchestrator"
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/service"
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/storage"
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/tests/testutils"
+)
+
+type PlatformSteps struct {
+	BaseTestSuite
+	log              *slog.Logger
+	pipelineManager  *service.PipelineManagerImpl
+	orchestrator     service.Orchestrator
+	orchestratorType string
+	lastResponse     *http.Response
+}
+
+func NewPlatformSteps() *PlatformSteps {
+	return &PlatformSteps{
+		BaseTestSuite: BaseTestSuite{
+			kafkaContainer: nil,
+		},
+		log: testutils.NewTestLogger(),
+	}
+}
+
+func (p *PlatformSteps) RegisterSteps(ctx *godog.ScenarioContext) {
+	ctx.Given(`^a running glassflow API server with local orchestrator$`, p.aRunningGlassflowAPIServerWithLocalOrchestrator)
+	ctx.Given(`^a running glassflow API server with k8s orchestrator$`, p.aRunningGlassflowAPIServerWithK8sOrchestrator)
+	ctx.When(`^I send a GET request to "([^"]*)"$`, p.iSendAGETRequestTo)
+	ctx.Then(`^the response status should be (\d+)$`, p.theResponseStatusShouldBe)
+	ctx.Then(`^the response should contain JSON:$`, p.theResponseShouldContainJSON)
+	ctx.Then(`^the response should have content type "([^"]*)"$`, p.theResponseShouldHaveContentType)
+}
+
+func (p *PlatformSteps) SetupResources() error {
+	if err := p.setupNATS(); err != nil {
+		return fmt.Errorf("setup nats: %w", err)
+	}
+	return nil
+}
+
+func (p *PlatformSteps) CleanupResources() error {
+	if err := p.cleanupNATS(); err != nil {
+		return fmt.Errorf("cleanup nats: %w", err)
+	}
+	return nil
+}
+
+func (p *PlatformSteps) aRunningGlassflowAPIServerWithLocalOrchestrator() error {
+	p.orchestratorType = "local"
+	return p.setupServices()
+}
+
+func (p *PlatformSteps) aRunningGlassflowAPIServerWithK8sOrchestrator() error {
+	p.orchestratorType = "k8s"
+	return p.setupServices()
+}
+
+func (p *PlatformSteps) setupServices() error {
+	// Create storage
+	db, err := storage.New(context.Background(), "test-pipelines", p.natsClient.JetStream())
+	if err != nil {
+		return fmt.Errorf("create storage: %w", err)
+	}
+
+	// Create orchestrator based on type
+	if p.orchestratorType == "local" {
+		p.orchestrator = orchestrator.NewLocalOrchestrator(p.natsClient, p.log)
+	} else {
+		// For k8s orchestrator, we'll create a mock one for testing
+		p.orchestrator = &MockK8sOrchestrator{log: p.log}
+	}
+
+	// Create pipeline manager
+	p.pipelineManager = service.NewPipelineManager(p.orchestrator, db)
+	return nil
+}
+
+func (p *PlatformSteps) iSendAGETRequestTo(endpoint string) error {
+	if endpoint != "/api/v1/platform" {
+		return fmt.Errorf("unsupported endpoint: %s", endpoint)
+	}
+
+	// Create handler
+	dlqSvc := service.NewDLQImpl(nil) // No DLQ client needed for platform tests
+	handler := api.NewRouter(p.log, p.pipelineManager, dlqSvc)
+
+	// Create request
+	req := httptest.NewRequest("GET", endpoint, nil)
+	w := httptest.NewRecorder()
+
+	// Call handler
+	handler.ServeHTTP(w, req)
+
+	// Store response for assertions
+	p.lastResponse = w.Result()
+	return nil
+}
+
+func (p *PlatformSteps) theResponseStatusShouldBe(expectedStatus int) error {
+	if p.lastResponse == nil {
+		return fmt.Errorf("no response available")
+	}
+
+	if p.lastResponse.StatusCode != expectedStatus {
+		return fmt.Errorf("expected status %d, got %d", expectedStatus, p.lastResponse.StatusCode)
+	}
+
+	return nil
+}
+
+func (p *PlatformSteps) theResponseShouldContainJSON(docString *godog.DocString) error {
+	if p.lastResponse == nil {
+		return fmt.Errorf("no response available")
+	}
+
+	var expectedResponse map[string]interface{}
+	if err := json.Unmarshal([]byte(docString.Content), &expectedResponse); err != nil {
+		return fmt.Errorf("parse expected JSON: %w", err)
+	}
+
+	var actualResponse map[string]interface{}
+	if err := json.NewDecoder(p.lastResponse.Body).Decode(&actualResponse); err != nil {
+		return fmt.Errorf("parse actual response: %w", err)
+	}
+
+	// Check if orchestrator type matches
+	if expectedOrch, ok := expectedResponse["orchestrator"].(string); ok {
+		if actualOrch, ok := actualResponse["orchestrator"].(string); ok {
+			if expectedOrch != actualOrch {
+				return fmt.Errorf("expected orchestrator %s, got %s", expectedOrch, actualOrch)
+			}
+		} else {
+			return fmt.Errorf("orchestrator field not found in response")
+		}
+	}
+
+	return nil
+}
+
+func (p *PlatformSteps) theResponseShouldHaveContentType(expectedContentType string) error {
+	if p.lastResponse == nil {
+		return fmt.Errorf("no response available")
+	}
+
+	contentType := p.lastResponse.Header.Get("Content-Type")
+	if contentType != expectedContentType {
+		return fmt.Errorf("expected content type %s, got %s", expectedContentType, contentType)
+	}
+
+	return nil
+}
+
+// MockK8sOrchestrator is a mock implementation for testing
+type MockK8sOrchestrator struct {
+	log *slog.Logger
+}
+
+func (m *MockK8sOrchestrator) GetType() string {
+	return "k8s"
+}
+
+func (m *MockK8sOrchestrator) SetupPipeline(_ context.Context, _ *models.PipelineConfig) error {
+	return fmt.Errorf("not implemented for testing")
+}
+
+func (m *MockK8sOrchestrator) ShutdownPipeline(_ context.Context, _ string) error {
+	return fmt.Errorf("not implemented for testing")
+}
+
+func (m *MockK8sOrchestrator) TerminatePipeline(_ context.Context, _ string) error {
+	return fmt.Errorf("not implemented for testing")
+}


### PR DESCRIPTION
Added new API endpoint for FE and SDK to discover underlying platform / orchestrator that pipelines are deployed on

Docker version: env GLASSFLOW_RUN_LOCAL=true
```sh
kiran@kirans-MacBook-Pro glassflow-api % curl http://localhost:8085/api/v1/platform
{"orchestrator":"local"}
```

K8 version: env GLASSFLOW_RUN_LOCAL=false
```sh
kiran@kirans-MacBook-Pro glassflow-api % curl http://localhost:8085/api/v1/platform
{"orchestrator":"k8s"}
```

I've created a separate test suite and controller. I believe we can add more details about underlying platform in future, which will help debug issues.