### PR TITLE
ETL-519: ETL-520: feat: allow failed pipelines to be resumed/edited/deleted

### DIFF
--- a/glassflow-api/internal/api/pipeline.go
+++ b/glassflow-api/internal/api/pipeline.go
@@ -695,7 +695,7 @@ func (h *handler) deletePipeline(w http.ResponseWriter, r *http.Request) {
 
 	// Check if pipeline is in a deletable state (stopped)
 	currentStatus := string(pipeline.Status.OverallStatus)
-	if currentStatus != internal.PipelineStatusStopped {
+	if currentStatus != internal.PipelineStatusStopped && currentStatus != internal.PipelineStatusFailed {
 		h.log.ErrorContext(r.Context(), "pipeline cannot be deleted due to invalid status", "pipeline_id", id, "current_status", currentStatus)
 		jsonError(w, http.StatusBadRequest,
 			fmt.Sprintf("pipeline can only be deleted if it's stopped, current status: %s", currentStatus),

--- a/glassflow-api/internal/orchestrator/k8s.go
+++ b/glassflow-api/internal/orchestrator/k8s.go
@@ -415,7 +415,7 @@ func (k *K8sOrchestrator) EditPipeline(ctx context.Context, pipelineID string, n
 	pipelineConfig := k.getPipelineConfigFromK8sResource(customResource)
 
 	// Validate pipeline is stopped
-	if pipelineConfig.Status.OverallStatus != internal.PipelineStatusStopped {
+	if pipelineConfig.Status.OverallStatus != internal.PipelineStatusStopped && pipelineConfig.Status.OverallStatus != internal.PipelineStatusFailed {
 		k.log.ErrorContext(ctx, "pipeline must be stopped before editing", "pipeline_id", pipelineID, "current_status", pipelineConfig.Status.OverallStatus)
 		return status.NewPipelineNotStoppedForEditError(models.PipelineStatus(pipelineConfig.Status.OverallStatus))
 	}

--- a/glassflow-api/internal/service/pipeline.go
+++ b/glassflow-api/internal/service/pipeline.go
@@ -358,7 +358,7 @@ func (p *PipelineService) EditPipeline(ctx context.Context, pid string, newCfg *
 	}
 
 	// Validate pipeline is in Stopped status
-	if currentPipeline.Status.OverallStatus != internal.PipelineStatusStopped {
+	if currentPipeline.Status.OverallStatus != internal.PipelineStatusStopped && currentPipeline.Status.OverallStatus != internal.PipelineStatusFailed {
 		p.log.ErrorContext(ctx, "pipeline must be stopped before editing", "pipeline_id", pid, "current_status", currentPipeline.Status.OverallStatus)
 		return status.NewPipelineNotStoppedForEditError(models.PipelineStatus(currentPipeline.Status.OverallStatus))
 	}

--- a/glassflow-api/internal/status/validation.go
+++ b/glassflow-api/internal/status/validation.go
@@ -58,8 +58,10 @@ var StatusValidationMatrix = map[models.PipelineStatus][]models.PipelineStatus{
 		models.PipelineStatus(internal.PipelineStatusFailed),
 	},
 
-	// Failed status has no valid transitions (terminal state)
-	models.PipelineStatus(internal.PipelineStatusFailed): {},
+	// Failed status can be deleted, edited or resumed
+	models.PipelineStatus(internal.PipelineStatusFailed): {
+		models.PipelineStatus(internal.PipelineStatusResuming),
+	},
 }
 
 // ValidateStatusTransition checks if a transition from one status to another is valid


### PR DESCRIPTION
Changes:
1. Allow failed pipelines to be deleted / edited.

## Create pipeline (that will fail)
```sh
% curl -v http://localhost:8085/api/v1/pipeline -H "Content-Type: application/json" -X POST --data-raw '{"pipeline_id": "failed-pipeline", "name": "failed-pipeline", "source": {"type": "kafka", "provider": "custom", "connection_params": {"brokers": ["kafka-controller-0.staging-cluster.glassflow.xyz:9094", "kafka-controller-1.staging-cluster.glassflow.xyz:9094", "kafka-controller-2.staging-cluster.glassflow.xyz:9094"], "mechanism": "PLAIN", "protocol": "SASL_PLAINTEXT","skip_auth":false, "username": "glassflow", "password": "k1vqMOWlZayLTWpA"}, "topics": [{"name": "oteltest25", "schema": {"type": "json", "fields": [{"name": "event_id", "type": "string"}, {"name": "user_id", "type": "string"}, {"name": "name", "type": "string"}, {"name": "email", "type": "string"}, {"name": "created_at", "type": "string"}]}, "consumer_group_initial_offset": "latest", "replicas": 1, "deduplication": {"enabled": true, "id_field": "event_id", "id_field_type": "string", "time_window": "1h0m0s"}}]}, "join": {"type": "temporal", "enabled": false}, "sink": {"type": "clickhouse", "host": "clickhouse.staging-cluster.glassflow.xyz", "port": "9000", "http_port": "8123", "database": "default", "username": "glassflow", "password": "cGdeQG1sI3lRWGVhZmZhbg==", "table": "oteltest25", "secure": false, "table_mapping": [{"source_id": "oteltest25", "field_name": "event_id", "column_name": "event_id", "column_type": "UUID"}, {"source_id": "oteltest25", "field_name": "user_id", "column_name": "user_id", "column_type": "UUID"},{"source_id": "oteltest2q5", "field_name": "user_ids", "column_name": "", "column_type": ""}, {"source_id": "oteltest25", "field_name": "name", "column_name": "name", "column_type": "String"}, {"source_id": "oteltest25", "field_name": "email", "column_name": "email", "column_type": "String"}, {"source_id": "oteltest25", "field_name": "created_at", "column_name": "created_at", "column_type": "DateTime"}], "max_batch_size": 1000, "max_delay_time": "1m0s", "skip_certificate_verification": true}, "exported_at": "2025-11-25T10:20:59.893Z", "exported_by": "GlassFlow UI", "version": "1.0.0"}'
```

## Check health after reconcile timeout (5 mins) - It should be marked as failed
```sh
% curl -v http://localhost:8085/api/v1/pipeline/failed-pipeline2/health
{"pipeline_id":"failed-pipeline2","pipeline_name":"failed-pipeline","overall_status":"Failed","created_at":"2025-11-25T11:15:25.962401Z","updated_at":"2025-11-25T11:20:28.932871Z"}
```

## Try edit with fixes
```sh
% curl -v http://localhost:8085/api/v1/pipeline/failed-pipeline2/edit -X POST --data-raw '{"pipeline_id": "failed-pipeline2", "name": "failed-pipeline", "source": {"type": "kafka", "provider": "custom", "connection_params": {"brokers": ["kafka-controller-0.staging-cluster.glassflow.xyz:9094", "kafka-controller-1.staging-cluster.glassflow.xyz:9094", "kafka-controller-2.staging-cluster.glassflow.xyz:9094"], "mechanism": "PLAIN", "protocol": "SASL_PLAINTEXT","skip_auth":false, "username": "glassflow", "password": "k1vqMOWlZayLTWpA"}, "topics": [{"name": "oteltest25", "schema": {"type": "json", "fields": [{"name": "event_id", "type": "string"}, {"name": "user_id", "type": "string"}, {"name": "name", "type": "string"}, {"name": "email", "type": "string"}, {"name": "created_at", "type": "string"}]}, "consumer_group_initial_offset": "latest", "replicas": 1, "deduplication": {"enabled": true, "id_field": "event_id", "id_field_type": "string", "time_window": "1h0m0s"}}]}, "join": {"type": "temporal", "enabled": false}, "sink": {"type": "clickhouse", "host": "clickhouse.staging-cluster.glassflow.xyz", "port": "9000", "http_port": "8123", "database": "default", "username": "glassflow", "password": "cGdeQG1sI3lRWGVhZmZhbg==", "table": "oteltest25", "secure": false, "table_mapping": [{"source_id": "oteltest25", "field_name": "event_id", "column_name": "event_id", "column_type": "UUID"}, {"source_id": "oteltest25", "field_name": "user_id", "column_name": "user_id", "column_type": "UUID"}, {"source_id": "oteltest25", "field_name": "name", "column_name": "name", "column_type": "String"}, {"source_id": "oteltest25", "field_name": "email", "column_name": "email", "column_type": "String"}, {"source_id": "oteltest25", "field_name": "created_at", "column_name": "created_at", "column_type": "DateTime"}], "max_batch_size": 1000, "max_delay_time": "1m0s", "skip_certificate_verification": true}, "exported_at": "2025-11-25T10:20:59.893Z", "exported_by": "GlassFlow UI", "version": "1.0.0"}'
< HTTP/1.1 204 No Content
```

## Check pipeline health
```sh
% curl -v http://localhost:8085/api/v1/pipeline/failed-pipeline/health
{"pipeline_id":"failed-pipeline2","pipeline_name":"failed-pipeline","overall_status":"Running","created_at":"2025-11-25T11:37:54.511141Z","updated_at":"2025-11-25T11:37:58.793842Z"}
```


# Resume a failed pipeline

## Create a failed pipeline
```sh
 curl -v http://localhost:8085/api/v1/pipeline -H "Content-Type: application/json" -X POST --data-raw '{"pipeline_id": "failed-pipeline2", "name": "failed-pipeline", "source": {"type": "kafka", "provider": "custom", "connection_params": {"brokers": ["kafka-controller-0.staging-cluster.glassflow.xyz:9094", "kafka-controller-1.staging-cluster.glassflow.xyz:9094", "kafka-controller-2.staging-cluster.glassflow.xyz:9094"], "mechanism": "PLAIN", "protocol": "SASL_PLAINTEXT","skip_auth":false, "username": "glassflow", "password": "k1vqMOWlZayLTWpA"}, "topics": [{"name": "oteltest25", "schema": {"type": "json", "fields": [{"name": "event_id", "type": "string"}, {"name": "user_id", "type": "string"}, {"name": "name", "type": "string"}, {"name": "email", "type": "string"}, {"name": "created_at", "type": "string"}]}, "consumer_group_initial_offset": "latest", "replicas": 1, "deduplication": {"enabled": true, "id_field": "event_id", "id_field_type": "string", "time_window": "1h0m0s"}}]}, "join": {"type": "temporal", "enabled": false}, "sink": {"type": "clickhouse", "host": "clickhouse.staging-cluster.glassflow.xyz", "port": "9000", "http_port": "8123", "database": "default", "username": "glassflow", "password": "cGdeQG1sI3lRWGVhZmZhbg==", "table": "oteltest25", "secure": false, "table_mapping": [{"source_id": "oteltest25", "field_name": "event_id", "column_name": "event_id", "column_type": "UUID"}, {"source_id": "oteltest25", "field_name": "user_id", "column_name": "user_id", "column_type": "UUID"},{"source_id": "oteltest2q5", "field_name": "user_ids", "column_name": "", "column_type": ""}, {"source_id": "oteltest25", "field_name": "name", "column_name": "name", "column_type": "String"}, {"source_id": "oteltest25", "field_name": "email", "column_name": "email", "column_type": "String"}, {"source_id": "oteltest25", "field_name": "created_at", "column_name": "created_at", "column_type": "DateTime"}], "max_batch_size": 1000, "max_delay_time": "1m0s", "skip_certificate_verification": true}, "exported_at": "2025-11-25T10:20:59.893Z", "exported_by": "GlassFlow UI", "version": "1.0.0"}'
```

## Check pipeline health
```sh
% curl -v http://localhost:8085/api/v1/pipeline/failed-pipeline2/health
{"pipeline_id":"failed-pipeline2","pipeline_name":"failed-pipeline","overall_status":"Failed","created_at":"2025-11-25T11:57:53.79193Z","updated_at":"2025-11-25T11:58:54.755689Z"}
```

## Resume a failed pipeline
```sh
 % curl -v http://localhost:8085/api/v1/pipeline/failed-pipeline2/resume -X POST
< HTTP/1.1 204 No Content
```


## Check health should be resuming
```sh
% curl -v http://localhost:8085/api/v1/pipeline/failed-pipeline2/health        
{"pipeline_id":"failed-pipeline2","pipeline_name":"failed-pipeline","overall_status":"Resuming","created_at":"2025-11-25T11:57:53.79193Z","updated_at":"2025-11-25T12:06:38.806765Z"}
```

## If not fixed only resume pipeline will fail again
```sh
 % curl -v http://localhost:8085/api/v1/pipeline/failed-pipeline2/health
{"pipeline_id":"failed-pipeline2","pipeline_name":"failed-pipeline","overall_status":"Failed","created_at":"2025-11-25T11:57:53.79193Z","updated_at":"2025-11-25T12:07:39.607627Z"}
```

