### PR TITLE
ETL-725: feat: terminate pipeline should override edit operation

### DIFF
--- a/glassflow-api/internal/orchestrator/k8s.go
+++ b/glassflow-api/internal/orchestrator/k8s.go
@@ -262,6 +262,7 @@ func (k *K8sOrchestrator) TerminatePipeline(ctx context.Context, pipelineID stri
 		internal.PipelinePauseAnnotation,
 		internal.PipelineResumeAnnotation,
 		internal.PipelineStopAnnotation,
+		internal.PipelineEditAnnotation,
 	}
 
 	for _, annotation := range conflictingAnnotations {


### PR DESCRIPTION
Allow edit pipeline operation to be cancelled with terminate pipeline