### PR TITLE
ETL-468: refactor: remove the default pipeline status if unknown

### DIFF
--- a/glassflow-api/internal/orchestrator/k8s.go
+++ b/glassflow-api/internal/orchestrator/k8s.go
@@ -88,10 +88,8 @@ func (k *K8sOrchestrator) getPipelineConfigFromK8sResource(customResource *unstr
 		case "Failed":
 			currentStatus = internal.PipelineStatusFailed
 		default:
-			currentStatus = internal.PipelineStatusCreated
+			currentStatus = "Unknown"
 		}
-	} else {
-		currentStatus = internal.PipelineStatusCreated
 	}
 
 	return &models.PipelineConfig{


### PR DESCRIPTION
Change:
1. Remove the default pipeline status as created when status unknown