### PR TITLE
feat: support to set NATS stream bytes and age

### DIFF
--- a/glassflow-api/cmd/glassflow/main.go
+++ b/glassflow-api/cmd/glassflow/main.go
@@ -59,9 +59,10 @@ type config struct {
 
 	JoinType string `default:"temporal" split_words:"true"`
 
-	NATSServer       string        `default:"localhost:4222" split_words:"true"`
-	NATSMaxStreamAge time.Duration `default:"24h" split_words:"true"`
-	NATSPipelineKV   string        `default:"glassflow-pipelines" split_words:"true"`
+	NATSServer         string        `default:"localhost:4222" split_words:"true"`
+	NATSMaxStreamAge   time.Duration `default:"168h" split_words:"true"`
+	NATSMaxStreamBytes int64         `default:"107374182400" split_words:"true"` // 100GB in bytes
+	NATSPipelineKV     string        `default:"glassflow-pipelines" split_words:"true"`
 
 	K8sNamespace       string `default:"glassflow" split_words:"true"`
 	K8sResourceKind    string `default:"Pipeline" split_words:"true"`
@@ -151,6 +152,7 @@ func mainErr(cfg *config, role models.Role) error {
 		ctx,
 		cfg.NATSServer,
 		client.WithMaxAge(cfg.NATSMaxStreamAge),
+		client.WithMaxBytes(cfg.NATSMaxStreamBytes),
 	)
 	if err != nil {
 		return fmt.Errorf("nats client: %w", err)

--- a/glassflow-api/internal/client/nats.go
+++ b/glassflow-api/internal/client/nats.go
@@ -21,11 +21,18 @@ func WithMaxAge(age time.Duration) NATSClientOption {
 	}
 }
 
+func WithMaxBytes(bytes int64) NATSClientOption {
+	return func(opts *NATSClient) {
+		opts.maxBytes = bytes
+	}
+}
+
 type NATSClient struct {
 	nc *nats.Conn
 	js jetstream.JetStream
 
-	maxAge time.Duration
+	maxAge   time.Duration
+	maxBytes int64
 }
 
 func NewNATSClient(ctx context.Context, url string, opts ...NATSClientOption) (*NATSClient, error) {
@@ -121,6 +128,7 @@ func (n *NATSClient) CreateOrUpdateStream(ctx context.Context, name, subject str
 
 		Retention: jetstream.LimitsPolicy,
 		MaxAge:    n.maxAge,
+		MaxBytes:  n.maxBytes,
 		Discard:   jetstream.DiscardOld,
 	}
 


### PR DESCRIPTION
Issue:
1. NATS stream age and stream size is not set by operator, causing crash during load test when stream size exceeds 

Change: 
1. Stream age and size will be set via operator, values set in HELM chart.
2. Linked to https://github.com/glassflow/glassflow-etl-k8s-operator/pull/49


## Tested with Max Age 24 hours and Max Byte 1 GB
```sh
 % nats stream info                                                                                                                                        
[k8] ? Select a Stream gf-64b1ce2c-users
Information for Stream gf-64b1ce2c-users created 2025-10-04 20:36:03

Limits:

        Maximum Messages: unlimited
     Maximum Per Subject: unlimited
           Maximum Bytes: 1.0 GiB
             Maximum Age: 1d0h0m0s
    Maximum Message Size: unlimited
```