### PR TITLE
feat: allow passing null values to CH

### DIFF
--- a/glassflow-api/internal/schema/types.go
+++ b/glassflow-api/internal/schema/types.go
@@ -57,6 +57,12 @@ func ExtractEventValue(dataType KafkaDataType, data any) (zero any, _ error) {
 }
 
 func ConvertValue(columnType ClickHouseDataType, fieldType KafkaDataType, data any) (zero any, _ error) {
+	// If data is nil, pass it through to let ClickHouse handle null validation
+	// HOTFIX: This is a temporary, will be moved up and sent to DLQ as a proper solution.
+	if data == nil {
+		return nil, nil
+	}
+
 	switch columnType {
 	case internal.CHTypeBool:
 		if fieldType != internal.KafkaTypeBool {


### PR DESCRIPTION
Change:
1. Avoid converting if value is nil




## Created a clickhouse table
``` sql
CREATE TABLE default.users_dedup
(
    `event_id` UUID NOT NULL,
    `user_id` UUID NOT NULL,
    `name` String NOT NULL DEFAULT '',
    `email` String NOT NULL DEFAULT '',
    `created_at` DateTime NOT NULL,
    `tags` Array(String) NOT NULL DEFAULT []
)
ENGINE = MergeTree
ORDER BY event_id
```


## created a pipeline
```sh
curl -v 'http://localhost:8085/api/v1/pipeline' -X POST --data-raw '{"pipeline_id": "kiran-dedup-no-join-docker", "name": "kiran-dedup-with-join-docker-version", "source": {"type": "kafka", "provider": "custom", "connection_params": {"brokers": ["localhost:9092"], "protocol": "PLAINTEXT", "skip_auth": true}, "topics": [{"consumer_group_initial_offset": "latest", "name": "users", "id": "users", "schema": {"type": "json", "fields": [{"name": "event_id", "type": "string"}, {"name": "user.id", "type": "string"}, {"name": "user.name", "type": "string"}, {"name": "user.email", "type": "string"}, {"name": "created_at", "type": "string"}]}, "deduplication": {"enabled": true, "id_field": "event_id", "id_field_type": "string", "time_window": "1m"}}]}, "sink": {"type": "clickhouse", "provider": "custom", "host": "localhost", "port": "9000", "http_port": "8123", "database": "default", "username": "default", "password": "c2VjcmV0", "secure": false, "skip_certificate_verification": true, "max_batch_size": 1, "max_delay_time": "10s", "table": "users_dedup", "table_mapping": [{"source_id": "users", "field_name": "event_id", "column_name": "event_id", "column_type": "String"}, {"source_id": "users", "field_name": "user.id", "column_name": "user_id", "column_type": "String"}, {"source_id": "users", "field_name": "user.name", "column_name": "name", "column_type": "String"}, {"source_id": "users", "field_name": "user.email", "column_name": "email", "column_type": "String"}, {"source_id": "users", "field_name": "created_at", "column_name": "created_at", "column_type": "DateTime"}]}}'
```


## Produced two messages 
1. One with correct value for a field
2. One with null value for the field
```sh
 % /opt/homebrew/bin/kafka-console-producer --bootstrap-server localhost:9092 --topic users
>{"event_id": "49a6fdd6f305428881f3436eb498fc9d", "user": {"id": "8db09a6aa33a46f6bdabe4683a34ac4d", "name": "John Doe", "email": "john@example.com"}, "created_at": "2024-03-20T10:00:00Z", "tags": ["tag1", "tag222"]}

>{"event_id": "f0ed455046a543459d9a51502cdc756d", "user": {"id": null, "name": null, "email": "jane@example.com"}, "created_at": "2024-03-20T10:03:00Z", "tags": ["tag13", "tag324"]}
```


## Clickhouse table
```sh
 select * from users_dedup;

SELECT *
FROM users_dedup

Query id: 08f03ed2-083e-40ef-8c83-70990b21d7e9

   ┌─event_id─────────────────────────────┬─user_id──────────────────────────────┬─name─────┬─email────────────┬──────────created_at─┬─tags─┐
1. │ 49a6fdd6-f305-4288-81f3-436eb498fc9d │ 8db09a6a-a33a-46f6-bdab-e4683a34ac4d │ John Doe │ john@example.com │ 2024-03-20 10:00:00 │ []   │
2. │ f0ed4550-46a5-4345-9d9a-51502cdc756d │ 00000000-0000-0000-0000-000000000000 │          │ jane@example.com │ 2024-03-20 10:03:00 │ []   │
   └──────────────────────────────────────┴──────────────────────────────────────┴──────────┴──────────────────┴─────────────────────┴──────┘
```

## Clickhouse automatically converts null values
1. Tried setting input_format_null_as_default = 0 in config
2. Tried setting input_format_null_as_default = 0 at session level in code