### PR TITLE
fix: add updated_at to listing endpoint

### DIFF
--- a/glassflow-api/internal/api/pipeline.go
+++ b/glassflow-api/internal/api/pipeline.go
@@ -343,8 +343,7 @@ type pipelineJSON struct {
 
 		Sources []joinSource `json:"sources"`
 	} `json:"join"`
-	Sink   clickhouseSink        `json:"sink"`
-	Status models.PipelineStatus `json:"status"`
+	Sink clickhouseSink `json:"sink"`
 }
 
 type sourceConnectionParams struct {
@@ -690,7 +689,6 @@ func toPipelineJSON(p models.PipelineConfig) pipelineJSON {
 			MaxDelayTime:                p.Sink.Batch.MaxDelayTime,
 			SkipCertificateVerification: p.Sink.ClickHouseConnectionParams.SkipCertificateCheck,
 		},
-		Status: p.Status.OverallStatus,
 	}
 }
 

--- a/glassflow-api/internal/models/configs.go
+++ b/glassflow-api/internal/models/configs.go
@@ -400,6 +400,7 @@ func (pc PipelineConfig) ToListPipeline() ListPipelineConfig {
 		Name:           pc.Name,
 		Transformation: TransformationType(transformation),
 		CreatedAt:      pc.CreatedAt,
+		UpdatedAt:      pc.Status.UpdatedAt,
 		Status:         status,
 	}
 }
@@ -409,6 +410,7 @@ type ListPipelineConfig struct {
 	Name           string             `json:"name"`
 	Transformation TransformationType `json:"transformation_type"`
 	CreatedAt      time.Time          `json:"created_at"`
+	UpdatedAt      time.Time          `json:"updated_at"`
 	Status         PipelineStatus     `json:"status"`
 }
 

--- a/glassflow-api/internal/storage/pipeline.go
+++ b/glassflow-api/internal/storage/pipeline.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/models"
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/service"
@@ -137,6 +138,8 @@ func (s *Storage) UpdatePipelineStatus(ctx context.Context, id string, status mo
 		return fmt.Errorf("unmarshal loaded entry: %w", err)
 	}
 
+	// Update the status and ensure UpdatedAt timestamp is set to current time
+	status.UpdatedAt = time.Now().UTC()
 	p.Status = status
 
 	pc, err := json.Marshal(p)


### PR DESCRIPTION
Changes:
1. Add updated_at to listing endpoint
2. Update it when pipeline statuses are changes during pipeline management operations


## Get pipelines
```sh
 % curl 'http://localhost:8085/api/v1/pipeline' | jq 
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   703  100   703    0     0  67208      0 --:--:-- --:--:-- --:--:-- 70300
[
  {
    "pipeline_id": "kiran-k8-4",
    "name": "k8 without join, testing pause/resume 1 replica",
    "transformation_type": "Ingest Only",
    "created_at": "2025-10-02T10:31:06.885891Z",
    "updated_at": "2025-10-04T12:33:16.713688Z",
    "status": "Stopped"
  },
  {
    "pipeline_id": "kiran-dedup-with-join-k8-5",
    "name": "kiran-dedup-with-join-docker-version",
    "transformation_type": "Join & Deduplication",
    "created_at": "2025-10-04T12:55:46.010053Z",
    "updated_at": "2025-10-04T13:13:57.111412Z",
    "status": "Terminated"
  },
  {
    "pipeline_id": "kiran-k8-2",
    "name": "k8 without join, testing pause/resume 1 replica",
    "transformation_type": "Ingest Only",
    "created_at": "2025-10-04T18:36:03.736974Z",
    "updated_at": "2025-10-04T18:36:46.293254Z",
    "status": "Paused"
  }
]
```