### PR TITLE
fix: pipeline resume should rebuild CRD spec

### DIFF
--- a/glassflow-api/internal/orchestrator/docker.go
+++ b/glassflow-api/internal/orchestrator/docker.go
@@ -499,7 +499,7 @@ func (d *LocalOrchestrator) cleanupNATSResources(ctx context.Context, pipeline *
 }
 
 // ResumePipeline implements Orchestrator.
-func (d *LocalOrchestrator) ResumePipeline(ctx context.Context, pid string) error {
+func (d *LocalOrchestrator) ResumePipeline(ctx context.Context, pid string, pipelineCfg *models.PipelineConfig) error {
 	d.m.Lock()
 	defer d.m.Unlock()
 

--- a/glassflow-api/internal/orchestrator/k8s.go
+++ b/glassflow-api/internal/orchestrator/k8s.go
@@ -343,7 +343,7 @@ func (k *K8sOrchestrator) DeletePipeline(ctx context.Context, pipelineID string)
 }
 
 // ResumePipeline implements Orchestrator.
-func (k *K8sOrchestrator) ResumePipeline(ctx context.Context, pipelineID string) error {
+func (k *K8sOrchestrator) ResumePipeline(ctx context.Context, pipelineID string, pipelineCfg *models.PipelineConfig) error {
 	k.log.InfoContext(ctx, "resuming k8s pipeline", "pipeline_id", pipelineID)
 
 	// Get the pipeline CRD
@@ -371,7 +371,7 @@ func (k *K8sOrchestrator) ResumePipeline(ctx context.Context, pipelineID string)
 	}
 
 	// Build new spec using the same logic as SetupPipeline
-	specMap, err := k.buildPipelineSpec(ctx, pipelineConfig)
+	specMap, err := k.buildPipelineSpec(ctx, pipelineCfg)
 	if err != nil {
 		return err
 	}

--- a/glassflow-api/internal/orchestrator/k8s.go
+++ b/glassflow-api/internal/orchestrator/k8s.go
@@ -370,6 +370,15 @@ func (k *K8sOrchestrator) ResumePipeline(ctx context.Context, pipelineID string)
 		return err
 	}
 
+	// Build new spec using the same logic as SetupPipeline
+	specMap, err := k.buildPipelineSpec(ctx, pipelineConfig)
+	if err != nil {
+		return err
+	}
+
+	// Replace the entire spec
+	customResource.Object["spec"] = specMap
+
 	annotations := customResource.GetAnnotations()
 	if annotations == nil {
 		annotations = make(map[string]string)

--- a/glassflow-api/internal/service/pipeline.go
+++ b/glassflow-api/internal/service/pipeline.go
@@ -17,7 +17,7 @@ type Orchestrator interface {
 	StopPipeline(ctx context.Context, pid string) error
 	TerminatePipeline(ctx context.Context, pid string) error
 	DeletePipeline(ctx context.Context, pid string) error
-	ResumePipeline(ctx context.Context, pid string) error
+	ResumePipeline(ctx context.Context, pid string, newCfg *models.PipelineConfig) error
 	EditPipeline(ctx context.Context, pid string, newCfg *models.PipelineConfig) error
 }
 
@@ -260,7 +260,7 @@ func (p *PipelineService) ResumePipeline(ctx context.Context, pid string) error 
 		return fmt.Errorf("update pipeline status: %w", err)
 	}
 
-	err = p.orchestrator.ResumePipeline(ctx, pid)
+	err = p.orchestrator.ResumePipeline(ctx, pid, pipeline)
 	if err != nil {
 		p.log.ErrorContext(ctx, "failed to resume pipeline in orchestrator", "pipeline_id", pid, "error", err)
 		return fmt.Errorf("resume pipeline: %w", err)

--- a/glassflow-api/internal/service/pipeline_edit_test.go
+++ b/glassflow-api/internal/service/pipeline_edit_test.go
@@ -43,8 +43,8 @@ func (m *MockOrchestrator) DeletePipeline(ctx context.Context, pid string) error
 	return args.Error(0)
 }
 
-func (m *MockOrchestrator) ResumePipeline(ctx context.Context, pid string) error {
-	args := m.Called(ctx, pid)
+func (m *MockOrchestrator) ResumePipeline(ctx context.Context, pid string, newCfg *models.PipelineConfig) error {
+	args := m.Called(ctx, pid, newCfg)
 	return args.Error(0)
 }
 

--- a/glassflow-api/internal/service/pipeline_test.go
+++ b/glassflow-api/internal/service/pipeline_test.go
@@ -45,7 +45,7 @@ func (m *mockOrchestrator) TerminatePipeline(ctx context.Context, pid string) er
 	return nil
 }
 
-func (m *mockOrchestrator) ResumePipeline(ctx context.Context, pid string) error {
+func (m *mockOrchestrator) ResumePipeline(ctx context.Context, pid string, newCfg *models.PipelineConfig) error {
 	m.resumeCalled = true
 	m.resumePipelineID = pid
 	return m.resumeError

--- a/glassflow-api/tests/steps/platform_steps.go
+++ b/glassflow-api/tests/steps/platform_steps.go
@@ -188,7 +188,7 @@ func (m *MockK8sOrchestrator) TerminatePipeline(_ context.Context, _ string) err
 	return fmt.Errorf("not implemented for testing")
 }
 
-func (m *MockK8sOrchestrator) ResumePipeline(_ context.Context, _ string) error {
+func (m *MockK8sOrchestrator) ResumePipeline(_ context.Context, _ string, _ *models.PipelineConfig) error {
 	return fmt.Errorf("not implemented for testing")
 }
 


### PR DESCRIPTION
Issues:
1. Migrated pipelines need to rebuild CRD spec for dedup component

Change:
1. CRD spec rebuilt when sending resume pipeline from API to k8