### PR TITLE
fix: remove status from GET pipeline endpoint

### DIFF
--- a/glassflow-api/internal/api/pipeline.go
+++ b/glassflow-api/internal/api/pipeline.go
@@ -343,8 +343,7 @@ type pipelineJSON struct {
 
 		Sources []joinSource `json:"sources"`
 	} `json:"join"`
-	Sink   clickhouseSink        `json:"sink"`
-	Status models.PipelineStatus `json:"status"`
+	Sink clickhouseSink `json:"sink"`
 }
 
 type sourceConnectionParams struct {
@@ -690,7 +689,6 @@ func toPipelineJSON(p models.PipelineConfig) pipelineJSON {
 			MaxDelayTime:                p.Sink.Batch.MaxDelayTime,
 			SkipCertificateVerification: p.Sink.ClickHouseConnectionParams.SkipCertificateCheck,
 		},
-		Status: p.Status.OverallStatus,
 	}
 }
 


### PR DESCRIPTION
Changes:
1. Removed status from get pipeline endpoint, but present in listing endpoint


## get pipeline by ID
```sh
curl 'http://localhost:8085/api/v1/pipeline/kiran-k8-4' | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1572  100  1572    0     0   130k      0 --:--:-- --:--:-- --:--:--  139k
{
  "pipeline_id": "kiran-k8-4",
  "name": "k8 without join, testing pause/resume 1 replica",
  "source": {
    "type": "kafka",
    "provider": "custom",
    "connection_params": {
      "brokers": [
        "kafka.default.svc.cluster.local:9092"
      ],
      "skip_auth": true,
      "protocol": "PLAINTEXT",
      "mechanism": "",
      "username": "",
      "password": "",
      "root_ca": ""
    },
    "topics": [
      {
        "name": "users",
        "id": "users",
        "schema": {
          "type": "json",
          "fields": [
            {
              "name": "event_id",
              "type": "string"
            },
            {
              "name": "user.id",
              "type": "string"
            },
            {
              "name": "user.name",
              "type": "string"
            },
            {
              "name": "user.email",
              "type": "string"
            },
            {
              "name": "created_at",
              "type": "string"
            }
          ]
        },
        "consumer_group_initial_offset": "latest",
        "replicas": 2,
        "deduplication": {
          "enabled": false,
          "id_field": "event_id",
          "id_field_type": "string",
          "time_window": "1m0s"
        }
      }
    ]
  },
  "join": {
    "type": "temporal",
    "enabled": false,
    "sources": null
  },
  "sink": {
    "type": "clickhouse",
    "host": "my-release-clickhouse.default.svc.cluster.local",
    "port": "9000",
    "http_port": "8123",
    "database": "default",
    "username": "default",
    "password": "cXZiZVNJM0ZLeg==",
    "table": "users_dedup",
    "secure": false,
    "table_mapping": [
      {
        "source_id": "users",
        "field_name": "event_id",
        "column_name": "event_id",
        "column_type": "String"
      },
      {
        "source_id": "users",
        "field_name": "user.id",
        "column_name": "user_id",
        "column_type": "String"
      },
      {
        "source_id": "users",
        "field_name": "user.name",
        "column_name": "name",
        "column_type": "String"
      },
      {
        "source_id": "users",
        "field_name": "user.email",
        "column_name": "email",
        "column_type": "String"
      },
      {
        "source_id": "users",
        "field_name": "created_at",
        "column_name": "created_at",
        "column_type": "DateTime"
      }
    ],
    "max_batch_size": 1000,
    "max_delay_time": "5s",
    "skip_certificate_verification": true
  }
}
```


## Get pipelines
```sh
 % curl 'http://localhost:8085/api/v1/pipeline' | jq 
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   703  100   703    0     0  67208      0 --:--:-- --:--:-- --:--:-- 70300
[
  {
    "pipeline_id": "kiran-k8-4",
    "name": "k8 without join, testing pause/resume 1 replica",
    "transformation_type": "Ingest Only",
    "created_at": "2025-10-02T10:31:06.885891Z",
    "updated_at": "2025-10-04T12:33:16.713688Z",
    "status": "Stopped"
  },
  {
    "pipeline_id": "kiran-dedup-with-join-k8-5",
    "name": "kiran-dedup-with-join-docker-version",
    "transformation_type": "Join & Deduplication",
    "created_at": "2025-10-04T12:55:46.010053Z",
    "updated_at": "2025-10-04T13:13:57.111412Z",
    "status": "Terminated"
  },
  {
    "pipeline_id": "kiran-k8-2",
    "name": "k8 without join, testing pause/resume 1 replica",
    "transformation_type": "Ingest Only",
    "created_at": "2025-10-04T18:36:03.736974Z",
    "updated_at": "2025-10-04T18:36:46.293254Z",
    "status": "Paused"
  }
]
```