### PR TITLE
ETL-332: Fix retry loop after error of batch fetching

### DIFF
--- a/glassflow-api/internal/constants.go
+++ b/glassflow-api/internal/constants.go
@@ -146,6 +146,10 @@ const (
 	// RunnersWatcher constants
 	RunnerWatcherInterval = 5 * time.Second
 	RunnerRestartDelay    = 2 * time.Second
-
+	
+	// DefaultReplicasCount is the default number of replicas for the component
 	DefaultReplicasCount = 1
+
+	// FetchRetryDelay is the delay between retries when fetching messages from NATS stream
+	FetchRetryDelay = 100 * time.Millisecond
 )

--- a/glassflow-api/internal/models/errors.go
+++ b/glassflow-api/internal/models/errors.go
@@ -1,0 +1,7 @@
+package models
+
+import "errors"
+
+var ErrNoNewMessages = errors.New("no new messages")
+
+func IsNoNewMessagesErr(err error) bool { return errors.Is(err, ErrNoNewMessages) }

--- a/glassflow-api/internal/sink/clickhouse.go
+++ b/glassflow-api/internal/sink/clickhouse.go
@@ -175,7 +175,7 @@ func (ch *ClickHouseSink) getMsgBatch(ctx context.Context) error {
 
 	if totalMessages == 0 {
 		ch.isInputDrained = true
-		return nil
+		return models.ErrNoNewMessages
 	}
 
 	if msgBatch.Error() != nil {
@@ -226,7 +226,9 @@ func (ch *ClickHouseSink) Start(ctx context.Context) error {
 	for {
 		err := ch.getMsgBatch(ctx)
 		if err != nil {
-			ch.log.Error("error on exporting data", slog.Any("error", err))
+			if !errors.Is(err, models.ErrNoNewMessages) {
+				ch.log.Error("error on exporting data", slog.Any("error", err))
+			}
 			// Add a small delay to prevent tight loop on errors
 			time.Sleep(100 * time.Millisecond)
 			continue

--- a/glassflow-api/internal/sink/clickhouse.go
+++ b/glassflow-api/internal/sink/clickhouse.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/nats-io/nats.go/jetstream"
 
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal"
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/batch"
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/client"
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/models"
@@ -230,8 +231,7 @@ func (ch *ClickHouseSink) Start(ctx context.Context) error {
 				ch.log.Error("error on exporting data", slog.Any("error", err))
 			}
 			// Add a small delay to prevent tight loop on errors
-			time.Sleep(100 * time.Millisecond)
-			continue
+			time.Sleep(internal.FetchRetryDelay)
 		}
 
 		// Check if we should shutdown


### PR DESCRIPTION
Changes:
1. Use retry delay not only after error, but after fetch of empty batch also, to not overload NATS cluster.
2. Fix endless retry loop in case of error (removed _continue_)