### PR TITLE
fix: allow mapper to accept zero values for nullable columns

### DIFF
--- a/glassflow-api/internal/schema/types_test.go
+++ b/glassflow-api/internal/schema/types_test.go
@@ -464,7 +464,7 @@ func TestParsers(t *testing.T) {
 			{"int input", 42, "42", true},
 			{"float input", 3.14, "3.14", true},
 			{"bool input", true, "true", true},
-			{"nil input", nil, "", true},
+			{"nil input", nil, "", false},
 		}
 
 		for _, tt := range tests {
@@ -492,7 +492,7 @@ func TestParsers(t *testing.T) {
 			{"bool input: false", false, false, false},
 			{"string input", "true", false, true},
 			{"int input", 1, false, true},
-			{"nil input", nil, false, true},
+			{"nil input", nil, false, false},
 		}
 
 		for _, tt := range tests {
@@ -547,7 +547,7 @@ func TestParsers(t *testing.T) {
 			{"int input", 42, 42.0, true},
 			{"string input", "3.14", 0, true},
 			{"invalid string", "invalid", 0, true},
-			{"nil input", nil, 0, true},
+			{"nil input", nil, 0, false},
 		}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {

--- a/glassflow-api/internal/schema/utils.go
+++ b/glassflow-api/internal/schema/utils.go
@@ -12,6 +12,8 @@ func ParseString(data any) (zero string, _ error) {
 	switch value := data.(type) {
 	case string:
 		return value, nil
+	case nil:
+		return "", nil // Handle null values by returning empty string
 	default:
 		return zero, fmt.Errorf("failed to parse string: %v, type is: %v", data, reflect.TypeOf(data))
 	}
@@ -21,6 +23,8 @@ func ParseBool(data any) (zero bool, _ error) {
 	switch value := data.(type) {
 	case bool:
 		return value, nil
+	case nil:
+		return false, nil // Handle null values by returning false
 	default:
 		return zero, fmt.Errorf("failed to parse bool: %v, type is: %v", data, reflect.TypeOf(data))
 	}
@@ -78,6 +82,8 @@ func ParseInt32(data any) (zero int32, _ error) {
 			return zero, fmt.Errorf("value out of range of int32: %f", value)
 		}
 		return int32(value), nil
+	case nil:
+		return 0, nil // Handle null values by returning 0
 	default:
 		return zero, fmt.Errorf("failed to parse int32: %v, type is: %v", data, reflect.TypeOf(data))
 	}
@@ -214,6 +220,8 @@ func ParseFloat32(data any) (zero float32, _ error) {
 		return float32(value), nil
 	case float32:
 		return value, nil
+	case nil:
+		return 0, nil // Handle null values by returning 0
 	default:
 		return zero, fmt.Errorf("failed to parse float32: %v, type is: %v", data, reflect.TypeOf(data))
 	}
@@ -232,6 +240,8 @@ func ParseFloat64(data any) (zero float64, _ error) {
 		return f, nil
 	case float64:
 		return value, nil
+	case nil:
+		return 0, nil // Handle null values by returning 0
 	default:
 		return zero, fmt.Errorf("failed to parse float64: %v, type is: %v", data, reflect.TypeOf(data))
 	}

--- a/glassflow-api/internal/schema/utils_test.go
+++ b/glassflow-api/internal/schema/utils_test.go
@@ -131,7 +131,8 @@ func TestParseFloat32(t *testing.T) {
 		{
 			name:        "Nil value",
 			input:       nil,
-			expectError: true,
+			expected:    0,
+			expectError: false,
 		},
 	}
 
@@ -200,7 +201,8 @@ func TestParseFloat64(t *testing.T) {
 		{
 			name:        "Nil value",
 			input:       nil,
-			expectError: true,
+			expected:    0,
+			expectError: false,
 		},
 	}
 
@@ -309,7 +311,8 @@ func TestParseString(t *testing.T) {
 		{
 			name:        "Nil value",
 			input:       nil,
-			expectError: true,
+			expected:    "",
+			expectError: false,
 		},
 	}
 
@@ -366,7 +369,8 @@ func TestParseBool(t *testing.T) {
 		{
 			name:        "Nil value",
 			input:       nil,
-			expectError: true,
+			expected:    false,
+			expectError: false,
 		},
 	}
 
@@ -618,6 +622,12 @@ func TestParseInt32(t *testing.T) {
 			name:        "Float too large",
 			input:       float64(2147483648),
 			expectError: true,
+		},
+		{
+			name:        "Nil value",
+			input:       nil,
+			expected:    0,
+			expectError: false,
 		},
 	}
 


### PR DESCRIPTION
Changes:
1. In Parser if a null value is encountered, use zero value for the data type instead of failing.