### PR TITLE
fix: k8 orchestrator enable dedup component true if filter enabled

### DIFF
--- a/glassflow-api/internal/api/pipeline.go
+++ b/glassflow-api/internal/api/pipeline.go
@@ -292,7 +292,7 @@ func getSinkStreamID(p pipelineJSON) (string, error) {
 		if len(p.Source.Topics) > 0 {
 			firstTopic := p.Source.Topics[0]
 			// If deduplication is enabled for this topic, use the dedup output stream
-			if firstTopic.Deduplication.Enabled || p.StatelessTransformation.Enabled {
+			if firstTopic.Deduplication.Enabled || p.StatelessTransformation.Enabled || p.Filter.Enabled {
 				sinkStreamID = models.GetDedupOutputStreamName(p.PipelineID, firstTopic.Topic)
 			} else {
 				sinkStreamID = models.GetIngestorStreamName(p.PipelineID, firstTopic.Topic)

--- a/glassflow-api/internal/orchestrator/k8s.go
+++ b/glassflow-api/internal/orchestrator/k8s.go
@@ -504,7 +504,7 @@ func (k *K8sOrchestrator) buildPipelineSpec(ctx context.Context, cfg *models.Pip
 			DedupWindow:  s.Deduplication.Window.Duration(),
 			Replicas:     s.Replicas,
 			Deduplication: &operator.Deduplication{
-				Enabled:          s.Deduplication.Enabled || cfg.StatelessTransformation.Enabled,
+				Enabled:          s.Deduplication.Enabled || cfg.StatelessTransformation.Enabled || cfg.Filter.Enabled,
 				OutputStream:     models.GetDedupOutputStreamName(cfg.ID, s.Name),
 				NATSConsumerName: models.GetNATSDedupConsumerName(cfg.ID),
 			},


### PR DESCRIPTION
Change: dedup does not come up if only filter is enabled