### PR TITLE
ETL-625: encrypt clickhouse and kafka credentials in Postgres

### DIFF
--- a/glassflow-api/cmd/glassflow/main.go
+++ b/glassflow-api/cmd/glassflow/main.go
@@ -69,6 +69,10 @@ type config struct {
 	// Database configuration
 	DatabaseURL string `default:"" split_words:"true"`
 
+	// Encryption configuration
+	EncryptionKeyPath string `default:"/etc/glassflow/secrets/encryption-key" split_words:"true"`
+	EncryptionKey     string `default:"" split_words:"true"`
+
 	K8sNamespace       string `default:"glassflow" split_words:"true"`
 	K8sResourceKind    string `default:"Pipeline" split_words:"true"`
 	K8sResourceName    string `default:"pipelines" split_words:"true"`
@@ -197,7 +201,12 @@ func mainEtl(
 		return fmt.Errorf("database URL is required: set GLASSFLOW_DATABASE_URL environment variable")
 	}
 
-	db, err := storage.NewPipelineStore(ctx, cfg.DatabaseURL, log)
+	encryptionKey, err := loadEncryptionKey(cfg, log)
+	if err != nil {
+		return fmt.Errorf("load encryption key: %w", err)
+	}
+
+	db, err := storage.NewPipelineStore(ctx, cfg.DatabaseURL, log, encryptionKey)
 	if err != nil {
 		return fmt.Errorf("create postgres store for pipelines: %w", err)
 	}

--- a/glassflow-api/cmd/glassflow/utils.go
+++ b/glassflow-api/cmd/glassflow/utils.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+)
+
+func loadEncryptionKey(cfg *config, log *slog.Logger) ([]byte, error) {
+	if cfg.EncryptionKey != "" {
+		key := []byte(cfg.EncryptionKey)
+		if len(key) != 32 {
+			return nil, fmt.Errorf("encryption key must be exactly 32 bytes, got %d bytes", len(key))
+		}
+		log.Info("encryption key loaded from environment variable")
+		return key, nil
+	}
+
+	if cfg.EncryptionKeyPath != "" {
+		keyData, err := os.ReadFile(cfg.EncryptionKeyPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				log.Info("encryption key file not found, encryption disabled",
+					slog.String("path", cfg.EncryptionKeyPath))
+				return nil, nil
+			}
+			return nil, fmt.Errorf("read encryption key file: %w", err)
+		}
+
+		key := keyData
+		if len(key) == 0 {
+			log.Info("encryption key file is empty, encryption disabled",
+				slog.String("path", cfg.EncryptionKeyPath))
+			return nil, nil
+		}
+
+		if len(key) != 32 {
+			return nil, fmt.Errorf("encryption key must be exactly 32 bytes, got %d bytes", len(key))
+		}
+
+		log.Info("encryption key loaded from file",
+			slog.String("path", cfg.EncryptionKeyPath))
+		return key, nil
+	}
+
+	return nil, nil
+}

--- a/glassflow-api/internal/constants.go
+++ b/glassflow-api/internal/constants.go
@@ -232,6 +232,5 @@ const (
 	DefaultProcessorMode               = AsyncMode
 
 	// Encryption constants
-	AESKeySize   = 32
-	GCMNonceSize = 12
+	AESKeySize = 32
 )

--- a/glassflow-api/internal/constants.go
+++ b/glassflow-api/internal/constants.go
@@ -230,4 +230,8 @@ const (
 	SyncMode             ProcessorMode = "sync"
 	AsyncMode            ProcessorMode = "async"
 	DefaultProcessorMode               = AsyncMode
+
+	// Encryption constants
+	AESKeySize   = 32
+	GCMNonceSize = 12
 )

--- a/glassflow-api/internal/encryption/README.md
+++ b/glassflow-api/internal/encryption/README.md
@@ -1,0 +1,28 @@
+# Encryption Package
+
+This package provides encryption services for connection credentials stored in PostgreSQL.
+
+## Overview
+
+Connection details (Kafka and ClickHouse credentials) are encrypted using **AES-256-GCM** before being stored in PostgreSQL. The encryption key is managed via Kubernetes Secrets and mounted as a file in the API pod.
+
+## Encryption Algorithm
+
+- **Algorithm**: AES-256-GCM (Galois/Counter Mode)
+- **Key Size**: 32 bytes (256 bits)
+- **Nonce Size**: 12 bytes (generated randomly for each encryption)
+- **Authentication**: Built-in authentication tag (16 bytes) prevents tampering
+
+## Key Management
+
+Users can provide their own encryption key via the Helm chart, or GlassFlow will automatically generate one during installation. The key is stored in a Kubernetes Secret and mounted as a file at `/etc/glassflow/secrets/encryption-key`.
+
+## Usage
+
+The encryption service is initialized with a 32-byte key and provides methods to encrypt/decrypt data:
+
+```go
+service, err := encryption.NewService(key)
+encrypted, err := service.Encrypt(plaintext)
+decrypted, err := service.Decrypt(encrypted)
+```

--- a/glassflow-api/internal/encryption/encryption.go
+++ b/glassflow-api/internal/encryption/encryption.go
@@ -1,0 +1,66 @@
+package encryption
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"io"
+)
+
+const (
+	aesKeySize   = 32
+	gcmNonceSize = 12
+)
+
+var (
+	ErrInvalidKeySize   = errors.New("encryption key must be exactly 32 bytes for AES-256")
+	ErrDecryptionFailed = errors.New("decryption failed: invalid ciphertext or authentication failed")
+)
+
+type Service struct {
+	aead cipher.AEAD
+}
+
+func NewService(key []byte) (*Service, error) {
+	if len(key) != aesKeySize {
+		return nil, fmt.Errorf("%w: got %d bytes", ErrInvalidKeySize, len(key))
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("create AES cipher: %w", err)
+	}
+
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("create GCM: %w", err)
+	}
+
+	return &Service{aead: aead}, nil
+}
+
+func (s *Service) Encrypt(plaintext []byte) ([]byte, error) {
+	nonce := make([]byte, gcmNonceSize)
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, fmt.Errorf("generate nonce: %w", err)
+	}
+
+	ciphertext := s.aead.Seal(nonce, nonce, plaintext, nil)
+	return ciphertext, nil
+}
+
+func (s *Service) Decrypt(ciphertext []byte) ([]byte, error) {
+	if len(ciphertext) < gcmNonceSize {
+		return nil, ErrDecryptionFailed
+	}
+
+	nonce, ciphertext := ciphertext[:gcmNonceSize], ciphertext[gcmNonceSize:]
+	plaintext, err := s.aead.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrDecryptionFailed, err)
+	}
+
+	return plaintext, nil
+}

--- a/glassflow-api/internal/encryption/encryption_test.go
+++ b/glassflow-api/internal/encryption/encryption_test.go
@@ -1,0 +1,183 @@
+package encryption
+
+import (
+	"crypto/rand"
+	"testing"
+)
+
+func TestNewService(t *testing.T) {
+	tests := []struct {
+		name    string
+		key     []byte
+		wantErr bool
+	}{
+		{
+			name:    "valid 32-byte key",
+			key:     make([]byte, 32),
+			wantErr: false,
+		},
+		{
+			name:    "invalid 16-byte key",
+			key:     make([]byte, 16),
+			wantErr: true,
+		},
+		{
+			name:    "invalid 64-byte key",
+			key:     make([]byte, 64),
+			wantErr: true,
+		},
+		{
+			name:    "empty key",
+			key:     []byte{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.key != nil && len(tt.key) > 0 {
+				rand.Read(tt.key)
+			}
+			_, err := NewService(tt.key)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewService() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestService_EncryptDecrypt(t *testing.T) {
+	key := make([]byte, 32)
+	rand.Read(key)
+
+	service, err := NewService(key)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	plaintext := []byte("test data to encrypt")
+	ciphertext, err := service.Encrypt(plaintext)
+	if err != nil {
+		t.Fatalf("Encrypt() error = %v", err)
+	}
+
+	if len(ciphertext) <= len(plaintext) {
+		t.Errorf("ciphertext should be longer than plaintext")
+	}
+
+	decrypted, err := service.Decrypt(ciphertext)
+	if err != nil {
+		t.Fatalf("Decrypt() error = %v", err)
+	}
+
+	if string(decrypted) != string(plaintext) {
+		t.Errorf("Decrypt() = %v, want %v", string(decrypted), string(plaintext))
+	}
+}
+
+func TestService_EncryptDecrypt_UniqueNonce(t *testing.T) {
+	key := make([]byte, 32)
+	rand.Read(key)
+
+	service, err := NewService(key)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	plaintext := []byte("same plaintext")
+	ciphertext1, err := service.Encrypt(plaintext)
+	if err != nil {
+		t.Fatalf("Encrypt() error = %v", err)
+	}
+
+	ciphertext2, err := service.Encrypt(plaintext)
+	if err != nil {
+		t.Fatalf("Encrypt() error = %v", err)
+	}
+
+	if string(ciphertext1) == string(ciphertext2) {
+		t.Error("encrypted data should be different due to unique nonces")
+	}
+
+	decrypted1, err := service.Decrypt(ciphertext1)
+	if err != nil {
+		t.Fatalf("Decrypt() error = %v", err)
+	}
+
+	decrypted2, err := service.Decrypt(ciphertext2)
+	if err != nil {
+		t.Fatalf("Decrypt() error = %v", err)
+	}
+
+	if string(decrypted1) != string(plaintext) || string(decrypted2) != string(plaintext) {
+		t.Error("both decrypted values should match plaintext")
+	}
+}
+
+func TestService_Decrypt_InvalidCiphertext(t *testing.T) {
+	key := make([]byte, 32)
+	rand.Read(key)
+
+	service, err := NewService(key)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		ciphertext []byte
+	}{
+		{
+			name:       "too short",
+			ciphertext: []byte("short"),
+		},
+		{
+			name:       "corrupted",
+			ciphertext: make([]byte, 50),
+		},
+		{
+			name:       "empty",
+			ciphertext: []byte{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.ciphertext != nil && len(tt.ciphertext) > 0 && tt.name == "corrupted" {
+				rand.Read(tt.ciphertext)
+			}
+			_, err := service.Decrypt(tt.ciphertext)
+			if err == nil {
+				t.Error("Decrypt() should fail for invalid ciphertext")
+			}
+		})
+	}
+}
+
+func TestService_WrongKey(t *testing.T) {
+	key1 := make([]byte, 32)
+	key2 := make([]byte, 32)
+	rand.Read(key1)
+	rand.Read(key2)
+
+	service1, err := NewService(key1)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	service2, err := NewService(key2)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	plaintext := []byte("test data")
+	ciphertext, err := service1.Encrypt(plaintext)
+	if err != nil {
+		t.Fatalf("Encrypt() error = %v", err)
+	}
+
+	_, err = service2.Decrypt(ciphertext)
+	if err == nil {
+		t.Error("Decrypt() should fail when using wrong key")
+	}
+}

--- a/glassflow-api/internal/errors.go
+++ b/glassflow-api/internal/errors.go
@@ -5,4 +5,8 @@ import "fmt"
 var (
 	ErrDLQNotExists    = fmt.Errorf("dlq does not exist")
 	ErrNoMessagesInDLQ = fmt.Errorf("no content")
+
+	// Encryption errors
+	ErrInvalidKeySize   = fmt.Errorf("encryption key must be exactly 32 bytes for AES-256")
+	ErrDecryptionFailed = fmt.Errorf("decryption failed: invalid ciphertext or authentication failed")
 )

--- a/glassflow-api/internal/storage/factory.go
+++ b/glassflow-api/internal/storage/factory.go
@@ -21,6 +21,6 @@ func MigratePipelinesFromNATSKV(
 }
 
 // NewPipelineStore creates a new PipelineStore implementation.
-func NewPipelineStore(ctx context.Context, dsn string, logger *slog.Logger) (service.PipelineStore, error) {
-	return postgres.NewPostgres(ctx, dsn, logger)
+func NewPipelineStore(ctx context.Context, dsn string, logger *slog.Logger, encryptionKey []byte) (service.PipelineStore, error) {
+	return postgres.NewPostgres(ctx, dsn, logger, encryptionKey)
 }

--- a/glassflow-api/internal/storage/postgres/connections.go
+++ b/glassflow-api/internal/storage/postgres/connections.go
@@ -2,22 +2,39 @@ package postgres
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/encryption"
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/models"
 )
 
 // insertConnectionWithConfig inserts a connection with the given config
 func (s *PostgresStorage) insertConnectionWithConfig(ctx context.Context, tx pgx.Tx, connType string, connConfig []byte) (uuid.UUID, error) {
+	configToStore := connConfig
+
+	if s.encryptionService != nil {
+		var err error
+		configToStore, err = encryptSensitiveFields(s.encryptionService, connType, connConfig)
+		if err != nil {
+			s.logger.ErrorContext(ctx, "failed to encrypt sensitive fields",
+				slog.String("connection_type", connType),
+				slog.String("error", err.Error()))
+			return uuid.Nil, fmt.Errorf("encrypt sensitive fields: %w", err)
+		}
+	}
 
 	var connID uuid.UUID
 	err := tx.QueryRow(ctx, `
 		INSERT INTO connections (type, config)
 		VALUES ($1, $2)
 		RETURNING id
-	`, connType, connConfig).Scan(&connID)
+	`, connType, configToStore).Scan(&connID)
 	if err != nil {
 		s.logger.ErrorContext(ctx, "failed to insert connection",
 			slog.String("connection_type", connType),
@@ -29,13 +46,26 @@ func (s *PostgresStorage) insertConnectionWithConfig(ctx context.Context, tx pgx
 }
 
 // updateConnectionWithConfig updates an existing connection with the given config
-func (s *PostgresStorage) updateConnectionWithConfig(ctx context.Context, tx pgx.Tx, connID uuid.UUID, connConfig []byte) error {
+func (s *PostgresStorage) updateConnectionWithConfig(ctx context.Context, tx pgx.Tx, connID uuid.UUID, connType string, connConfig []byte) error {
+
+	configToStore := connConfig
+
+	if s.encryptionService != nil {
+		var err error
+		configToStore, err = encryptSensitiveFields(s.encryptionService, connType, connConfig)
+		if err != nil {
+			s.logger.ErrorContext(ctx, "failed to encrypt sensitive fields",
+				slog.String("connection_id", connID.String()),
+				slog.String("error", err.Error()))
+			return fmt.Errorf("encrypt sensitive fields: %w", err)
+		}
+	}
 
 	_, err := tx.Exec(ctx, `
 		UPDATE connections
 		SET config = $1, updated_at = NOW()
 		WHERE id = $2
-	`, connConfig, connID)
+	`, configToStore, connID)
 	if err != nil {
 		s.logger.ErrorContext(ctx, "failed to update connection",
 			slog.String("connection_id", connID.String()),
@@ -44,4 +74,172 @@ func (s *PostgresStorage) updateConnectionWithConfig(ctx context.Context, tx pgx
 	}
 
 	return nil
+}
+
+// encryptSensitiveFields encrypts sensitive fields in the connection config JSON
+func encryptSensitiveFields(encryptionService *encryption.Service, connType string, configJSON []byte) ([]byte, error) {
+	if encryptionService == nil {
+		return configJSON, nil
+	}
+
+	switch connType {
+	case "kafka":
+		var config models.IngestorComponentConfig
+		if err := json.Unmarshal(configJSON, &config); err != nil {
+			return nil, fmt.Errorf("unmarshal kafka config: %w", err)
+		}
+		if err := encryptKafkaFields(encryptionService, &config); err != nil {
+			return nil, err
+		}
+		return json.Marshal(config)
+	case "clickhouse":
+		var config models.SinkComponentConfig
+		if err := json.Unmarshal(configJSON, &config); err != nil {
+			return nil, fmt.Errorf("unmarshal clickhouse config: %w", err)
+		}
+		if err := encryptClickHouseFields(encryptionService, &config); err != nil {
+			return nil, err
+		}
+		return json.Marshal(config)
+	default:
+		return configJSON, nil
+	}
+}
+
+// decryptSensitiveFields decrypts sensitive fields in the connection config JSON
+func decryptSensitiveFields(encryptionService *encryption.Service, connType string, configJSON []byte) ([]byte, error) {
+	if encryptionService == nil {
+		return configJSON, nil
+	}
+
+	switch connType {
+	case "kafka":
+		var config models.IngestorComponentConfig
+		if err := json.Unmarshal(configJSON, &config); err != nil {
+			return nil, fmt.Errorf("unmarshal kafka config: %w", err)
+		}
+		if err := decryptKafkaFields(encryptionService, &config); err != nil {
+			return nil, err
+		}
+		return json.Marshal(config)
+	case "clickhouse":
+		var config models.SinkComponentConfig
+		if err := json.Unmarshal(configJSON, &config); err != nil {
+			return nil, fmt.Errorf("unmarshal clickhouse config: %w", err)
+		}
+		if err := decryptClickHouseFields(encryptionService, &config); err != nil {
+			return nil, err
+		}
+		return json.Marshal(config)
+	default:
+		return configJSON, nil
+	}
+}
+
+// encryptKafkaFields encrypts sensitive fields in Kafka connection config
+func encryptKafkaFields(encryptionService *encryption.Service, config *models.IngestorComponentConfig) error {
+	// Encrypt password
+	if config.KafkaConnectionParams.SASLPassword != "" {
+		encrypted, err := encryptionService.Encrypt([]byte(config.KafkaConnectionParams.SASLPassword))
+		if err != nil {
+			return fmt.Errorf("encrypt password: %w", err)
+		}
+		config.KafkaConnectionParams.SASLPassword = base64.StdEncoding.EncodeToString(encrypted)
+	}
+
+	// Encrypt TLS key
+	if config.KafkaConnectionParams.TLSKey != "" {
+		encrypted, err := encryptionService.Encrypt([]byte(config.KafkaConnectionParams.TLSKey))
+		if err != nil {
+			return fmt.Errorf("encrypt tls_key: %w", err)
+		}
+		config.KafkaConnectionParams.TLSKey = base64.StdEncoding.EncodeToString(encrypted)
+	}
+
+	// Encrypt Kerberos keytab
+	if config.KafkaConnectionParams.KerberosKeytab != "" {
+		encrypted, err := encryptionService.Encrypt([]byte(config.KafkaConnectionParams.KerberosKeytab))
+		if err != nil {
+			return fmt.Errorf("encrypt kerberos_keytab: %w", err)
+		}
+		config.KafkaConnectionParams.KerberosKeytab = base64.StdEncoding.EncodeToString(encrypted)
+	}
+
+	return nil
+}
+
+// encryptClickHouseFields encrypts sensitive fields in ClickHouse connection config
+func encryptClickHouseFields(encryptionService *encryption.Service, config *models.SinkComponentConfig) error {
+	// Encrypt password
+	if config.ClickHouseConnectionParams.Password != "" {
+		encrypted, err := encryptionService.Encrypt([]byte(config.ClickHouseConnectionParams.Password))
+		if err != nil {
+			return fmt.Errorf("encrypt password: %w", err)
+		}
+		// TODO KIRAN DEBUG - remove this
+		fmt.Println(string(encrypted))
+		config.ClickHouseConnectionParams.Password = base64.StdEncoding.EncodeToString(encrypted)
+	}
+
+	return nil
+}
+
+// decryptKafkaFields decrypts sensitive fields in Kafka connection config
+func decryptKafkaFields(encryptionService *encryption.Service, config *models.IngestorComponentConfig) error {
+	// Decrypt password - try to decrypt if it looks like base64-encoded encrypted data
+	if config.KafkaConnectionParams.SASLPassword != "" {
+		if decrypted, err := attemptDecryptField(encryptionService, config.KafkaConnectionParams.SASLPassword); err == nil {
+			config.KafkaConnectionParams.SASLPassword = decrypted
+		}
+		// If decryption fails, assume it's plaintext (backward compatibility)
+	}
+
+	// Decrypt TLS key
+	if config.KafkaConnectionParams.TLSKey != "" {
+		if decrypted, err := attemptDecryptField(encryptionService, config.KafkaConnectionParams.TLSKey); err == nil {
+			config.KafkaConnectionParams.TLSKey = decrypted
+		}
+	}
+
+	// Decrypt Kerberos keytab
+	if config.KafkaConnectionParams.KerberosKeytab != "" {
+		if decrypted, err := attemptDecryptField(encryptionService, config.KafkaConnectionParams.KerberosKeytab); err == nil {
+			config.KafkaConnectionParams.KerberosKeytab = decrypted
+		}
+	}
+
+	return nil
+}
+
+// decryptClickHouseFields decrypts sensitive fields in ClickHouse connection config
+func decryptClickHouseFields(encryptionService *encryption.Service, config *models.SinkComponentConfig) error {
+	// Decrypt password
+	if config.ClickHouseConnectionParams.Password != "" {
+		if decrypted, err := attemptDecryptField(encryptionService, config.ClickHouseConnectionParams.Password); err == nil {
+			config.ClickHouseConnectionParams.Password = decrypted
+		}
+		// If decryption fails, assume it's plaintext (backward compatibility)
+	}
+
+	return nil
+}
+
+// attemptDecryptField attempts to decrypt a field. Returns the decrypted value if successful,
+// or an error if the field is not encrypted (plaintext). This allows us backward compatibility.
+func attemptDecryptField(encryptionService *encryption.Service, fieldValue string) (string, error) {
+	// Try to base64 decode
+	encryptedBytes, err := base64.StdEncoding.DecodeString(fieldValue)
+	if err != nil {
+		// Not base64 encoded, must be plaintext
+		return "", fmt.Errorf("not base64 encoded")
+	}
+
+	// Try to decrypt
+	decrypted, err := encryptionService.Decrypt(encryptedBytes)
+	if err != nil {
+		// Decryption failed, might be plaintext that happens to be valid base64
+		return "", fmt.Errorf("decryption failed")
+	}
+
+	return string(decrypted), nil
 }

--- a/glassflow-api/internal/storage/postgres/connections.go
+++ b/glassflow-api/internal/storage/postgres/connections.go
@@ -176,8 +176,6 @@ func encryptClickHouseFields(encryptionService *encryption.Service, config *mode
 		if err != nil {
 			return fmt.Errorf("encrypt password: %w", err)
 		}
-		// TODO KIRAN DEBUG - remove this
-		fmt.Println(string(encrypted))
 		config.ClickHouseConnectionParams.Password = base64.StdEncoding.EncodeToString(encrypted)
 	}
 

--- a/glassflow-api/internal/storage/postgres/pipelines.go
+++ b/glassflow-api/internal/storage/postgres/pipelines.go
@@ -649,7 +649,7 @@ func (s *PostgresStorage) updateKafkaSource(ctx context.Context, tx pgx.Tx, kafk
 		return fmt.Errorf("marshal kafka connection config: %w", err)
 	}
 
-	err = s.updateConnectionWithConfig(ctx, tx, kafkaConnID, connBytes)
+	err = s.updateConnectionWithConfig(ctx, tx, kafkaConnID, "kafka", connBytes)
 	if err != nil {
 		return fmt.Errorf("update kafka connection: %w", err)
 	}
@@ -705,7 +705,7 @@ func (s *PostgresStorage) updateClickHouseSink(ctx context.Context, tx pgx.Tx, c
 		return fmt.Errorf("marshal clickhouse connection config: %w", err)
 	}
 
-	err = s.updateConnectionWithConfig(ctx, tx, chConnID, connBytes)
+	err = s.updateConnectionWithConfig(ctx, tx, chConnID, "clickhouse", connBytes)
 	if err != nil {
 		return fmt.Errorf("update clickhouse connection: %w", err)
 	}

--- a/glassflow-api/tests/steps/pipeline_steps.go
+++ b/glassflow-api/tests/steps/pipeline_steps.go
@@ -373,7 +373,7 @@ func (p *PipelineSteps) setupPipelineService() error {
 		// Migrations are automatically run in StartPostgresContainer()
 	}
 
-	db, err := storage.NewPipelineStore(context.Background(), p.postgresContainer.GetDSN(), p.log)
+	db, err := storage.NewPipelineStore(context.Background(), p.postgresContainer.GetDSN(), p.log, nil)
 	if err != nil {
 		return fmt.Errorf("create postgres pipeline storage: %w", err)
 	}

--- a/glassflow-api/tests/steps/platform_steps.go
+++ b/glassflow-api/tests/steps/platform_steps.go
@@ -96,7 +96,7 @@ func (p *PlatformSteps) setupServices() error {
 	}
 
 	// Create storage
-	db, err := storage.NewPipelineStore(context.Background(), p.postgresContainer.GetDSN(), p.log)
+	db, err := storage.NewPipelineStore(context.Background(), p.postgresContainer.GetDSN(), p.log, nil)
 	if err != nil {
 		return fmt.Errorf("create postgres storage: %w", err)
 	}


### PR DESCRIPTION
Issue: source and sink creds are not encrypted only encoded which is a potential risk

This PR allows user to set an encryption key / file, the API uses this to encrypt/ decrypt  connection creds at rest using AES 256 in GCM. 

A separate PR will move pipeline JSON in CRD to k8 secret (API will create it in it's own namespace which will be read by operator)

[Additional logs](https://linear.app/glassflow/issue/ETL-625)