### PR TITLE
Update README.md - Replace Quick Start with Demo and new intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@
 
 # GlassFlow for ClickHouse Streaming ETL
 
-GlassFlow is an open-source ETL tool that enables real-time data processing from Kafka to ClickHouse with features like deduplication and temporal joins.
+GlassFlow is an open-source streaming ETL that enables real-time data processing from Kafka to ClickHouse with features like deduplication and temporal joins. ClickHouse users can clean and ingest high-frequency data streams without using RMT or FINAL at ClickHouse.
 
-## ⚡️ Quick Start
-This guide walks you through a **local installation using Docker Compose** — perfect for development, testing, or trying out GlassFlow on your machine.
+## ⚡️ Run a local demo
+This guide walks you through a **local installation using Docker Compose** using the GlassFlow UI. It spins up a local Kafka, GlassFlow and a local ClickHouse. It showcases how deduplication works at GlassFlow. It is perfect for development, testing, or trying out GlassFlow on your machine.
 
 1. Clone the repository:
 ```bash
@@ -37,24 +37,141 @@ git clone https://github.com/glassflow/clickhouse-etl.git
 cd clickhouse-etl
 ```
 
-2. Start the services:
+
+2. Navigate to the demo directory:
 ```bash
-docker compose up
+cd demos
 ```
 
-3. Access the web interface at `http://localhost:8080` to configure your pipeline.
 
-4. View the logs:
+3. Start the local infrastructure:
 ```bash
-# Follow logs in real-time for all containers
-docker compose logs -f
-
-# logs for the backend api
-docker compose logs api -f
-
-# logs for the UI
-docker compose logs ui -f
+docker compose up -d
 ```
+This will start the following services:
+- Kafka (ports 9092 - external, 9093 - internal)
+- ClickHouse (ports 8123 - HTTP, 9000 - Native)
+- GlassFlow ClickHouse ETL application (port 8080)
+
+
+4. Create Kafka Topics:
+```bash
+# Create a new Kafka topic
+docker compose exec kafka kafka-topics \
+    --topic users \
+    --create \
+    --partitions 1 \
+    --replication-factor 1 \
+    --bootstrap-server localhost:9092
+```
+
+
+5. Create ClickHouse Table:
+```bash
+docker compose exec clickhouse clickhouse-client \
+    --user default \
+    --password secret \
+    --query "
+CREATE TABLE IF NOT EXISTS users_dedup (
+    event_id UUID,
+    user_id UUID,
+    name String,
+    email String,
+    created_at DateTime,
+    tags Array(String)
+) ENGINE = MergeTree 
+ORDER BY event_id"
+```
+
+
+6. Generate a test event in Kafka to help you create the pipeline in the UI
+```bash
+# Send multiple JSON events to Kafka
+echo '{"event_id": "49a6fdd6f305428881f3436eb498fc9d", "user": {"id": "8db09a6aa33a46f6bdabe4683a34ac4d", "name": "John Doe", "email": "john@example.com"}, "created_at": "2024-03-20T10:00:00Z", "tags": ["tag1", "tag222"]}' |
+docker compose exec -T kafka kafka-console-producer \
+    --topic users \
+    --bootstrap-server localhost:9092
+```
+
+
+7. Configure Pipeline in UI
+
+Access the GlassFlow UI at http://localhost:8080 and use these connection details to create a deduplication pipeline:
+
+  Kafka Connection
+```bash
+Authentication Method: No Authentication
+Security Protocol: PLAINTEXT
+Bootstrap Servers: kafka:9093
+```
+  Kafka Topic
+```bash
+Topic Name: users
+Consumer Group Initial Offset: latest
+Schema:
+{
+  "event_id": "49a6fdd6f305428881f3436eb498fc9d",
+  "user": {
+    "id": "8db09a6aa33a46f6bdabe4683a34ac4d",
+    "name": "Jane Smith",
+    "email": "jane@example.com"
+  },
+  "created_at": "2024-03-20T10:03:00Z",
+  "tags": ["tag13", "tag324"]
+}
+```
+
+  Deduplication
+```bash
+Enabled: true
+Deduplicate Key: event_id
+Deduplicate Key Type: string
+Time Window: 1h
+```
+
+  ClickHouse Connection
+```bash
+Host: clickhouse
+HTTP/S Port: 8123
+Native Port: 9000
+Username: default
+Password: secret
+Use SSL: false
+```
+
+  ClickHouse Table
+```bash
+Table: users_dedup
+```
+
+  Send data to Kafka
+```bash
+# Send multiple JSON events to Kafka
+echo '{"event_id": "49a6fdd6f305428881f3436eb498fc9d", "user": {"id": "8db09a6aa33a46f6bdabe4683a34ac4d", "name": "John Doe", "email": "john@example.com"}, "created_at": "2024-03-20T10:00:00Z", "tags": ["tag1", "tag222"]}
+{"event_id": "49a6fdd6f305428881f3436eb498fc9d", "user": {"id": "8db09a6aa33a46f6bdabe4683a34ac4d", "name": "John Doe", "email": "john@example.com"}, "created_at": "2024-03-20T10:01:00Z", "tags": ["tag1", "tag222"]}
+{"event_id": "f0ed455046a543459d9a51502cdc756d", "user": {"id": "a7f93b87e29c4978848731e204e47e97", "name": "Jane Smith", "email": "jane@example.com"}, "created_at": "2024-03-20T10:03:00Z", "tags": ["tag13", "tag324"]}' |
+docker compose exec -T kafka kafka-console-producer \
+    --topic users \
+    --bootstrap-server localhost:9092
+```
+
+Verify Results
+After a few seconds (maximum delay time - default 1 minute), you should see the deduplicated events in ClickHouse:
+```bash
+docker compose exec clickhouse clickhouse-client \
+    --user default \
+    --password secret \
+     -f prettycompact \
+    --query "SELECT * FROM users_dedup"
+```
+
+```bash
+   ┌─event_id─┬─user_id─┬─name───────┬─email────────────┬──────────created_at─┬─tags────────────────┐
+1. │      123 │     456 │ John Doe   │ john@example.com │ 2024-03-20 10:00:00 │ ["tag1", "tag222"]  │
+2. │      124 │     457 │ Jane Smith │ jane@example.com │ 2024-03-20 10:03:00 │ ["tag13", "tag324"] │
+   └──────────┴─────────┴────────────┴──────────────────┴─────────────────────┴─────────────────────┘
+```
+To start creating your own pipelines with the UI, you can follow the pipeline/usage/web-ui guide.
 
 ## 🧭 Installation Options
 
@@ -71,7 +188,7 @@ For local testing or a small POC, you can also use Docker and Docker Compose to 
 ## 🎥 Demo
 
 ### Live Demo
-See a working demo of GlassFlow in action at [demo.glassflow.dev](https://demo.glassflow.dev).
+Log in and see a working demo of GlassFlow running on a GPC cluster at [demo.glassflow.dev](https://demo.glassflow.dev). You will see a Grafana dashboard and the setup that we used.
 
 ![GlassFlow Pipeline Data Flow](https://raw.githubusercontent.com/glassflow/clickhouse-etl/main/docs/public/assets/glassflow_demo.png)
 


### PR DESCRIPTION
I received feedback from users:
1. They don't understand why they should use GlassFlow if they are not coming from the website here.
2. In the current quick start, we didn't explain that Kafa and CH will run locally, and users are confused about what to do.
3. The Live Demo section didn't explain what happens on the live demo. Users are thinking they need to sign up for a Saas.