### PR TITLE
feat: remove all annotations before adding terminate

### DIFF
--- a/glassflow-api/internal/orchestrator/k8s.go
+++ b/glassflow-api/internal/orchestrator/k8s.go
@@ -282,6 +282,24 @@ func (k *K8sOrchestrator) TerminatePipeline(ctx context.Context, pipelineID stri
 		annotations = make(map[string]string)
 	}
 
+	// Clear any conflicting operation annotations to ensure terminate takes precedence
+	// This prevents stuck pipelines from ignoring terminate requests
+	conflictingAnnotations := []string{
+		"pipeline.etl.glassflow.io/create",
+		"pipeline.etl.glassflow.io/pause",
+		"pipeline.etl.glassflow.io/resume",
+		"pipeline.etl.glassflow.io/stop",
+	}
+
+	for _, annotation := range conflictingAnnotations {
+		if _, exists := annotations[annotation]; exists {
+			k.log.Info("clearing conflicting annotation for terminate",
+				slog.String("pipeline_id", pipelineID),
+				slog.String("annotation", annotation))
+			delete(annotations, annotation)
+		}
+	}
+
 	// Add terminate annotation
 	annotations["pipeline.etl.glassflow.io/terminate"] = "true"
 	customResource.SetAnnotations(annotations)


### PR DESCRIPTION
Changes:
1. Remove any existing annotations before terminate to make it easy for operator to decide what to do.


## Created a pipeline with wrong sink connection
```sh
 % curl -v 'http://localhost:8085/api/v1/pipeline' -X POST --data-raw '{"pipeline_id": "kiran-k8-2", "name": "k8 without join, testing pause/resume 1 replica", "source": {"type": "kafka", "provider": "custom", "connection_params": {"brokers": ["kafka.default.svc.cluster.local:9092"], "protocol": "PLAINTEXT", "skip_auth": true}, "topics": [{"consumer_group_initial_offset": "latest", "name": "users", "id": "users", "replicas": 1, "schema": {"type": "json", "fields": [{"name": "event_id", "type": "string"}, {"name": "user.id", "type": "string"}, {"name": "user.name", "type": "string"}, {"name": "user.email", "type": "string"}, {"name": "created_at", "type": "string"}]}, "deduplication": {"enabled": false, "id_field": "event_id", "id_field_type": "string", "time_window": "1m"}}]}, "sink": {"type": "clickhouse", "provider": "custom", "host": "my-release-clickhouse.default.svc.cluster.local", "port": "9001", "http_port": "8124", "database": "default", "username": "default", "password": "cXZiZVNJM0ZLeg==", "secure": false, "skip_certificate_verification": true, "max_batch_size": 1000, "max_delay_time": "5s", "table": "users_dedup", "table_mapping": [{"source_id": "users", "field_name": "event_id", "column_name": "event_id", "column_type": "String"}, {"source_id": "users", "field_name": "user.id", "column_name": "user_id", "column_type": "String"}, {"source_id": "users", "field_name": "user.name", "column_name": "name", "column_type": "String"}, {"source_id": "users", "field_name": "user.email", "column_name": "email", "column_type": "String"}, {"source_id": "users", "field_name": "created_at", "column_name": "created_at", "column_type": "DateTime"}]}}'
```

## Sent data to ingestor
```sh
/$ kafka-console-producer.sh --bootstrap-server localhost:9092 --topic users
>{"event_id": "49a6fdd6f305428881f3436eb498fc9d", "user": {"id": "8db09a6aa33a46f6bdabe4683a34ac4d", "name": "John Doe", "email": "john@example.com"}, "created_at": "2024-03-20T10:00:00Z", "tags": ["tag1", "tag222"]}
```


## Sink pod started restarting with error
```sh
{"time":"2025-09-29T15:17:13.461836802Z","level":"INFO","msg":"Running service","service":"sink"}
{"time":"2025-09-29T15:17:43.493454802Z","level":"ERROR","msg":"failed to create clickhouse client","error":"failed to connect to ClickHouse: ping failed: dial tcp 10.96.138.181:9001: i/o timeout"}
{"time":"2025-09-29T15:17:43.495191427Z","level":"ERROR","msg":"failed to create ClickHouse sink: ","error":"failed to create sink: failed to create clickhouse client: failed to connect to ClickHouse: ping failed: dial tcp 10.96.138.181:9001: i/o timeout"}
2025/09/29 15:17:43 ERROR Service failed error="sink runner failed: create sink: failed to create sink: failed to create clickhouse client: failed to connect to ClickHouse: ping failed: dial tcp 10.96.138.181:9001: i/o timeout"
```


## Terminated pipeline
```sh
 % curl -v 'http://localhost:8085/api/v1/pipeline/kiran-k8-2/terminate' -X POST
< HTTP/1.1 204 No Content
```


## Checked k8, pipeline pods, deployments, namespace and CRD was removed.
## Checked NATS stream was removed.