### PR TITLE
fix: #224: ETL-343: support for "day" duration for a deduplication window

### DIFF
--- a/glassflow-api/internal/models/configs_test.go
+++ b/glassflow-api/internal/models/configs_test.go
@@ -1,9 +1,11 @@
 package models
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal"
 )
@@ -324,5 +326,466 @@ func TestGetWildcardNATSSubjectName(t *testing.T) {
 	expected := fmt.Sprintf("%s.%s", streamName, internal.WildcardSubject)
 	if result != expected {
 		t.Errorf("GetWildcardNATSSubjectName(%q) = %q, want %q", streamName, result, expected)
+	}
+}
+
+// JSONDuration Tests
+
+func TestConvertDaysToHours(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "single day",
+			input:    "1d",
+			expected: "24h",
+		},
+		{
+			name:     "multiple days",
+			input:    "7d",
+			expected: "168h",
+		},
+		{
+			name:     "day with hours",
+			input:    "1d12h",
+			expected: "24h12h",
+		},
+		{
+			name:     "day with hours and minutes",
+			input:    "2d6h30m",
+			expected: "48h6h30m",
+		},
+		{
+			name:     "day with all units",
+			input:    "1d12h30m45s",
+			expected: "24h12h30m45s",
+		},
+		{
+			name:     "multiple days with mixed units",
+			input:    "3d2h15m",
+			expected: "72h2h15m",
+		},
+		{
+			name:     "no days - should remain unchanged",
+			input:    "12h30m",
+			expected: "12h30m",
+		},
+		{
+			name:     "only hours - should remain unchanged",
+			input:    "24h",
+			expected: "24h",
+		},
+		{
+			name:     "only minutes - should remain unchanged",
+			input:    "30m",
+			expected: "30m",
+		},
+		{
+			name:     "only seconds - should remain unchanged",
+			input:    "45s",
+			expected: "45s",
+		},
+		{
+			name:     "zero days",
+			input:    "0d",
+			expected: "0h",
+		},
+		{
+			name:     "large number of days",
+			input:    "365d",
+			expected: "8760h",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := convertDaysToHours(tt.input)
+			if result != tt.expected {
+				t.Errorf("convertDaysToHours(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestJSONDurationUnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name        string
+		jsonInput   string
+		expected    time.Duration
+		expectError bool
+	}{
+		// Day-based durations (new functionality)
+		{
+			name:      "single day",
+			jsonInput: `"1d"`,
+			expected:  24 * time.Hour,
+		},
+		{
+			name:      "multiple days",
+			jsonInput: `"7d"`,
+			expected:  7 * 24 * time.Hour,
+		},
+		{
+			name:      "day with hours",
+			jsonInput: `"1d12h"`,
+			expected:  36 * time.Hour,
+		},
+		{
+			name:      "day with hours and minutes",
+			jsonInput: `"2d6h30m"`,
+			expected:  2*24*time.Hour + 6*time.Hour + 30*time.Minute,
+		},
+		{
+			name:      "day with all units",
+			jsonInput: `"1d12h30m45s"`,
+			expected:  24*time.Hour + 12*time.Hour + 30*time.Minute + 45*time.Second,
+		},
+		{
+			name:      "zero days",
+			jsonInput: `"0d"`,
+			expected:  0,
+		},
+		{
+			name:      "large number of days",
+			jsonInput: `"365d"`,
+			expected:  365 * 24 * time.Hour,
+		},
+		// Standard Go duration formats (existing functionality)
+		{
+			name:      "hours only",
+			jsonInput: `"24h"`,
+			expected:  24 * time.Hour,
+		},
+		{
+			name:      "hours and minutes",
+			jsonInput: `"12h30m"`,
+			expected:  12*time.Hour + 30*time.Minute,
+		},
+		{
+			name:      "minutes only",
+			jsonInput: `"30m"`,
+			expected:  30 * time.Minute,
+		},
+		{
+			name:      "seconds only",
+			jsonInput: `"45s"`,
+			expected:  45 * time.Second,
+		},
+		{
+			name:      "milliseconds",
+			jsonInput: `"500ms"`,
+			expected:  500 * time.Millisecond,
+		},
+		{
+			name:      "nanoseconds",
+			jsonInput: `"1000ns"`,
+			expected:  1000 * time.Nanosecond,
+		},
+		{
+			name:      "complex duration",
+			jsonInput: `"1h30m45s"`,
+			expected:  time.Hour + 30*time.Minute + 45*time.Second,
+		},
+		// Error cases
+		{
+			name:        "invalid duration format",
+			jsonInput:   `"invalid"`,
+			expectError: true,
+		},
+		{
+			name:        "non-string input",
+			jsonInput:   `123`,
+			expectError: true,
+		},
+		{
+			name:        "empty string",
+			jsonInput:   `""`,
+			expectError: true,
+		},
+		{
+			name:      "negative duration",
+			jsonInput: `"-1h"`,
+			expected:  -1 * time.Hour,
+		},
+		{
+			name:        "invalid JSON",
+			jsonInput:   `invalid json`,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var d JSONDuration
+			err := json.Unmarshal([]byte(tt.jsonInput), &d)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error for input %q, but got none", tt.jsonInput)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error for input %q: %v", tt.jsonInput, err)
+				return
+			}
+
+			if d.Duration() != tt.expected {
+				t.Errorf("Expected duration %v, got %v for input %q", tt.expected, d.Duration(), tt.jsonInput)
+			}
+		})
+	}
+}
+
+func TestJSONDurationMarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		duration time.Duration
+		expected string
+	}{
+		{
+			name:     "single day equivalent",
+			duration: 24 * time.Hour,
+			expected: `"24h0m0s"`,
+		},
+		{
+			name:     "multiple days equivalent",
+			duration: 7 * 24 * time.Hour,
+			expected: `"168h0m0s"`,
+		},
+		{
+			name:     "day with hours equivalent",
+			duration: 36 * time.Hour,
+			expected: `"36h0m0s"`,
+		},
+		{
+			name:     "complex duration",
+			duration: 2*24*time.Hour + 6*time.Hour + 30*time.Minute,
+			expected: `"54h30m0s"`,
+		},
+		{
+			name:     "zero duration",
+			duration: 0,
+			expected: `"0s"`,
+		},
+		{
+			name:     "seconds only",
+			duration: 45 * time.Second,
+			expected: `"45s"`,
+		},
+		{
+			name:     "minutes only",
+			duration: 30 * time.Minute,
+			expected: `"30m0s"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := NewJSONDuration(tt.duration)
+			result, err := json.Marshal(d)
+
+			if err != nil {
+				t.Errorf("Unexpected error marshaling duration %v: %v", tt.duration, err)
+				return
+			}
+
+			if string(result) != tt.expected {
+				t.Errorf("Expected JSON %q, got %q for duration %v", tt.expected, string(result), tt.duration)
+			}
+		})
+	}
+}
+
+func TestJSONDurationString(t *testing.T) {
+	tests := []struct {
+		name     string
+		duration time.Duration
+		expected string
+	}{
+		{
+			name:     "single day equivalent",
+			duration: 24 * time.Hour,
+			expected: "24h0m0s",
+		},
+		{
+			name:     "complex duration",
+			duration: 2*24*time.Hour + 6*time.Hour + 30*time.Minute + 45*time.Second,
+			expected: "54h30m45s",
+		},
+		{
+			name:     "zero duration",
+			duration: 0,
+			expected: "0s",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := NewJSONDuration(tt.duration)
+			result := d.String()
+
+			if result != tt.expected {
+				t.Errorf("Expected string %q, got %q for duration %v", tt.expected, result, tt.duration)
+			}
+		})
+	}
+}
+
+func TestJSONDurationDuration(t *testing.T) {
+	tests := []struct {
+		name     string
+		duration time.Duration
+	}{
+		{
+			name:     "single day equivalent",
+			duration: 24 * time.Hour,
+		},
+		{
+			name:     "complex duration",
+			duration: 2*24*time.Hour + 6*time.Hour + 30*time.Minute + 45*time.Second,
+		},
+		{
+			name:     "zero duration",
+			duration: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := NewJSONDuration(tt.duration)
+			result := d.Duration()
+
+			if result != tt.duration {
+				t.Errorf("Expected duration %v, got %v", tt.duration, result)
+			}
+		})
+	}
+}
+
+func TestJSONDurationRoundTrip(t *testing.T) {
+	// Test that marshaling and unmarshaling preserves the duration
+	tests := []struct {
+		name      string
+		jsonInput string
+	}{
+		{
+			name:      "day format",
+			jsonInput: `"1d"`,
+		},
+		{
+			name:      "day with hours",
+			jsonInput: `"2d12h"`,
+		},
+		{
+			name:      "complex day format",
+			jsonInput: `"1d6h30m45s"`,
+		},
+		{
+			name:      "standard hour format",
+			jsonInput: `"24h"`,
+		},
+		{
+			name:      "standard complex format",
+			jsonInput: `"12h30m45s"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Unmarshal
+			var d1 JSONDuration
+			err := json.Unmarshal([]byte(tt.jsonInput), &d1)
+			if err != nil {
+				t.Errorf("Failed to unmarshal %q: %v", tt.jsonInput, err)
+				return
+			}
+
+			// Marshal back
+			jsonOutput, err := json.Marshal(d1)
+			if err != nil {
+				t.Errorf("Failed to marshal duration %v: %v", d1.Duration(), err)
+				return
+			}
+
+			// Unmarshal again
+			var d2 JSONDuration
+			err = json.Unmarshal(jsonOutput, &d2)
+			if err != nil {
+				t.Errorf("Failed to unmarshal marshaled result %q: %v", string(jsonOutput), err)
+				return
+			}
+
+			// Check that durations are equal
+			if d1.Duration() != d2.Duration() {
+				t.Errorf("Round trip failed: original %v, after round trip %v", d1.Duration(), d2.Duration())
+			}
+		})
+	}
+}
+
+func TestJSONDurationEdgeCases(t *testing.T) {
+	tests := []struct {
+		name        string
+		jsonInput   string
+		expectError bool
+		description string
+	}{
+		{
+			name:        "very large number of days",
+			jsonInput:   `"999999d"`,
+			expectError: true,
+			description: "Should reject very large day values that exceed Go duration limits",
+		},
+		{
+			name:        "day with zero hours",
+			jsonInput:   `"1d0h"`,
+			expectError: false,
+			description: "Should handle zero values in mixed units",
+		},
+		{
+			name:        "day with zero minutes",
+			jsonInput:   `"1d12h0m"`,
+			expectError: false,
+			description: "Should handle zero minutes",
+		},
+		{
+			name:        "day with zero seconds",
+			jsonInput:   `"1d12h30m0s"`,
+			expectError: false,
+			description: "Should handle zero seconds",
+		},
+		{
+			name:        "malformed day format",
+			jsonInput:   `"1dx"`,
+			expectError: true,
+			description: "Should reject malformed day format",
+		},
+		{
+			name:        "day with invalid number",
+			jsonInput:   `"xd"`,
+			expectError: true,
+			description: "Should reject invalid day number",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var d JSONDuration
+			err := json.Unmarshal([]byte(tt.jsonInput), &d)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error for %q (%s), but got none", tt.jsonInput, tt.description)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error for %q (%s): %v", tt.jsonInput, tt.description, err)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
Issue:
1. Go time package doesn't support parsing days.

Changes:
1. Added a helper method to support parsing day level time parsing.
2. Added config tests to validate time parsing with days, hours, mins, seconds.
3. Checked NATS stream if they reflect the duration 


### Create pipeline with dedup window 1 day 12 hour
```sh
 %  curl 'http://localhost:8085/api/v1/pipeline' -X POST --data-raw '{"pipeline_id": "kiran-dedup-no-join-docker-v-zyg4zv2m-6", "name": "kiran-dedup-no-join-docker-version", "source": {"type": "kafka", "provider": "custom", "connection_params": {"brokers": ["localhost:9092"], "protocol": "PLAINTEXT", "skip_auth": true}, "topics": [{"consumer_group_initial_offset": "latest", "name": "users", "replicas": 3, "id": "users", "schema": {"type": "json", "fields": [{"name": "event_id", "type": "string"}, {"name": "user.id", "type": "string"}, {"name": "user.name", "type": "string"}, {"name": "user.email", "type": "string"}, {"name": "created_at", "type": "string"}, {"name": "tags", "type": "array"}]}, "deduplication": {"enabled": true, "id_field": "event_id", "id_field_type": "string", "time_window": "1d12h"}}]}, "join": {"enabled": false, "type": "temporal", "sources": []}, "sink": {"type": "clickhouse", "provider": "custom", "host": "localhost", "port": "9000", "http_port": "8123", "database": "default", "username": "default", "password": "c2VjcmV0", "secure": false, "skip_certificate_verification": true, "max_batch_size": 1, "max_delay_time": "10s", "table": "users_dedup", "table_mapping": [{"source_id": "users", "field_name": "event_id", "column_name": "event_id", "column_type": "String"}, {"source_id": "users", "field_name": "user.id", "column_name": "user_id", "column_type": "String"}, {"source_id": "users", "field_name": "user.name", "column_name": "name", "column_type": "String"}, {"source_id": "users", "field_name": "user.email", "column_name": "email", "column_type": "String"}, {"source_id": "users", "field_name": "created_at", "column_name": "created_at", "column_type": "DateTime"}, {"source_id": "users", "field_name": "tags", "column_name": "tags", "column_type": "Array(String)"}]}}'
```


### Check nats stream dedup window
```sh

[k8] ? Select a Stream gf-689b54af-users
Information for Stream gf-689b54af-users created 2025-09-23 09:43:28

                Subjects: gf-689b54af-users.*
                Replicas: 1
                 Storage: File

Options:

               Retention: Limits
         Acknowledgments: true
          Discard Policy: Old
        Duplicate Window: 1d12h0m0s
```