### PR TITLE
ETL-238: Two pipelines reading from same topic should both consume events

### DIFF
--- a/glassflow-api/internal/api/pipeline.go
+++ b/glassflow-api/internal/api/pipeline.go
@@ -338,6 +338,7 @@ func (p pipelineJSON) toModel() (zero models.PipelineConfig, _ error) {
 		topics = append(topics, models.KafkaTopicsConfig{
 			Name:                       t.Topic,
 			ID:                         t.ID,
+			ConsumerGroupName:          models.GetKafkaConsumerGroupName(p.PipelineID),
 			ConsumerGroupInitialOffset: t.ConsumerGroupInitialOffset,
 			Deduplication: models.DeduplicationConfig{
 				Enabled: t.Deduplication.Enabled,

--- a/glassflow-api/internal/constants.go
+++ b/glassflow-api/internal/constants.go
@@ -121,11 +121,11 @@ const (
 	NATSMaxConnectionWait = 2 * time.Minute
 
 	// Kafka consumer constants
-	ConsumerGroupName  = "glassflow-consumer-group"
-	ClientID           = "glassflow-consumer"
-	DefaultDialTimeout = 5000 * time.Millisecond
-	MechanismSHA256    = "SCRAM-SHA-256"
-	MechanismSHA512    = "SCRAM-SHA-512"
+	ConsumerGroupNamePrefix = "glassflow-consumer-group"
+	ClientID                = "glassflow-consumer"
+	DefaultDialTimeout      = 5000 * time.Millisecond
+	MechanismSHA256         = "SCRAM-SHA-256"
+	MechanismSHA512         = "SCRAM-SHA-512"
 
 	// Ingestor constants
 	IngestorInitialRetryDelay = 500 * time.Millisecond
@@ -140,5 +140,5 @@ const (
 
 	// RunnersWatcher constants
 	RunnerWatcherInterval = 5 * time.Second
-	RunnerRestartDelay   = 2 * time.Second
+	RunnerRestartDelay    = 2 * time.Second
 )

--- a/glassflow-api/internal/models/configs.go
+++ b/glassflow-api/internal/models/configs.go
@@ -82,6 +82,7 @@ type KafkaTopicsConfig struct {
 	Name                       string `json:"name"`
 	ID                         string `json:"id"`
 	ConsumerGroupInitialOffset string `json:"consumer_group_initial_offset" default:"earliest"`
+	ConsumerGroupName          string `json:"consumer_group_name"`
 
 	Deduplication       DeduplicationConfig `json:"deduplication"`
 	OutputStreamID      string              `json:"output_stream_id"`
@@ -507,4 +508,8 @@ func GetIngestorStreamName(pipelineID, topicName string) string {
 func GetPipelineNATSSubject(pipelineID, topicName string) string {
 	streamName := GetIngestorStreamName(pipelineID, topicName)
 	return fmt.Sprintf("%s.%s", streamName, internal.DefaultSubjectName)
+}
+
+func GetKafkaConsumerGroupName(pipelineID string) string {
+	return fmt.Sprintf("%s-%s", internal.ConsumerGroupNamePrefix, GenerateStreamHash(pipelineID))
 }

--- a/glassflow-api/internal/models/configs_test.go
+++ b/glassflow-api/internal/models/configs_test.go
@@ -272,3 +272,25 @@ func TestGetJoinedStreamName(t *testing.T) {
 		t.Errorf("GetJoinedStreamName(%q) = %q, should end with 'joined'", pipelineID, result)
 	}
 }
+
+func TestGetKafkaConsumerGroupName(t *testing.T) {
+	pipelineID := "test-pipeline-123"
+	result := GetKafkaConsumerGroupName(pipelineID)
+
+	// Should contain the hash
+	hash := GenerateStreamHash(pipelineID)
+	if !strings.Contains(result, hash) {
+		t.Errorf("GetKafkaConsumerGroupName(%q) = %q, should contain hash %q", pipelineID, result, hash)
+	}
+
+	// Should start with the prefix
+	if !strings.HasPrefix(result, internal.ConsumerGroupNamePrefix) {
+		t.Errorf("GetKafkaConsumerGroupName(%q) = %q, should start with %q", pipelineID, result, internal.ConsumerGroupNamePrefix)
+	}
+
+	// Should be equal to expected full name
+	expected := internal.ConsumerGroupNamePrefix + "-" + hash
+	if result != expected {
+		t.Errorf("GetKafkaConsumerGroupName(%q) = %q, want %q", pipelineID, result, expected)
+	}
+}

--- a/glassflow-api/tests/features/ingestor/ingestor.feature
+++ b/glassflow-api/tests/features/ingestor/ingestor.feature
@@ -64,6 +64,7 @@ Feature: Kafka Ingestor
                     {
                         "name": "test_topic",
                         "id": "topic_id",
+                        "consumer_group_name": "glassflow-consumer-group-pipeline-123",
                         "partitions": 1,
                         "deduplication": {
                             "enabled": true,
@@ -144,6 +145,7 @@ Feature: Kafka Ingestor
                     {
                         "name": "test_topic",
                         "id": "topic_id",
+                        "consumer_group_name": "glassflow-consumer-group-pipeline-123",
                         "partitions": 1,
                         "deduplication": {
                             "enabled": false
@@ -160,7 +162,7 @@ Feature: Kafka Ingestor
             | 3   | {"id": "789", "name": "Bob Bishop"}     |
             | 4   | {"id": "789", "name": "Uliana Gromova"} |
 
-        And a running ingestor component
+        And I run the ingestor component
 
         Then I check results stream with content
             | id  | name           |
@@ -222,6 +224,7 @@ Feature: Kafka Ingestor
                     {
                         "name": "test_topic",
                         "id": "topic_id",
+                        "consumer_group_name": "glassflow-consumer-group-pipeline-123",
                         "partitions": 1,
                         "deduplication": {
                             "enabled": true,
@@ -302,6 +305,7 @@ Feature: Kafka Ingestor
                     {
                         "name": "test_topic",
                         "id": "topic_id",
+                        "consumer_group_name": "glassflow-consumer-group-pipeline-123",
                         "partitions": 1,
                         "deduplication": {
                             "enabled": false

--- a/glassflow-api/tests/features/pipeline/pipeline.feature
+++ b/glassflow-api/tests/features/pipeline/pipeline.feature
@@ -65,6 +65,7 @@ Feature: Kafka to CH pipeline
                         {
                             "name": "test_topic",
                             "consumer_group_initial_offset": "earliest",
+                            "consumer_group_name": "glassflow-consumer-group-kafka-to-clickhouse-pipeline-b00001",
                             "deduplication": {
                                 "enabled": true,
                                 "id_field": "id",
@@ -180,6 +181,7 @@ Feature: Kafka to CH pipeline
                         {
                             "name": "test_emails",
                             "consumer_group_initial_offset": "earliest",
+                            "consumer_group_name": "glassflow-consumer-group-kafka-to-clickhouse-pipeline-b00002",
                             "deduplication": {
                                 "enabled": false
                             },
@@ -189,6 +191,7 @@ Feature: Kafka to CH pipeline
                         {
                             "name": "test_users",
                             "consumer_group_initial_offset": "earliest",
+                            "consumer_group_name": "glassflow-consumer-group-kafka-to-clickhouse-pipeline-b00002",
                             "deduplication": {
                                 "enabled": false
                             },
@@ -329,6 +332,7 @@ Feature: Kafka to CH pipeline
                         {
                             "name": "test_emails",
                             "consumer_group_initial_offset": "earliest",
+                            "consumer_group_name": "glassflow-consumer-group-kafka-to-clickhouse-pipeline-b00003",
                             "deduplication": {
                                 "enabled": true,
                                 "id_field": "user_id",
@@ -341,6 +345,7 @@ Feature: Kafka to CH pipeline
                         {
                             "name": "test_users",
                             "consumer_group_initial_offset": "earliest",
+                            "consumer_group_name": "glassflow-consumer-group-kafka-to-clickhouse-pipeline-b00003",
                             "deduplication": {
                                 "enabled": true,
                                 "id_field": "id",
@@ -473,6 +478,7 @@ Feature: Kafka to CH pipeline
                         {
                             "name": "test_topic",
                             "consumer_group_initial_offset": "earliest",
+                            "consumer_group_name": "glassflow-consumer-group-kafka-to-clickhouse-pipeline-b00004",
                             "deduplication": {
                                 "enabled": false
                             },
@@ -569,6 +575,7 @@ Feature: Kafka to CH pipeline
                         {
                             "name": "test_measurments",
                             "consumer_group_initial_offset": "earliest",
+                            "consumer_group_name": "glassflow-consumer-group-kafka-to-clickhouse-pipeline-b00005",
                             "deduplication": {
                                 "enabled": true,
                                 "id_field": "id",


### PR DESCRIPTION
Added configurable name for the kafka consumer group name, which depends from the pipeline id.