### PR TITLE
fix: incorrect transformer arg sent to dedup

### DIFF
--- a/glassflow-api/cmd/glassflow/deduplication.go
+++ b/glassflow-api/cmd/glassflow/deduplication.go
@@ -154,12 +154,13 @@ func mainDeduplicator(
 	)
 
 	// Create stateless transformer if enabled
-	var statelessTransformer *json.Transformer
+	var statelessTransformer deduplication.StatelessTransformer
 	if pipelineCfg.StatelessTransformation.Enabled {
-		statelessTransformer, err = json.NewTransformer(pipelineCfg.StatelessTransformation.Config.Transform)
+		transformer, err := json.NewTransformer(pipelineCfg.StatelessTransformation.Config.Transform)
 		if err != nil {
 			return fmt.Errorf("create stateless transformer: %w", err)
 		}
+		statelessTransformer = transformer
 
 		log.InfoContext(ctx, "Stateless transformer enabled",
 			slog.Int("transformations_count", len(pipelineCfg.StatelessTransformation.Config.Transform)))

--- a/glassflow-api/internal/deduplication/service.go
+++ b/glassflow-api/internal/deduplication/service.go
@@ -24,7 +24,7 @@ type batchWriter interface {
 	WriteNatsBatch(ctx context.Context, messages []*nats.Msg) error
 }
 
-type statelessTransformer interface {
+type StatelessTransformer interface {
 	Transform(inputBytes []byte) ([]byte, error)
 }
 
@@ -37,7 +37,7 @@ type DedupService struct {
 	reader               batchReader
 	writer               batchWriter
 	dlqWriter            batchWriter
-	statelessTransformer statelessTransformer
+	statelessTransformer StatelessTransformer
 	deduplicator         Dedup
 	cancel               context.CancelFunc
 	shutdownOnce         sync.Once
@@ -52,7 +52,7 @@ func NewDedupService(
 	reader batchReader,
 	writer batchWriter,
 	dlqWriter batchWriter,
-	statelessTransformer statelessTransformer,
+	statelessTransformer StatelessTransformer,
 	deduplicator Dedup,
 	log *slog.Logger,
 	batchSize int,


### PR DESCRIPTION
Issue:
The arg type to DedupService construtor fn for statelessTransform was incorrect, it was silently passing since the argument type was interface and a struct or Transformer was passed instead of statelessTransform interface