### PR TITLE
feat: extend data type conversion for kafka types after switching to gjson parsing in sink

### DIFF
--- a/glassflow-api/internal/schema/types_test.go
+++ b/glassflow-api/internal/schema/types_test.go
@@ -296,6 +296,14 @@ func TestConvertValue(t *testing.T) {
 			wantErr:    false,
 		},
 		{
+			name:       "uint to UInt8 (uint64 from gjson)",
+			columnType: internal.CHTypeUInt8,
+			fieldType:  internal.KafkaTypeUint,
+			input:      uint64(200),
+			want:       uint8(200),
+			wantErr:    false,
+		},
+		{
 			name:       "uint16 to UInt16",
 			columnType: internal.CHTypeUInt16,
 			fieldType:  internal.KafkaTypeUint16,
@@ -304,11 +312,27 @@ func TestConvertValue(t *testing.T) {
 			wantErr:    false,
 		},
 		{
+			name:       "uint to UInt16 (uint64 from gjson)",
+			columnType: internal.CHTypeUInt16,
+			fieldType:  internal.KafkaTypeUint,
+			input:      uint64(200),
+			want:       uint16(200),
+			wantErr:    false,
+		},
+		{
 			name:       "uint32 to UInt32",
 			columnType: internal.CHTypeUInt32,
 			fieldType:  internal.KafkaTypeUint32,
 			input:      uint32(32),
 			want:       uint32(32),
+			wantErr:    false,
+		},
+		{
+			name:       "uint to UInt32 (uint64 from gjson)",
+			columnType: internal.CHTypeUInt32,
+			fieldType:  internal.KafkaTypeUint,
+			input:      uint64(100000),
+			want:       uint32(100000),
 			wantErr:    false,
 		},
 		{

--- a/glassflow-api/internal/schema/utils.go
+++ b/glassflow-api/internal/schema/utils.go
@@ -124,6 +124,26 @@ func ParseUint8(data any) (zero uint8, _ error) {
 			return zero, fmt.Errorf("value out of range of uint8: %d", value)
 		}
 		return uint8(value), nil
+	case uint64:
+		if value > math.MaxUint8 {
+			return zero, fmt.Errorf("value out of range of uint8: %d", value)
+		}
+		return uint8(value), nil
+	case int:
+		if value < 0 || value > int(math.MaxUint8) {
+			return zero, fmt.Errorf("value out of range of uint8: %d", value)
+		}
+		return uint8(value), nil
+	case int32:
+		if value < 0 || value > int32(math.MaxUint8) {
+			return zero, fmt.Errorf("value out of range of uint8: %d", value)
+		}
+		return uint8(value), nil
+	case int64:
+		if value < 0 || value > int64(math.MaxUint8) {
+			return zero, fmt.Errorf("value out of range of uint8: %d", value)
+		}
+		return uint8(value), nil
 	case float64:
 		if value > float64(math.MaxUint8) {
 			return zero, fmt.Errorf("value out of range of uint8: %f", value)
@@ -152,6 +172,26 @@ func ParseUint16(data any) (zero uint16, _ error) {
 			return zero, fmt.Errorf("value out of range of uint16: %d", value)
 		}
 		return uint16(value), nil
+	case uint64:
+		if value > math.MaxUint16 {
+			return zero, fmt.Errorf("value out of range of uint16: %d", value)
+		}
+		return uint16(value), nil
+	case int:
+		if value < 0 || value > int(math.MaxUint16) {
+			return zero, fmt.Errorf("value out of range of uint16: %d", value)
+		}
+		return uint16(value), nil
+	case int32:
+		if value < 0 || value > int32(math.MaxUint16) {
+			return zero, fmt.Errorf("value out of range of uint16: %d", value)
+		}
+		return uint16(value), nil
+	case int64:
+		if value < 0 || value > int64(math.MaxUint16) {
+			return zero, fmt.Errorf("value out of range of uint16: %d", value)
+		}
+		return uint16(value), nil
 	case float64:
 		if value > float64(math.MaxUint16) {
 			return zero, fmt.Errorf("value out of range of uint16: %f", value)
@@ -177,6 +217,26 @@ func ParseUint32(data any) (zero uint32, _ error) {
 		return value, nil
 	case uint:
 		if value > math.MaxUint32 {
+			return zero, fmt.Errorf("value out of range of uint32: %d", value)
+		}
+		return uint32(value), nil
+	case uint64:
+		if value > math.MaxUint32 {
+			return zero, fmt.Errorf("value out of range of uint32: %d", value)
+		}
+		return uint32(value), nil
+	case int:
+		if value < 0 || int64(value) > int64(math.MaxUint32) {
+			return zero, fmt.Errorf("value out of range of uint32: %d", value)
+		}
+		return uint32(value), nil
+	case int32:
+		if value < 0 {
+			return zero, fmt.Errorf("value out of range of uint32: %d", value)
+		}
+		return uint32(value), nil
+	case int64:
+		if value < 0 || value > int64(math.MaxUint32) {
 			return zero, fmt.Errorf("value out of range of uint32: %d", value)
 		}
 		return uint32(value), nil

--- a/glassflow-api/internal/schema/utils_test.go
+++ b/glassflow-api/internal/schema/utils_test.go
@@ -37,6 +37,17 @@ func TestParseUint8(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name:        "Valid uint64 within range (from gjson)",
+			input:       uint64(200),
+			expected:    200,
+			expectError: false,
+		},
+		{
+			name:        "Uint64 too large for uint8",
+			input:       uint64(math.MaxUint8 + 1),
+			expectError: true,
+		},
+		{
 			name:        "Uint too large",
 			input:       uint(math.MaxUint8 + 1),
 			expectError: true,


### PR DESCRIPTION
ConvertValueFromGjson returns uint64 where kafka source data type is set to uint and the some value converting functions did not support conversion for this case