### PR TITLE
refactor: ETL-192: add status transition validation

### DIFF
--- a/glassflow-api/internal/api/pipeline.go
+++ b/glassflow-api/internal/api/pipeline.go
@@ -12,6 +12,7 @@ import (
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal"
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/models"
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/service"
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/status"
 )
 
 func (h *handler) createPipeline(w http.ResponseWriter, r *http.Request) {
@@ -71,6 +72,11 @@ func (h *handler) stopPipeline(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, service.ErrNotImplemented):
 			jsonError(w, http.StatusNotImplemented, "feature not implemented for this version", nil)
 		default:
+			// Check if it's a status validation error
+			if statusErr, ok := status.GetStatusValidationError(err); ok {
+				jsonStatusValidationError(w, statusErr)
+				return
+			}
 			serverError(w)
 		}
 		return
@@ -101,6 +107,11 @@ func (h *handler) terminatePipeline(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, service.ErrNotImplemented):
 			jsonError(w, http.StatusNotImplemented, "feature not implemented for this version", nil)
 		default:
+			// Check if it's a status validation error
+			if statusErr, ok := status.GetStatusValidationError(err); ok {
+				jsonStatusValidationError(w, statusErr)
+				return
+			}
 			serverError(w)
 		}
 		return
@@ -132,6 +143,11 @@ func (h *handler) pausePipeline(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, service.ErrNotImplemented):
 			jsonError(w, http.StatusNotImplemented, "feature not implemented for this version", nil)
 		default:
+			// Check if it's a status validation error
+			if statusErr, ok := status.GetStatusValidationError(err); ok {
+				jsonStatusValidationError(w, statusErr)
+				return
+			}
 			h.log.Error("failed to pause pipeline", slog.String("pipeline_id", id), slog.Any("error", err))
 			serverError(w)
 		}
@@ -164,6 +180,11 @@ func (h *handler) resumePipeline(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, service.ErrNotImplemented):
 			jsonError(w, http.StatusNotImplemented, "feature not implemented for this version", nil)
 		default:
+			// Check if it's a status validation error
+			if statusErr, ok := status.GetStatusValidationError(err); ok {
+				jsonStatusValidationError(w, statusErr)
+				return
+			}
 			h.log.Error("failed to resume pipeline", slog.String("pipeline_id", id), slog.Any("error", err))
 			serverError(w)
 		}

--- a/glassflow-api/internal/api/response.go
+++ b/glassflow-api/internal/api/response.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/status"
 )
 
 func jsonResponse(w http.ResponseWriter, code int, v any) {
@@ -31,9 +33,36 @@ type errorResponse struct {
 	Field   map[string]string `json:"field,omitempty"`
 }
 
+type statusValidationErrorResponse struct {
+	Message          string   `json:"message"`
+	Code             string   `json:"code"`
+	CurrentStatus    string   `json:"current_status,omitempty"`
+	RequestedStatus  string   `json:"requested_status,omitempty"`
+	ValidTransitions []string `json:"valid_transitions,omitempty"`
+}
+
 func jsonError(w http.ResponseWriter, code int, message string, field map[string]string) {
 	jsonResponse(w, code, &errorResponse{
 		Message: message,
 		Field:   field,
 	})
+}
+
+func jsonStatusValidationError(w http.ResponseWriter, statusErr *status.StatusValidationError) {
+	response := &statusValidationErrorResponse{
+		Message:         statusErr.Message,
+		Code:            statusErr.Code,
+		CurrentStatus:   string(statusErr.CurrentStatus),
+		RequestedStatus: string(statusErr.RequestedStatus),
+	}
+
+	// Convert valid transitions to strings
+	if len(statusErr.ValidTransitions) > 0 {
+		response.ValidTransitions = make([]string, len(statusErr.ValidTransitions))
+		for i, transition := range statusErr.ValidTransitions {
+			response.ValidTransitions[i] = string(transition)
+		}
+	}
+
+	jsonResponse(w, statusErr.HTTPStatus(), response)
 }

--- a/glassflow-api/internal/service/pipeline_test.go
+++ b/glassflow-api/internal/service/pipeline_test.go
@@ -139,7 +139,7 @@ func TestPipelineManager_PausePipeline(t *testing.T) {
 			initialStatus: internal.PipelineStatusPaused,
 			orchestrator:  &mockOrchestrator{orchestratorType: "local"},
 			store:         &mockPipelineStore{},
-			expectedError: "pipeline is already paused",
+			expectedError: "Invalid status transition from Paused to Pausing",
 		},
 		{
 			name:          "pipeline already pausing",
@@ -147,7 +147,7 @@ func TestPipelineManager_PausePipeline(t *testing.T) {
 			initialStatus: internal.PipelineStatusPausing,
 			orchestrator:  &mockOrchestrator{orchestratorType: "local"},
 			store:         &mockPipelineStore{},
-			expectedError: "pipeline is already being paused",
+			expectedError: "Pipeline is already in Pausing state",
 		},
 		{
 			name:          "pipeline terminated",
@@ -155,7 +155,7 @@ func TestPipelineManager_PausePipeline(t *testing.T) {
 			initialStatus: internal.PipelineStatusTerminated,
 			orchestrator:  &mockOrchestrator{orchestratorType: "local"},
 			store:         &mockPipelineStore{},
-			expectedError: "no pipeline with given id exists",
+			expectedError: "Cannot transition from terminal state Terminated to Pausing",
 		},
 		{
 			name:          "orchestrator pause error",
@@ -273,7 +273,7 @@ func TestPipelineManager_ResumePipeline(t *testing.T) {
 			initialStatus: internal.PipelineStatusRunning,
 			orchestrator:  &mockOrchestrator{orchestratorType: "local"},
 			store:         &mockPipelineStore{},
-			expectedError: "pipeline is already running",
+			expectedError: "Invalid status transition from Running to Resuming",
 		},
 		{
 			name:          "pipeline already resuming",
@@ -281,7 +281,7 @@ func TestPipelineManager_ResumePipeline(t *testing.T) {
 			initialStatus: internal.PipelineStatusResuming,
 			orchestrator:  &mockOrchestrator{orchestratorType: "local"},
 			store:         &mockPipelineStore{},
-			expectedError: "pipeline is already being resumed",
+			expectedError: "Pipeline is already in Resuming state",
 		},
 		{
 			name:          "pipeline terminated",
@@ -289,7 +289,7 @@ func TestPipelineManager_ResumePipeline(t *testing.T) {
 			initialStatus: internal.PipelineStatusTerminated,
 			orchestrator:  &mockOrchestrator{orchestratorType: "local"},
 			store:         &mockPipelineStore{},
-			expectedError: "no pipeline with given id exists",
+			expectedError: "Cannot transition from terminal state Terminated to Resuming",
 		},
 		{
 			name:          "pipeline not paused",
@@ -297,7 +297,7 @@ func TestPipelineManager_ResumePipeline(t *testing.T) {
 			initialStatus: internal.PipelineStatusCreated,
 			orchestrator:  &mockOrchestrator{orchestratorType: "local"},
 			store:         &mockPipelineStore{},
-			expectedError: "pipeline must be paused to resume",
+			expectedError: "Invalid status transition from Created to Resuming",
 		},
 		{
 			name:          "orchestrator resume error",

--- a/glassflow-api/internal/status/errors.go
+++ b/glassflow-api/internal/status/errors.go
@@ -1,0 +1,122 @@
+package status
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/models"
+)
+
+// StatusValidationError represents a specific error for invalid status transitions
+type StatusValidationError struct {
+	// CurrentStatus is the current pipeline status
+	CurrentStatus models.PipelineStatus `json:"current_status"`
+	// RequestedStatus is the status that was requested
+	RequestedStatus models.PipelineStatus `json:"requested_status"`
+	// Message is a human-readable error message
+	Message string `json:"message"`
+	// Code is a machine-readable error code
+	Code string `json:"code"`
+	// ValidTransitions lists the valid transitions from the current status
+	ValidTransitions []models.PipelineStatus `json:"valid_transitions,omitempty"`
+}
+
+// Error implements the error interface
+func (e *StatusValidationError) Error() string {
+	return e.Message
+}
+
+// HTTPStatus returns the appropriate HTTP status code for this error
+func (e *StatusValidationError) HTTPStatus() int {
+	return http.StatusBadRequest
+}
+
+// ErrorCode returns the error code for API responses
+func (e *StatusValidationError) ErrorCode() string {
+	return e.Code
+}
+
+// NewInvalidTransitionError creates a new StatusValidationError for invalid transitions
+func NewInvalidTransitionError(current, requested models.PipelineStatus) *StatusValidationError {
+	validTransitions, _ := GetValidTransitions(current)
+
+	return &StatusValidationError{
+		CurrentStatus:    current,
+		RequestedStatus:  requested,
+		Message:          fmt.Sprintf("Invalid status transition from %s to %s", current, requested),
+		Code:             "INVALID_STATUS_TRANSITION",
+		ValidTransitions: validTransitions,
+	}
+}
+
+// NewTerminalStateError creates a new StatusValidationError for terminal state violations
+func NewTerminalStateError(current, requested models.PipelineStatus) *StatusValidationError {
+	return &StatusValidationError{
+		CurrentStatus:   current,
+		RequestedStatus: requested,
+		Message:         fmt.Sprintf("Cannot transition from terminal state %s to %s", current, requested),
+		Code:            "TERMINAL_STATE_VIOLATION",
+	}
+}
+
+// NewUnknownStatusError creates a new StatusValidationError for unknown statuses
+func NewUnknownStatusError(status models.PipelineStatus) *StatusValidationError {
+	return &StatusValidationError{
+		CurrentStatus:   status,
+		RequestedStatus: "",
+		Message:         fmt.Sprintf("Unknown pipeline status: %s", status),
+		Code:            "UNKNOWN_STATUS",
+	}
+}
+
+// NewPipelineNotFoundError creates a new StatusValidationError for missing pipelines
+func NewPipelineNotFoundError(pipelineID string) *StatusValidationError {
+	return &StatusValidationError{
+		CurrentStatus:   "",
+		RequestedStatus: "",
+		Message:         fmt.Sprintf("Pipeline not found: %s", pipelineID),
+		Code:            "PIPELINE_NOT_FOUND",
+	}
+}
+
+// NewPipelineAlreadyInStateError creates a new StatusValidationError for operations on pipelines already in the target state
+func NewPipelineAlreadyInStateError(current, requested models.PipelineStatus) *StatusValidationError {
+	return &StatusValidationError{
+		CurrentStatus:   current,
+		RequestedStatus: requested,
+		Message:         fmt.Sprintf("Pipeline is already in %s state", requested),
+		Code:            "PIPELINE_ALREADY_IN_STATE",
+	}
+}
+
+// NewPipelineInTransitionError creates a new StatusValidationError for operations on pipelines in transitional states
+func NewPipelineInTransitionError(current, requested models.PipelineStatus) *StatusValidationError {
+	return &StatusValidationError{
+		CurrentStatus:   current,
+		RequestedStatus: requested,
+		Message:         fmt.Sprintf("Pipeline is currently transitioning from %s state, cannot perform %s operation", current, requested),
+		Code:            "PIPELINE_IN_TRANSITION",
+	}
+}
+
+// Error codes for different types of validation failures
+const (
+	ErrorCodeInvalidTransition      = "INVALID_STATUS_TRANSITION"
+	ErrorCodeTerminalStateViolation = "TERMINAL_STATE_VIOLATION"
+	ErrorCodeUnknownStatus          = "UNKNOWN_STATUS"
+	ErrorCodePipelineNotFound       = "PIPELINE_NOT_FOUND"
+	ErrorCodePipelineAlreadyInState = "PIPELINE_ALREADY_IN_STATE"
+	ErrorCodePipelineInTransition   = "PIPELINE_IN_TRANSITION"
+)
+
+// IsStatusValidationError checks if an error is a StatusValidationError
+func IsStatusValidationError(err error) bool {
+	_, ok := err.(*StatusValidationError)
+	return ok
+}
+
+// GetStatusValidationError extracts StatusValidationError from an error
+func GetStatusValidationError(err error) (*StatusValidationError, bool) {
+	statusErr, ok := err.(*StatusValidationError)
+	return statusErr, ok
+}

--- a/glassflow-api/internal/status/errors_test.go
+++ b/glassflow-api/internal/status/errors_test.go
@@ -1,0 +1,256 @@
+package status
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal"
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/models"
+)
+
+func TestStatusValidationError(t *testing.T) {
+	tests := []struct {
+		name           string
+		error          *StatusValidationError
+		expectedCode   string
+		expectedStatus int
+		expectedMsg    string
+	}{
+		{
+			name: "Invalid transition error",
+			error: NewInvalidTransitionError(
+				models.PipelineStatus(internal.PipelineStatusRunning),
+				models.PipelineStatus(internal.PipelineStatusPaused),
+			),
+			expectedCode:   ErrorCodeInvalidTransition,
+			expectedStatus: 400,
+			expectedMsg:    "Invalid status transition from Running to Paused",
+		},
+		{
+			name: "Terminal state error",
+			error: NewTerminalStateError(
+				models.PipelineStatus(internal.PipelineStatusTerminated),
+				models.PipelineStatus(internal.PipelineStatusRunning),
+			),
+			expectedCode:   ErrorCodeTerminalStateViolation,
+			expectedStatus: 400,
+			expectedMsg:    "Cannot transition from terminal state Terminated to Running",
+		},
+		{
+			name: "Unknown status error",
+			error: NewUnknownStatusError(
+				models.PipelineStatus("Unknown"),
+			),
+			expectedCode:   ErrorCodeUnknownStatus,
+			expectedStatus: 400,
+			expectedMsg:    "Unknown pipeline status: Unknown",
+		},
+		{
+			name:           "Pipeline not found error",
+			error:          NewPipelineNotFoundError("test-pipeline"),
+			expectedCode:   ErrorCodePipelineNotFound,
+			expectedStatus: 400,
+			expectedMsg:    "Pipeline not found: test-pipeline",
+		},
+		{
+			name: "Pipeline already in state error",
+			error: NewPipelineAlreadyInStateError(
+				models.PipelineStatus(internal.PipelineStatusRunning),
+				models.PipelineStatus(internal.PipelineStatusRunning),
+			),
+			expectedCode:   ErrorCodePipelineAlreadyInState,
+			expectedStatus: 400,
+			expectedMsg:    "Pipeline is already in Running state",
+		},
+		{
+			name: "Pipeline in transition error",
+			error: NewPipelineInTransitionError(
+				models.PipelineStatus(internal.PipelineStatusPausing),
+				models.PipelineStatus(internal.PipelineStatusPaused),
+			),
+			expectedCode:   ErrorCodePipelineInTransition,
+			expectedStatus: 400,
+			expectedMsg:    "Pipeline is currently transitioning from Pausing state, cannot perform Paused operation",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test Error() method
+			if tt.error.Error() != tt.expectedMsg {
+				t.Errorf("expected error message %q, got %q", tt.expectedMsg, tt.error.Error())
+			}
+
+			// Test HTTPStatus() method
+			if tt.error.HTTPStatus() != tt.expectedStatus {
+				t.Errorf("expected HTTP status %d, got %d", tt.expectedStatus, tt.error.HTTPStatus())
+			}
+
+			// Test ErrorCode() method
+			if tt.error.ErrorCode() != tt.expectedCode {
+				t.Errorf("expected error code %q, got %q", tt.expectedCode, tt.error.ErrorCode())
+			}
+		})
+	}
+}
+
+func TestIsStatusValidationError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "StatusValidationError",
+			err:      NewInvalidTransitionError(models.PipelineStatus(internal.PipelineStatusRunning), models.PipelineStatus(internal.PipelineStatusPaused)),
+			expected: true,
+		},
+		{
+			name:     "Regular error",
+			err:      fmt.Errorf("regular error"),
+			expected: false,
+		},
+		{
+			name:     "Nil error",
+			err:      nil,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsStatusValidationError(tt.err)
+			if result != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestGetStatusValidationError(t *testing.T) {
+	tests := []struct {
+		name           string
+		err            error
+		expectedError  *StatusValidationError
+		expectedExists bool
+	}{
+		{
+			name:           "StatusValidationError",
+			err:            NewInvalidTransitionError(models.PipelineStatus(internal.PipelineStatusRunning), models.PipelineStatus(internal.PipelineStatusPaused)),
+			expectedError:  NewInvalidTransitionError(models.PipelineStatus(internal.PipelineStatusRunning), models.PipelineStatus(internal.PipelineStatusPaused)),
+			expectedExists: true,
+		},
+		{
+			name:           "Regular error",
+			err:            fmt.Errorf("regular error"),
+			expectedError:  nil,
+			expectedExists: false,
+		},
+		{
+			name:           "Nil error",
+			err:            nil,
+			expectedError:  nil,
+			expectedExists: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			statusErr, exists := GetStatusValidationError(tt.err)
+			if exists != tt.expectedExists {
+				t.Errorf("expected exists %v, got %v", tt.expectedExists, exists)
+			}
+			if tt.expectedExists && statusErr == nil {
+				t.Errorf("expected StatusValidationError, got nil")
+			}
+		})
+	}
+}
+
+func TestValidatePipelineOperation(t *testing.T) {
+	tests := []struct {
+		name        string
+		pipeline    *models.PipelineConfig
+		operation   models.PipelineStatus
+		expectError bool
+		errorCode   string
+	}{
+		{
+			name: "Valid operation",
+			pipeline: &models.PipelineConfig{
+				Status: models.PipelineHealth{
+					OverallStatus: models.PipelineStatus(internal.PipelineStatusRunning),
+				},
+			},
+			operation:   models.PipelineStatus(internal.PipelineStatusPausing),
+			expectError: false,
+		},
+		{
+			name: "Pipeline already in target state",
+			pipeline: &models.PipelineConfig{
+				Status: models.PipelineHealth{
+					OverallStatus: models.PipelineStatus(internal.PipelineStatusRunning),
+				},
+			},
+			operation:   models.PipelineStatus(internal.PipelineStatusRunning),
+			expectError: true,
+			errorCode:   ErrorCodePipelineAlreadyInState,
+		},
+		{
+			name: "Pipeline in transitional state",
+			pipeline: &models.PipelineConfig{
+				Status: models.PipelineHealth{
+					OverallStatus: models.PipelineStatus(internal.PipelineStatusPausing),
+				},
+			},
+			operation:   models.PipelineStatus(internal.PipelineStatusPaused),
+			expectError: true,
+			errorCode:   ErrorCodePipelineInTransition,
+		},
+		{
+			name:        "Nil pipeline",
+			pipeline:    nil,
+			operation:   models.PipelineStatus(internal.PipelineStatusRunning),
+			expectError: true,
+			errorCode:   ErrorCodePipelineNotFound,
+		},
+		{
+			name: "Invalid transition",
+			pipeline: &models.PipelineConfig{
+				Status: models.PipelineHealth{
+					OverallStatus: models.PipelineStatus(internal.PipelineStatusRunning),
+				},
+			},
+			operation:   models.PipelineStatus(internal.PipelineStatusPaused),
+			expectError: true,
+			errorCode:   ErrorCodeInvalidTransition,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidatePipelineOperation(tt.pipeline, tt.operation)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+					return
+				}
+
+				statusErr, ok := GetStatusValidationError(err)
+				if !ok {
+					t.Errorf("expected StatusValidationError, got %T", err)
+					return
+				}
+
+				if statusErr.Code != tt.errorCode {
+					t.Errorf("expected error code %q, got %q", tt.errorCode, statusErr.Code)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/glassflow-api/internal/status/validation.go
+++ b/glassflow-api/internal/status/validation.go
@@ -1,0 +1,182 @@
+package status
+
+import (
+	"fmt"
+
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal"
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/models"
+)
+
+// StatusTransition represents a valid transition from one status to another
+type StatusTransition struct {
+	From   models.PipelineStatus
+	To     models.PipelineStatus
+	Action string // Description of the action that triggers this transition
+}
+
+// StatusValidationMatrix defines all valid pipeline status transitions
+var StatusValidationMatrix = map[models.PipelineStatus][]models.PipelineStatus{
+	// Created status can only transition to Running
+	models.PipelineStatus(internal.PipelineStatusCreated): {
+		models.PipelineStatus(internal.PipelineStatusRunning),
+	},
+
+	// Running status can transition to Pausing, Stopping, or Terminating
+	models.PipelineStatus(internal.PipelineStatusRunning): {
+		models.PipelineStatus(internal.PipelineStatusPausing),
+		models.PipelineStatus(internal.PipelineStatusStopping),
+		models.PipelineStatus(internal.PipelineStatusTerminating),
+	},
+
+	// Pausing status can only transition to Paused
+	models.PipelineStatus(internal.PipelineStatusPausing): {
+		models.PipelineStatus(internal.PipelineStatusPaused),
+	},
+
+	// Paused status can transition to Resuming or Stopping
+	models.PipelineStatus(internal.PipelineStatusPaused): {
+		models.PipelineStatus(internal.PipelineStatusResuming),
+		models.PipelineStatus(internal.PipelineStatusStopping),
+	},
+
+	// Resuming status can only transition to Running
+	models.PipelineStatus(internal.PipelineStatusResuming): {
+		models.PipelineStatus(internal.PipelineStatusRunning),
+	},
+
+	// Stopping status can only transition to Stopped
+	models.PipelineStatus(internal.PipelineStatusStopping): {
+		models.PipelineStatus(internal.PipelineStatusStopped),
+	},
+
+	// Stopped status has no valid transitions (terminal state)
+	models.PipelineStatus(internal.PipelineStatusStopped): {},
+
+	// Terminating status can only transition to Terminated
+	models.PipelineStatus(internal.PipelineStatusTerminating): {
+		models.PipelineStatus(internal.PipelineStatusTerminated),
+	},
+
+	// Terminated status has no valid transitions (terminal state)
+	models.PipelineStatus(internal.PipelineStatusTerminated): {},
+
+	// Failed status has no valid transitions (terminal state)
+	models.PipelineStatus(internal.PipelineStatusFailed): {},
+}
+
+// StatusTransitionDescriptions provides human-readable descriptions for transitions
+var StatusTransitionDescriptions = map[string]string{
+	"Created->Running":        "Start pipeline execution",
+	"Running->Pausing":        "Pause pipeline",
+	"Running->Stopping":       "Stop pipeline",
+	"Running->Terminating":    "Terminate pipeline",
+	"Pausing->Paused":         "Complete pause operation",
+	"Paused->Resuming":        "Resume pipeline",
+	"Paused->Stopping":        "Stop paused pipeline",
+	"Resuming->Running":       "Complete resume operation",
+	"Stopping->Stopped":       "Complete stop operation",
+	"Terminating->Terminated": "Complete termination operation",
+}
+
+// ValidateStatusTransition checks if a transition from one status to another is valid
+func ValidateStatusTransition(from, to models.PipelineStatus) error {
+	// Check if the transition is valid according to the matrix
+	validTransitions, exists := StatusValidationMatrix[from]
+	if !exists {
+		return NewUnknownStatusError(from)
+	}
+
+	// Check if the target status is in the list of valid transitions
+	for _, validStatus := range validTransitions {
+		if validStatus == to {
+			return nil
+		}
+	}
+
+	// Check if this is a terminal state violation
+	if IsTerminalStatus(from) {
+		return NewTerminalStateError(from, to)
+	}
+
+	// If we get here, the transition is invalid
+	return NewInvalidTransitionError(from, to)
+}
+
+// GetValidTransitions returns all valid transitions from a given status
+func GetValidTransitions(from models.PipelineStatus) ([]models.PipelineStatus, error) {
+	validTransitions, exists := StatusValidationMatrix[from]
+	if !exists {
+		return nil, fmt.Errorf("unknown status: %s", from)
+	}
+
+	// Return a copy to prevent external modification
+	result := make([]models.PipelineStatus, len(validTransitions))
+	copy(result, validTransitions)
+	return result, nil
+}
+
+// IsTerminalStatus checks if a status is a terminal state (no further transitions allowed)
+func IsTerminalStatus(status models.PipelineStatus) bool {
+	validTransitions, exists := StatusValidationMatrix[status]
+	return exists && len(validTransitions) == 0
+}
+
+// IsTransitionalStatus checks if a status is transitional (temporary state during operations)
+func IsTransitionalStatus(status models.PipelineStatus) bool {
+	transitionalStatuses := []models.PipelineStatus{
+		models.PipelineStatus(internal.PipelineStatusPausing),
+		models.PipelineStatus(internal.PipelineStatusResuming),
+		models.PipelineStatus(internal.PipelineStatusStopping),
+		models.PipelineStatus(internal.PipelineStatusTerminating),
+	}
+
+	for _, transitional := range transitionalStatuses {
+		if status == transitional {
+			return true
+		}
+	}
+	return false
+}
+
+// GetStatusDescription returns a human-readable description of a status
+func GetStatusDescription(status models.PipelineStatus) string {
+	descriptions := map[models.PipelineStatus]string{
+		models.PipelineStatus(internal.PipelineStatusCreated):     "Pipeline created and ready to start",
+		models.PipelineStatus(internal.PipelineStatusRunning):     "Pipeline is actively processing data",
+		models.PipelineStatus(internal.PipelineStatusPausing):     "Pipeline is being paused",
+		models.PipelineStatus(internal.PipelineStatusPaused):      "Pipeline is paused and not processing data",
+		models.PipelineStatus(internal.PipelineStatusResuming):    "Pipeline is being resumed",
+		models.PipelineStatus(internal.PipelineStatusStopping):    "Pipeline is being stopped",
+		models.PipelineStatus(internal.PipelineStatusStopped):     "Pipeline has been stopped",
+		models.PipelineStatus(internal.PipelineStatusTerminating): "Pipeline is being terminated",
+		models.PipelineStatus(internal.PipelineStatusTerminated):  "Pipeline has been terminated",
+		models.PipelineStatus(internal.PipelineStatusFailed):      "Pipeline has failed",
+	}
+
+	if description, exists := descriptions[status]; exists {
+		return description
+	}
+	return fmt.Sprintf("Unknown status: %s", status)
+}
+
+// ValidatePipelineOperation validates a pipeline operation and returns specific errors
+func ValidatePipelineOperation(pipeline *models.PipelineConfig, operation models.PipelineStatus) error {
+	if pipeline == nil {
+		return NewPipelineNotFoundError("")
+	}
+
+	currentStatus := pipeline.Status.OverallStatus
+
+	// Check if pipeline is already in the target state
+	if currentStatus == operation {
+		return NewPipelineAlreadyInStateError(currentStatus, operation)
+	}
+
+	// Check if pipeline is in a transitional state
+	if IsTransitionalStatus(currentStatus) {
+		return NewPipelineInTransitionError(currentStatus, operation)
+	}
+
+	// Validate the transition
+	return ValidateStatusTransition(currentStatus, operation)
+}

--- a/glassflow-api/internal/status/validation.go
+++ b/glassflow-api/internal/status/validation.go
@@ -33,10 +33,11 @@ var StatusValidationMatrix = map[models.PipelineStatus][]models.PipelineStatus{
 		models.PipelineStatus(internal.PipelineStatusPaused),
 	},
 
-	// Paused status can transition to Resuming or Stopping
+	// Paused status can transition to Resuming, Stopping, or Terminating
 	models.PipelineStatus(internal.PipelineStatusPaused): {
 		models.PipelineStatus(internal.PipelineStatusResuming),
 		models.PipelineStatus(internal.PipelineStatusStopping),
+		models.PipelineStatus(internal.PipelineStatusTerminating),
 	},
 
 	// Resuming status can only transition to Running

--- a/glassflow-api/internal/status/validation.go
+++ b/glassflow-api/internal/status/validation.go
@@ -64,20 +64,6 @@ var StatusValidationMatrix = map[models.PipelineStatus][]models.PipelineStatus{
 	models.PipelineStatus(internal.PipelineStatusFailed): {},
 }
 
-// StatusTransitionDescriptions provides human-readable descriptions for transitions
-var StatusTransitionDescriptions = map[string]string{
-	"Created->Running":        "Start pipeline execution",
-	"Running->Pausing":        "Pause pipeline",
-	"Running->Stopping":       "Stop pipeline",
-	"Running->Terminating":    "Terminate pipeline",
-	"Pausing->Paused":         "Complete pause operation",
-	"Paused->Resuming":        "Resume pipeline",
-	"Paused->Stopping":        "Stop paused pipeline",
-	"Resuming->Running":       "Complete resume operation",
-	"Stopping->Stopped":       "Complete stop operation",
-	"Terminating->Terminated": "Complete termination operation",
-}
-
 // ValidateStatusTransition checks if a transition from one status to another is valid
 func ValidateStatusTransition(from, to models.PipelineStatus) error {
 	// Check if the transition is valid according to the matrix

--- a/glassflow-api/internal/status/validation_test.go
+++ b/glassflow-api/internal/status/validation_test.go
@@ -1,0 +1,397 @@
+package status
+
+import (
+	"testing"
+
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal"
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/models"
+)
+
+func TestValidateStatusTransition(t *testing.T) {
+	tests := []struct {
+		name        string
+		from        models.PipelineStatus
+		to          models.PipelineStatus
+		expectError bool
+		errorMsg    string
+	}{
+		// Valid transitions
+		{
+			name:        "Created to Running",
+			from:        models.PipelineStatus(internal.PipelineStatusCreated),
+			to:          models.PipelineStatus(internal.PipelineStatusRunning),
+			expectError: false,
+		},
+		{
+			name:        "Running to Pausing",
+			from:        models.PipelineStatus(internal.PipelineStatusRunning),
+			to:          models.PipelineStatus(internal.PipelineStatusPausing),
+			expectError: false,
+		},
+		{
+			name:        "Running to Stopping",
+			from:        models.PipelineStatus(internal.PipelineStatusRunning),
+			to:          models.PipelineStatus(internal.PipelineStatusStopping),
+			expectError: false,
+		},
+		{
+			name:        "Running to Terminating",
+			from:        models.PipelineStatus(internal.PipelineStatusRunning),
+			to:          models.PipelineStatus(internal.PipelineStatusTerminating),
+			expectError: false,
+		},
+		{
+			name:        "Pausing to Paused",
+			from:        models.PipelineStatus(internal.PipelineStatusPausing),
+			to:          models.PipelineStatus(internal.PipelineStatusPaused),
+			expectError: false,
+		},
+		{
+			name:        "Paused to Resuming",
+			from:        models.PipelineStatus(internal.PipelineStatusPaused),
+			to:          models.PipelineStatus(internal.PipelineStatusResuming),
+			expectError: false,
+		},
+		{
+			name:        "Paused to Stopping",
+			from:        models.PipelineStatus(internal.PipelineStatusPaused),
+			to:          models.PipelineStatus(internal.PipelineStatusStopping),
+			expectError: false,
+		},
+		{
+			name:        "Resuming to Running",
+			from:        models.PipelineStatus(internal.PipelineStatusResuming),
+			to:          models.PipelineStatus(internal.PipelineStatusRunning),
+			expectError: false,
+		},
+		{
+			name:        "Stopping to Stopped",
+			from:        models.PipelineStatus(internal.PipelineStatusStopping),
+			to:          models.PipelineStatus(internal.PipelineStatusStopped),
+			expectError: false,
+		},
+		{
+			name:        "Terminating to Terminated",
+			from:        models.PipelineStatus(internal.PipelineStatusTerminating),
+			to:          models.PipelineStatus(internal.PipelineStatusTerminated),
+			expectError: false,
+		},
+
+		// Invalid transitions
+		{
+			name:        "Created to Paused (invalid)",
+			from:        models.PipelineStatus(internal.PipelineStatusCreated),
+			to:          models.PipelineStatus(internal.PipelineStatusPaused),
+			expectError: true,
+		},
+		{
+			name:        "Running to Running (invalid)",
+			from:        models.PipelineStatus(internal.PipelineStatusRunning),
+			to:          models.PipelineStatus(internal.PipelineStatusRunning),
+			expectError: true,
+		},
+		{
+			name:        "Paused to Paused (invalid)",
+			from:        models.PipelineStatus(internal.PipelineStatusPaused),
+			to:          models.PipelineStatus(internal.PipelineStatusPaused),
+			expectError: true,
+		},
+		{
+			name:        "Stopped to Running (invalid - terminal state)",
+			from:        models.PipelineStatus(internal.PipelineStatusStopped),
+			to:          models.PipelineStatus(internal.PipelineStatusRunning),
+			expectError: true,
+		},
+		{
+			name:        "Terminated to Running (invalid - terminal state)",
+			from:        models.PipelineStatus(internal.PipelineStatusTerminated),
+			to:          models.PipelineStatus(internal.PipelineStatusRunning),
+			expectError: true,
+		},
+		{
+			name:        "Failed to Running (invalid - terminal state)",
+			from:        models.PipelineStatus(internal.PipelineStatusFailed),
+			to:          models.PipelineStatus(internal.PipelineStatusRunning),
+			expectError: true,
+		},
+		{
+			name:        "Running to Resuming (invalid)",
+			from:        models.PipelineStatus(internal.PipelineStatusRunning),
+			to:          models.PipelineStatus(internal.PipelineStatusResuming),
+			expectError: true,
+		},
+		{
+			name:        "Paused to Pausing (invalid)",
+			from:        models.PipelineStatus(internal.PipelineStatusPaused),
+			to:          models.PipelineStatus(internal.PipelineStatusPausing),
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateStatusTransition(tt.from, tt.to)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestGetValidTransitions(t *testing.T) {
+	tests := []struct {
+		name           string
+		from           models.PipelineStatus
+		expectedCount  int
+		expectedStatus []models.PipelineStatus
+		expectError    bool
+	}{
+		{
+			name:          "Created status transitions",
+			from:          models.PipelineStatus(internal.PipelineStatusCreated),
+			expectedCount: 1,
+			expectedStatus: []models.PipelineStatus{
+				models.PipelineStatus(internal.PipelineStatusRunning),
+			},
+			expectError: false,
+		},
+		{
+			name:          "Running status transitions",
+			from:          models.PipelineStatus(internal.PipelineStatusRunning),
+			expectedCount: 3,
+			expectedStatus: []models.PipelineStatus{
+				models.PipelineStatus(internal.PipelineStatusPausing),
+				models.PipelineStatus(internal.PipelineStatusStopping),
+				models.PipelineStatus(internal.PipelineStatusTerminating),
+			},
+			expectError: false,
+		},
+		{
+			name:          "Paused status transitions",
+			from:          models.PipelineStatus(internal.PipelineStatusPaused),
+			expectedCount: 2,
+			expectedStatus: []models.PipelineStatus{
+				models.PipelineStatus(internal.PipelineStatusResuming),
+				models.PipelineStatus(internal.PipelineStatusStopping),
+			},
+			expectError: false,
+		},
+		{
+			name:           "Stopped status transitions (terminal)",
+			from:           models.PipelineStatus(internal.PipelineStatusStopped),
+			expectedCount:  0,
+			expectedStatus: []models.PipelineStatus{},
+			expectError:    false,
+		},
+		{
+			name:        "Unknown status",
+			from:        models.PipelineStatus("Unknown"),
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			transitions, err := GetValidTransitions(tt.from)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if len(transitions) != tt.expectedCount {
+				t.Errorf("expected %d transitions, got %d", tt.expectedCount, len(transitions))
+			}
+
+			// Check that all expected transitions are present
+			for _, expectedStatus := range tt.expectedStatus {
+				found := false
+				for _, transition := range transitions {
+					if transition == expectedStatus {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected transition to %s not found", expectedStatus)
+				}
+			}
+		})
+	}
+}
+
+func TestIsTerminalStatus(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   models.PipelineStatus
+		expected bool
+	}{
+		{
+			name:     "Stopped is terminal",
+			status:   models.PipelineStatus(internal.PipelineStatusStopped),
+			expected: true,
+		},
+		{
+			name:     "Terminated is terminal",
+			status:   models.PipelineStatus(internal.PipelineStatusTerminated),
+			expected: true,
+		},
+		{
+			name:     "Failed is terminal",
+			status:   models.PipelineStatus(internal.PipelineStatusFailed),
+			expected: true,
+		},
+		{
+			name:     "Running is not terminal",
+			status:   models.PipelineStatus(internal.PipelineStatusRunning),
+			expected: false,
+		},
+		{
+			name:     "Paused is not terminal",
+			status:   models.PipelineStatus(internal.PipelineStatusPaused),
+			expected: false,
+		},
+		{
+			name:     "Created is not terminal",
+			status:   models.PipelineStatus(internal.PipelineStatusCreated),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsTerminalStatus(tt.status)
+			if result != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestIsTransitionalStatus(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   models.PipelineStatus
+		expected bool
+	}{
+		{
+			name:     "Pausing is transitional",
+			status:   models.PipelineStatus(internal.PipelineStatusPausing),
+			expected: true,
+		},
+		{
+			name:     "Resuming is transitional",
+			status:   models.PipelineStatus(internal.PipelineStatusResuming),
+			expected: true,
+		},
+		{
+			name:     "Stopping is transitional",
+			status:   models.PipelineStatus(internal.PipelineStatusStopping),
+			expected: true,
+		},
+		{
+			name:     "Terminating is transitional",
+			status:   models.PipelineStatus(internal.PipelineStatusTerminating),
+			expected: true,
+		},
+		{
+			name:     "Running is not transitional",
+			status:   models.PipelineStatus(internal.PipelineStatusRunning),
+			expected: false,
+		},
+		{
+			name:     "Paused is not transitional",
+			status:   models.PipelineStatus(internal.PipelineStatusPaused),
+			expected: false,
+		},
+		{
+			name:     "Created is not transitional",
+			status:   models.PipelineStatus(internal.PipelineStatusCreated),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsTransitionalStatus(tt.status)
+			if result != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestGetStatusDescription(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   models.PipelineStatus
+		expected string
+	}{
+		{
+			name:     "Created status description",
+			status:   models.PipelineStatus(internal.PipelineStatusCreated),
+			expected: "Pipeline created and ready to start",
+		},
+		{
+			name:     "Running status description",
+			status:   models.PipelineStatus(internal.PipelineStatusRunning),
+			expected: "Pipeline is actively processing data",
+		},
+		{
+			name:     "Paused status description",
+			status:   models.PipelineStatus(internal.PipelineStatusPaused),
+			expected: "Pipeline is paused and not processing data",
+		},
+		{
+			name:     "Unknown status description",
+			status:   models.PipelineStatus("Unknown"),
+			expected: "Unknown status: Unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetStatusDescription(tt.status)
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+// TestStatusValidationMatrixCompleteness ensures all status constants are covered
+func TestStatusValidationMatrixCompleteness(t *testing.T) {
+	allStatuses := []models.PipelineStatus{
+		models.PipelineStatus(internal.PipelineStatusCreated),
+		models.PipelineStatus(internal.PipelineStatusRunning),
+		models.PipelineStatus(internal.PipelineStatusPausing),
+		models.PipelineStatus(internal.PipelineStatusPaused),
+		models.PipelineStatus(internal.PipelineStatusResuming),
+		models.PipelineStatus(internal.PipelineStatusStopping),
+		models.PipelineStatus(internal.PipelineStatusStopped),
+		models.PipelineStatus(internal.PipelineStatusTerminating),
+		models.PipelineStatus(internal.PipelineStatusTerminated),
+		models.PipelineStatus(internal.PipelineStatusFailed),
+	}
+
+	for _, status := range allStatuses {
+		_, exists := StatusValidationMatrix[status]
+		if !exists {
+			t.Errorf("status %s is not defined in StatusValidationMatrix", status)
+		}
+	}
+}

--- a/glassflow-api/internal/status/validation_test.go
+++ b/glassflow-api/internal/status/validation_test.go
@@ -59,6 +59,12 @@ func TestValidateStatusTransition(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name:        "Paused to Terminating",
+			from:        models.PipelineStatus(internal.PipelineStatusPaused),
+			to:          models.PipelineStatus(internal.PipelineStatusTerminating),
+			expectError: false,
+		},
+		{
 			name:        "Resuming to Running",
 			from:        models.PipelineStatus(internal.PipelineStatusResuming),
 			to:          models.PipelineStatus(internal.PipelineStatusRunning),
@@ -176,10 +182,11 @@ func TestGetValidTransitions(t *testing.T) {
 		{
 			name:          "Paused status transitions",
 			from:          models.PipelineStatus(internal.PipelineStatusPaused),
-			expectedCount: 2,
+			expectedCount: 3,
 			expectedStatus: []models.PipelineStatus{
 				models.PipelineStatus(internal.PipelineStatusResuming),
 				models.PipelineStatus(internal.PipelineStatusStopping),
+				models.PipelineStatus(internal.PipelineStatusTerminating),
 			},
 			expectError: false,
 		},


### PR DESCRIPTION
Changes:
1. centralize status transition validation in CH-ETL
2. propagate status transition validation errors to API
3. update both orchestrators to use this validation
4. API response structure to send specific errors



### Create pipeline
```sh
 % curl -v 'http://localhost:8085/api/v1/pipeline' -X POST --data-raw '{"pipeline_id": "kiran-dedup-k8-1", "name": "k8 without join, testing pause/resume 3 replica", "source": {"type": "kafka", "provider": "custom", "connection_params": {"brokers": ["kafka.default.svc.cluster.local:9092"], "protocol": "PLAINTEXT", "skip_auth": true}, "topics": [{"consumer_group_initial_offset": "latest", "name": "users", "id": "users", "replicas": 3, "schema": {"type": "json", "fields": [{"name": "event_id", "type": "string"}, {"name": "user.id", "type": "string"}, {"name": "user.name", "type": "string"}, {"name": "user.email", "type": "string"}, {"name": "created_at", "type": "string"}]}, "deduplication": {"enabled": false, "id_field": "event_id", "id_field_type": "string", "time_window": "1m"}}]}, "sink": {"type": "clickhouse", "provider": "custom", "host": "my-release-clickhouse.default.svc.cluster.local", "port": "9000", "http_port": "8123", "database": "default", "username": "default", "password": "cXZiZVNJM0ZLeg==", "secure": false, "skip_certificate_verification": true, "max_batch_size": 1000, "max_delay_time": "5s", "table": "users_dedup", "table_mapping": [{"source_id": "users", "field_name": "event_id", "column_name": "event_id", "column_type": "String"}, {"source_id": "users", "field_name": "user.id", "column_name": "user_id", "column_type": "String"}, {"source_id": "users", "field_name": "user.name", "column_name": "name", "column_type": "String"}, {"source_id": "users", "field_name": "user.email", "column_name": "email", "column_type": "String"}, {"source_id": "users", "field_name": "created_at", "column_name": "created_at", "column_type": "DateTime"}]}}'
```


## On a running pipeline

### Attempt resume
```sh
 % curl -v 'http://localhost:8085/api/v1/pipeline/kiran-dedup-k8-1/resume' -X POST
< HTTP/1.1 400 Bad Request
{"message":"Invalid status transition from Running to Resuming","code":"INVALID_STATUS_TRANSITION","current_status":"Running","requested_status":"Resuming","valid_transitions":["Pausing","Stopping","Terminating"]}
```

## On a paused pipeline

### Attempt pause
```sh
 % curl -v 'http://localhost:8085/api/v1/pipeline/kiran-dedup-k8-1/pause' -X POST
< HTTP/1.1 400 Bad Request
{"message":"Invalid status transition from Paused to Pausing","code":"INVALID_STATUS_TRANSITION","current_status":"Paused","requested_status":"Pausing","valid_transitions":["Resuming","Stopping"]}
```

## On a stopped  pipeline

### Attempt pause
```sh
 % curl -v 'http://localhost:8085/api/v1/pipeline/kiran-dedup-k8-1/pause' -X POST
< HTTP/1.1 400 Bad Request
{"message":"Cannot transition from terminal state Stopped to Pausing","code":"TERMINAL_STATE_VIOLATION","current_status":"Stopped","requested_status":"Pausing"}
```


### Attempt resume 
```sh
 % curl -v 'http://localhost:8085/api/v1/pipeline/kiran-dedup-k8-1/resume' -X POST
< HTTP/1.1 400 Bad Request
{"message":"Cannot transition from terminal state Stopped to Resuming","code":"TERMINAL_STATE_VIOLATION","current_status":"Stopped","requested_status":"Resuming"}
```

### Attempt terminate 
```sh
 % curl -v 'http://localhost:8085/api/v1/pipeline/kiran-dedup-k8-1/terminate' -X DELETE
< HTTP/1.1 400 Bad Request
{"message":"Cannot transition from terminal state Stopped to Terminating","code":"TERMINAL_STATE_VIOLATION","current_status":"Stopped","requested_status":"Terminating"}
```

### Attempt stop
```sh
 % curl -v 'http://localhost:8085/api/v1/pipeline/kiran-dedup-k8-1/stop' -X POST
< HTTP/1.1 400 Bad Request
{"message":"Cannot transition from terminal state Stopped to Stopping","code":"TERMINAL_STATE_VIOLATION","current_status":"Stopped","requested_status":"Stopping"}
```

## On a terminated pipeline

### Attempt pause
```sh
 % curl -v 'http://localhost:8085/api/v1/pipeline/kiran-dedup-k8-1/pause' -X POST
< HTTP/1.1 400 Bad Request
{"message":"Cannot transition from terminal state Terminated to Pausing","code":"TERMINAL_STATE_VIOLATION","current_status":"Terminated","requested_status":"Pausing"}
```


### Attempt resume
```sh
 % curl -v 'http://localhost:8085/api/v1/pipeline/kiran-dedup-k8-1/resume' -X POST
< HTTP/1.1 400 Bad Request
{"message":"Cannot transition from terminal state Terminated to Resuming","code":"TERMINAL_STATE_VIOLATION","current_status":"Terminated","requested_status":"Resuming"}
```


### Attempt stop
```sh
{"message":"Cannot transition from terminal state Terminated to Stopping","code":"TERMINAL_STATE_VIOLATION","current_status":"Terminated","requested_status":"Stopping"}
```

### Attempt terminate
```sh
 % curl -v 'http://localhost:8085/api/v1/pipeline/kiran-dedup-k8-1/terminate' -X DELETE
< HTTP/1.1 400 Bad Request
{"message":"Cannot transition from terminal state Terminated to Terminating","code":"TERMINAL_STATE_VIOLATION","current_status":"Terminated","requested_status":"Terminating"}
```