### PR TITLE
fix: metric names double prefix

### DIFF
--- a/glassflow-api/pkg/observability/meter.go
+++ b/glassflow-api/pkg/observability/meter.go
@@ -79,17 +79,17 @@ func NewMeter(component, pipelineID string) *Meter {
 	meter := otel.Meter("glassflow-etl")
 
 	return &Meter{
-		KafkaRecordsRead: mustCreateCounter(meter, "glassflow_kafka_records_read_total",
+		KafkaRecordsRead: mustCreateCounter(meter, "kafka_records_read_total",
 			"Total number of records read from Kafka"),
-		RecordsProcessedPerSec: mustCreateGauge(meter, "glassflow_records_processed_per_second",
+		RecordsProcessedPerSec: mustCreateGauge(meter, "records_processed_per_second",
 			"Number of records processed per second"),
-		DLQRecordsWritten: mustCreateCounter(meter, "glassflow_dlq_records_written_total",
+		DLQRecordsWritten: mustCreateCounter(meter, "dlq_records_written_total",
 			"Total number of records written to dead letter queue"),
-		ClickHouseRecordsWritten: mustCreateCounter(meter, "glassflow_clickhouse_records_written_total",
+		ClickHouseRecordsWritten: mustCreateCounter(meter, "clickhouse_records_written_total",
 			"Total number of records written to ClickHouse"),
-		SinkRecordsPerSec: mustCreateGauge(meter, "glassflow_clickhouse_records_written_per_second",
+		SinkRecordsPerSec: mustCreateGauge(meter, "clickhouse_records_written_per_second",
 			"Number of records written to ClickHouse per second"),
-		ProcessingDuration: mustCreateHistogram(meter, "glassflow_processing_duration_seconds",
+		ProcessingDuration: mustCreateHistogram(meter, "processing_duration_seconds",
 			"Processing duration in seconds"),
 		component:  component,
 		pipelineID: pipelineID,


### PR DESCRIPTION
Issue: OTEL SDK by default adds service namespace to metrics causing duplicate preifx

Change: Update metric names to remove prefix and OTEL SDK add it