### PR TITLE
ETL-627:  DB revisions migration job container 

### DIFF
--- a/.github/workflows/build_image.yaml
+++ b/.github/workflows/build_image.yaml
@@ -24,6 +24,8 @@ jobs:
       glassflow-sink-arm64: ${{ steps.gen-output.outputs.glassflow-sink-arm64 }}
       glassflow-dedup-amd64: ${{ steps.gen-output.outputs.glassflow-dedup-amd64 }}
       glassflow-dedup-arm64: ${{ steps.gen-output.outputs.glassflow-dedup-arm64 }}
+      glassflow-migration-amd64: ${{ steps.gen-output.outputs.glassflow-migration-amd64 }}
+      glassflow-migration-arm64: ${{ steps.gen-output.outputs.glassflow-migration-arm64 }}
     permissions:
       contents: read
       packages: write
@@ -40,6 +42,8 @@ jobs:
             image_name: glassflow-etl-sink
           - name: glassflow-dedup
             image_name: glassflow-etl-dedup
+          - name: glassflow-migration
+            image_name: glassflow-etl-migration
         platform:
           - os: linux
             arch: amd64
@@ -59,19 +63,29 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
       - name: Download etl artifact
+        if: matrix.component.name != 'glassflow-migration'
         uses: actions/download-artifact@v4
         with:
           name: glassflow-api-${{ matrix.platform.os }}-${{ matrix.platform.arch }}
           path: glassflow-api/bin
       - name: Make artifacts executable
+        if: matrix.component.name != 'glassflow-migration'
         run: chmod +x glassflow-api/bin/*
+      - name: Set Dockerfile path
+        id: set-dockerfile
+        run: |
+          if [ "${{ matrix.component.name }}" = "glassflow-migration" ]; then
+            echo "dockerfile=glassflow-api/migrations/Dockerfile" >> $GITHUB_OUTPUT
+          else
+            echo "dockerfile=glassflow-api/docker/${{ matrix.component.name }}/Dockerfile" >> $GITHUB_OUTPUT
+          fi
       - name: Build & push Docker image
         uses: docker/build-push-action@v6
         id: build-arch-image
         with:
           platforms: ${{ matrix.platform.os }}/${{ matrix.platform.arch }}
           context: .
-          file: glassflow-api/docker/${{ matrix.component.name }}/Dockerfile
+          file: ${{ steps.set-dockerfile.outputs.dockerfile }}
           push: ${{ inputs.push }}
           provenance: false
           outputs: push-by-digest=true,type=image
@@ -84,6 +98,16 @@ jobs:
           ARCH: ${{ matrix.platform.arch }}
           DIGEST: ${{ steps.build-arch-image.outputs.digest }}
           COMPONENT: ${{ matrix.component.name }}
+      - name: Build Summary
+        if: always()
+        run: |
+          echo "### Built Component Image" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Component**: ${{ matrix.component.name }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Image**: ghcr.io/glassflow/${{ matrix.component.image_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Architecture**: ${{ matrix.platform.arch }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Digest**: \`${{ steps.build-arch-image.outputs.digest }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Status**: ${{ job.status }}" >> $GITHUB_STEP_SUMMARY
 
   push-docker-manifest:
     name: Push API Image
@@ -108,6 +132,9 @@ jobs:
           - amd64_digest: ${{ needs.build-docker-image.outputs.glassflow-dedup-amd64 }}
             arm64_digest: ${{ needs.build-docker-image.outputs.glassflow-dedup-arm64 }}
             repository: glassflow-etl-dedup
+          - amd64_digest: ${{ needs.build-docker-image.outputs.glassflow-migration-amd64 }}
+            arm64_digest: ${{ needs.build-docker-image.outputs.glassflow-migration-arm64 }}
+            repository: glassflow-etl-migration
     if: ${{ inputs.push }}
     needs: build-docker-image
     steps:

--- a/glassflow-api/migrations/Dockerfile
+++ b/glassflow-api/migrations/Dockerfile
@@ -15,10 +15,10 @@ RUN apk add --no-cache curl postgresql-client && \
     rm -rf /tmp/*
 
 # Copy migration SQL files (only up migrations)
-COPY *.up.sql /migrations/
+COPY glassflow-api/migrations/*.up.sql /migrations/
 
 # Copy entrypoint script
-COPY docker-entrypoint.sh /docker-entrypoint.sh
+COPY glassflow-api/migrations/docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh
 
 # Set working directory

--- a/glassflow-api/migrations/Dockerfile
+++ b/glassflow-api/migrations/Dockerfile
@@ -1,0 +1,27 @@
+FROM alpine:3.20
+
+# Install golang-migrate and postgresql-client
+RUN apk add --no-cache curl postgresql-client && \
+    MIGRATE_VERSION="v4.19.1" && \
+    ARCH="$(uname -m)" && \
+    case "$ARCH" in \
+        x86_64) ARCH="amd64" ;; \
+        aarch64|arm64) ARCH="arm64" ;; \
+        *) echo "Unsupported architecture: $ARCH"; exit 1 ;; \
+    esac && \
+    curl -L "https://github.com/golang-migrate/migrate/releases/download/${MIGRATE_VERSION}/migrate.linux-${ARCH}.tar.gz" | tar xvz && \
+    mv migrate /usr/local/bin/migrate && \
+    chmod +x /usr/local/bin/migrate && \
+    rm -rf /tmp/*
+
+# Copy migration SQL files (only up migrations)
+COPY *.up.sql /migrations/
+
+# Copy entrypoint script
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+# Set working directory
+WORKDIR /migrations
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/glassflow-api/migrations/docker-entrypoint.sh
+++ b/glassflow-api/migrations/docker-entrypoint.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# Migration entrypoint script
+# This script validates the connection URL and runs database migrations
+
+set -e
+
+# Validate POSTGRES_CONNECTION_URL is set
+if [ -z "${POSTGRES_CONNECTION_URL}" ]; then
+    echo "ERROR: POSTGRES_CONNECTION_URL environment variable is required"
+    exit 1
+fi
+
+echo "Starting database migration..."
+echo ""
+
+# Test database connection
+echo "Testing database connection..."
+if psql "${POSTGRES_CONNECTION_URL}" -c "SELECT 1" >/dev/null 2>&1; then
+    echo "Database connection successful"
+    echo ""
+else
+    echo "ERROR: Failed to connect to database"
+    echo "The database should already exist:"
+    echo "  - For internal PostgreSQL: Created automatically by the PostgreSQL chart"
+    echo "  - For external PostgreSQL: Should be pre-created before running migrations"
+    echo ""
+    echo "Connection URL format: postgresql://username:password@host:port/database?sslmode={sslmode=disable|allow|prefer|require}"
+    exit 1
+fi
+
+# Run migrations
+echo "Running migrations..."
+migrate -path /migrations -database "${POSTGRES_CONNECTION_URL}" up || {
+    EXIT_CODE=$?
+    if [ $EXIT_CODE -eq 1 ]; then
+        # Exit code 1 might mean "no change" which is OK
+        echo "No new migrations to apply"
+    else
+        echo "ERROR: Migration failed with exit code: $EXIT_CODE"
+        exit $EXIT_CODE
+    fi
+}
+
+echo ""
+echo "Migrations completed successfully!"


### PR DESCRIPTION
Issue:
Current migrations script downloads revision scripts, Goland migrate tool and PSQL client.
This causes some security vulnerabilities.

Solutions:
1. Replaced script with migrations container
2. Update image build CI pipeline to build the image
3. Kept the script for local development, testing and rollback
4. Refactor build CI pipelines / added some enhancements (summary)


@PabloPardoGarcia @ashish-bagri Please check if any additional steps to add security are required
[Corresponding charts PR](https://github.com/glassflow/charts/pull/37/changes)
Replaced migration script with migration container