### PR TITLE
ETL-813: cleanup join component nats stream consumer names

### DIFF
--- a/glassflow-api/cmd/glassflow/main.go
+++ b/glassflow-api/cmd/glassflow/main.go
@@ -376,16 +376,12 @@ func mainJoin(ctx context.Context, nc *client.NATSClient, cfg *config, log *slog
 		return fmt.Errorf("join must have exactly 2 sources")
 	}
 
-	if pipelineCfg.Join.OutputStreamID == "" {
-		return fmt.Errorf("join output stream ID must be specified")
-	}
-
 	schemaMapper, err := schema.NewMapper(pipelineCfg.Mapper)
 	if err != nil {
 		return fmt.Errorf("create schema mapper: %w", err)
 	}
 
-	joinRunner := service.NewJoinRunner(log, nc, pipelineCfg.Join, schemaMapper)
+	joinRunner := service.NewJoinRunner(log, nc, pipelineCfg, schemaMapper)
 
 	usageStatsClient := newUsageStatsClient(cfg, log, nil)
 

--- a/glassflow-api/internal/api/pipeline.go
+++ b/glassflow-api/internal/api/pipeline.go
@@ -249,9 +249,6 @@ func newJoinComponentConfig(p pipelineJSON) (zero models.JoinComponentConfig, _ 
 	if err != nil {
 		return zero, fmt.Errorf("create join config: %w", err)
 	}
-	joinComponentConfig.OutputStreamID = models.GetJoinedStreamName(p.PipelineID)
-	joinComponentConfig.NATSLeftConsumerName = models.GetNATSJoinLeftConsumerName(p.PipelineID)
-	joinComponentConfig.NATSRightConsumerName = models.GetNATSJoinRightConsumerName(p.PipelineID)
 
 	return joinComponentConfig, nil
 }

--- a/glassflow-api/internal/models/configs.go
+++ b/glassflow-api/internal/models/configs.go
@@ -210,15 +210,12 @@ type JoinSourceConfig struct {
 }
 
 type JoinComponentConfig struct {
-	Type           string             `json:"type"`
-	Enabled        bool               `json:"enabled"`
-	Sources        []JoinSourceConfig `json:"sources"`
-	OutputStreamID string             `json:"output_stream_id"`
+	Type    string             `json:"type"`
+	Enabled bool               `json:"enabled"`
+	Sources []JoinSourceConfig `json:"sources"`
 
-	NATSLeftConsumerName  string       `json:"nats_left_consumer_name"`
-	NATSRightConsumerName string       `json:"nats_right_consumer_name"`
-	LeftBufferTTL         JSONDuration `json:"left_buffer_ttl"`
-	RightBufferTTL        JSONDuration `json:"right_buffer_ttl"`
+	LeftBufferTTL  JSONDuration `json:"left_buffer_ttl"`
+	RightBufferTTL JSONDuration `json:"right_buffer_ttl"`
 }
 
 type JoinOrder string

--- a/glassflow-api/internal/orchestrator/docker.go
+++ b/glassflow-api/internal/orchestrator/docker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"sync"
 	"time"
 
@@ -93,6 +94,9 @@ func (d *LocalOrchestrator) SetupPipeline(ctx context.Context, pi *models.Pipeli
 	//nolint: contextcheck // new context for long running processes
 	ctx = context.Background()
 
+	// Ensure stale join-specific env does not leak across local test pipelines.
+	d.clearJoinEnvVars(ctx)
+
 	var (
 		sinkConsumerStream  string
 		sinkConsumerSubject string
@@ -177,7 +181,12 @@ func (d *LocalOrchestrator) SetupPipeline(ctx context.Context, pi *models.Pipeli
 		}
 		d.log.DebugContext(ctx, "created join right buffer KV store successfully")
 
-		d.joinRunner = service.NewJoinRunner(d.log.With("component", "join"), d.nc, pi.Join, schemaMapper)
+		// Join runner resolves these from env (operator-style contract).
+		os.Setenv("NATS_LEFT_INPUT_STREAM_PREFIX", leftInputStreamName)
+		os.Setenv("NATS_RIGHT_INPUT_STREAM_PREFIX", rightInputStreamName)
+		os.Setenv("NATS_SUBJECT_PREFIX", sinkConsumerStream)
+		os.Setenv("GLASSFLOW_POD_INDEX", internal.DefaultSubjectName)
+		d.joinRunner = service.NewJoinRunner(d.log.With("component", "join"), d.nc, *pi, schemaMapper)
 		err = d.joinRunner.Start(ctx)
 		if err != nil {
 			d.log.ErrorContext(ctx, "failed to start join runner", "left_stream", leftInputStreamName, "right_stream", rightInputStreamName, "error", err)
@@ -440,7 +449,23 @@ func (d *LocalOrchestrator) terminatePipelineComponents(ctx context.Context, pid
 	// Clear pipeline config at the end (similar to cleaning d.id)
 	d.pipelineConfig = nil
 
+	// Remove join-specific env for the next local pipeline setup.
+	d.clearJoinEnvVars(ctx)
+
 	return nil
+}
+
+func (d *LocalOrchestrator) clearJoinEnvVars(ctx context.Context) {
+	for _, key := range []string{
+		"NATS_LEFT_INPUT_STREAM_PREFIX",
+		"NATS_RIGHT_INPUT_STREAM_PREFIX",
+		"NATS_SUBJECT_PREFIX",
+		"GLASSFLOW_POD_INDEX",
+	} {
+		if err := os.Unsetenv(key); err != nil {
+			d.log.WarnContext(ctx, "failed to unset env var", "key", key, "error", err)
+		}
+	}
 }
 
 // cleanupNATSResources cleans up NATS streams and KV stores for a pipeline
@@ -471,11 +496,12 @@ func (d *LocalOrchestrator) cleanupNATSResources(ctx context.Context, pipeline *
 	// Clean up join resources if join is enabled
 	if pipeline.Join.Enabled {
 		// Clean up join output stream
-		if pipeline.Join.OutputStreamID != "" {
-			d.log.DebugContext(ctx, "deleting join output stream", "stream", pipeline.Join.OutputStreamID)
-			err := d.nc.DeleteStream(ctx, pipeline.Join.OutputStreamID)
+		outputStreamID := models.GetJoinedStreamName(pipeline.ID)
+		if outputStreamID != "" {
+			d.log.DebugContext(ctx, "deleting join output stream", "stream", outputStreamID)
+			err := d.nc.DeleteStream(ctx, outputStreamID)
 			if err != nil {
-				d.log.ErrorContext(ctx, "failed to delete join output stream", "error", err, "stream", pipeline.Join.OutputStreamID)
+				d.log.ErrorContext(ctx, "failed to delete join output stream", "error", err, "stream", outputStreamID)
 				// Continue with other cleanup even if this fails
 			}
 		}

--- a/glassflow-api/internal/service/join_runner.go
+++ b/glassflow-api/internal/service/join_runner.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal"
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/client"
@@ -17,8 +18,9 @@ import (
 )
 
 type JoinRunner struct {
-	log *slog.Logger
-	nc  *client.NATSClient
+	log        *slog.Logger
+	nc         *client.NATSClient
+	pipelineID string
 
 	joinCfg      models.JoinComponentConfig
 	schemaMapper schema.Mapper
@@ -28,55 +30,13 @@ type JoinRunner struct {
 	doneCh    chan struct{}
 }
 
-// getJoinInputStreamName returns the NATS stream name the join consumes from.
-// When an explicit env var is set for a side (left/right), it is used directly.
-// Otherwise it falls back to the stream ID from the pipeline config.
-func getJoinInputStreamName(fallbackStreamID, envVarName string) string {
-	streamName := os.Getenv(envVarName)
-	if streamName != "" {
-		return streamName
-	}
-	return fallbackStreamID
-}
-
-// getJoinOutputSubject returns the NATS subject the join publishes to.
-// When GLASSFLOW_POD_INDEX and NATS_SUBJECT_PREFIX are set, subject is "NATS_SUBJECT_PREFIX.GLASSFLOW_POD_INDEX".
-// Otherwise it falls back to the default subject derived from outputStreamID.
-func getJoinOutputSubject(outputStreamID string) string {
-	prefix := os.Getenv("NATS_SUBJECT_PREFIX")
-	podIndex := os.Getenv("GLASSFLOW_POD_INDEX")
-	if prefix != "" && podIndex != "" {
-		return fmt.Sprintf("%s.%s", prefix, podIndex)
-	}
-	return models.GetNATSSubjectNameDefault(outputStreamID)
-}
-
-func getLeftRightInputStreamsFromJoinConfig(joinCfg models.JoinComponentConfig) (leftStream, rightStream string, err error) {
-	if len(joinCfg.Sources) != 2 {
-		return "", "", fmt.Errorf("join must have exactly 2 sources, got %d", len(joinCfg.Sources))
-	}
-
-	if joinCfg.Sources[0].Orientation == "left" {
-		leftStream = joinCfg.Sources[0].StreamID
-		rightStream = joinCfg.Sources[1].StreamID
-	} else {
-		leftStream = joinCfg.Sources[1].StreamID
-		rightStream = joinCfg.Sources[0].StreamID
-	}
-
-	if leftStream == "" || rightStream == "" {
-		return "", "", fmt.Errorf("both left and right streams must be specified in join sources")
-	}
-
-	return leftStream, rightStream, nil
-}
-
-func NewJoinRunner(log *slog.Logger, nc *client.NATSClient, joinCfg models.JoinComponentConfig, schemaMapper schema.Mapper) *JoinRunner {
+func NewJoinRunner(log *slog.Logger, nc *client.NATSClient, pipelineConfig models.PipelineConfig, schemaMapper schema.Mapper) *JoinRunner {
 	return &JoinRunner{
-		nc:  nc,
-		log: log,
+		nc:         nc,
+		log:        log,
+		pipelineID: pipelineConfig.ID,
 
-		joinCfg:      joinCfg,
+		joinCfg:      pipelineConfig.Join,
 		schemaMapper: schemaMapper,
 
 		component: nil,
@@ -103,42 +63,52 @@ func (j *JoinRunner) Start(ctx context.Context) error {
 	}
 
 	var (
-		leftConsumer    jetstream.Consumer
-		rightConsumer   jetstream.Consumer
-		leftBuffer      kv.KeyValueStore
-		rightBuffer     kv.KeyValueStore
-		leftStreamName  string
-		rightStreamName string
-		err             error
+		leftConsumer  jetstream.Consumer
+		rightConsumer jetstream.Consumer
+		leftBuffer    kv.KeyValueStore
+		rightBuffer   kv.KeyValueStore
+		err           error
 	)
 
-	leftStreamName = mapper.GetLeftStream()
-	rightStreamName = mapper.GetRightStream()
-
-	leftInputFallback, rightInputFallback, err := getLeftRightInputStreamsFromJoinConfig(j.joinCfg)
+	leftInputStreamName, err := getJoinLeftInputStreamName()
 	if err != nil {
-		j.log.ErrorContext(ctx, "invalid join stream configuration", "error", err)
-		return fmt.Errorf("resolve left/right join streams: %w", err)
+		j.log.ErrorContext(ctx, "failed to resolve join left input stream", "error", err)
+		return fmt.Errorf("resolve join left input stream: %w", err)
 	}
 
-	if j.joinCfg.OutputStreamID == "" {
-		return fmt.Errorf("join output stream ID cannot be empty")
+	rightInputStreamName, err := getJoinRightInputStreamName()
+	if err != nil {
+		j.log.ErrorContext(ctx, "failed to resolve join right input stream", "error", err)
+		return fmt.Errorf("resolve join right input stream: %w", err)
 	}
 
-	leftInputStreamName := getJoinInputStreamName(leftInputFallback, "NATS_LEFT_INPUT_STREAM_PREFIX")
-	rightInputStreamName := getJoinInputStreamName(rightInputFallback, "NATS_RIGHT_INPUT_STREAM_PREFIX")
-	outputSubject := getJoinOutputSubject(j.joinCfg.OutputStreamID)
+	outputSubject, err := getJoinOutputSubject()
+	if err != nil {
+		j.log.ErrorContext(ctx, "failed to resolve join output subject", "error", err)
+		return fmt.Errorf("resolve join output subject: %w", err)
+	}
+
+	// Mapper stream names are schema source IDs and are required for join-key extraction.
+	leftSourceID := mapper.GetLeftStream()
+	rightSourceID := mapper.GetRightStream()
+	if leftSourceID == "" || rightSourceID == "" {
+		return fmt.Errorf("join mapper stream names are required; got left=%q right=%q", leftSourceID, rightSourceID)
+	}
+
 	j.log.InfoContext(ctx, "Join will read/write NATS resources",
 		"left_input_stream", leftInputStreamName,
 		"right_input_stream", rightInputStreamName,
-		"output_subject", outputSubject)
+		"output_subject", outputSubject,
+		"left_source", leftSourceID,
+		"right_source", rightSourceID,
+	)
 
 	leftConsumer, err = stream.NewNATSConsumer(
 		ctx,
 		j.nc.JetStream(),
 		jetstream.ConsumerConfig{
-			Name:          j.joinCfg.NATSLeftConsumerName,
-			Durable:       j.joinCfg.NATSLeftConsumerName,
+			Name:          models.GetNATSJoinLeftConsumerName(j.pipelineID),
+			Durable:       models.GetNATSJoinLeftConsumerName(j.pipelineID),
 			FilterSubject: models.GetWildcardNATSSubjectName(leftInputStreamName),
 			AckPolicy:     jetstream.AckExplicitPolicy,
 			AckWait:       internal.NatsDefaultAckWait,
@@ -155,8 +125,8 @@ func (j *JoinRunner) Start(ctx context.Context) error {
 		ctx,
 		j.nc.JetStream(),
 		jetstream.ConsumerConfig{
-			Name:          j.joinCfg.NATSRightConsumerName,
-			Durable:       j.joinCfg.NATSRightConsumerName,
+			Name:          models.GetNATSJoinRightConsumerName(j.pipelineID),
+			Durable:       models.GetNATSJoinRightConsumerName(j.pipelineID),
 			FilterSubject: models.GetWildcardNATSSubjectName(rightInputStreamName),
 			AckPolicy:     jetstream.AckExplicitPolicy,
 			AckWait:       internal.NatsDefaultAckWait,
@@ -198,8 +168,8 @@ func (j *JoinRunner) Start(ctx context.Context) error {
 		j.schemaMapper,
 		leftBuffer,
 		rightBuffer,
-		leftStreamName,
-		rightStreamName,
+		leftSourceID,
+		rightSourceID,
 		j.doneCh,
 		j.log,
 	)
@@ -233,4 +203,35 @@ func (j *JoinRunner) Shutdown() {
 // Done returns a channel that signals when the component stops by itself
 func (j *JoinRunner) Done() <-chan struct{} {
 	return j.doneCh
+}
+
+// getJoinInputStreamName returns the NATS stream name the join consumes from.
+func getJoinLeftInputStreamName() (string, error) {
+	return getRequiredEnvVar("NATS_LEFT_INPUT_STREAM_PREFIX")
+}
+func getJoinRightInputStreamName() (string, error) {
+	return getRequiredEnvVar("NATS_RIGHT_INPUT_STREAM_PREFIX")
+}
+
+// getJoinOutputSubject returns the NATS subject the join publishes to
+func getJoinOutputSubject() (string, error) {
+	prefix, err := getRequiredEnvVar("NATS_SUBJECT_PREFIX")
+	if err != nil {
+		return "", err
+	}
+
+	podIndex, err := getRequiredEnvVar("GLASSFLOW_POD_INDEX")
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%s.%s", prefix, podIndex), nil
+}
+
+func getRequiredEnvVar(name string) (string, error) {
+	val := strings.TrimSpace(os.Getenv(name))
+	if val == "" {
+		return "", fmt.Errorf("required environment variable %s is missing or empty", name)
+	}
+	return val, nil
 }

--- a/glassflow-api/tests/features/pipeline/pipeline.feature
+++ b/glassflow-api/tests/features/pipeline/pipeline.feature
@@ -217,10 +217,7 @@ Feature: Kafka to CH pipeline
                             "orientation": "right",
                             "stream_id": "gf-609e6e0a-test_users"
                         }
-                    ],
-                    "output_stream_id": "gf-609e6e0a-joined",
-                    "nats_left_consumer_name": "gf-nats-jl-609e6e0a",
-                    "nats_right_consumer_name": "gf-nats-jr-609e6e0a"
+                    ]
                 },
                 "sink": {
                     "type": "clickhouse",
@@ -376,10 +373,7 @@ Feature: Kafka to CH pipeline
                             "orientation": "right",
                             "stream_id": "gf-a75779b0-test_users"
                         }
-                    ],
-                    "output_stream_id": "gf-a75779b0-joined",
-                    "nats_left_consumer_name": "gf-nats-jl-a75779b0",
-                    "nats_right_consumer_name": "gf-nats-jr-a75779b0"
+                    ]
                 },
                 "sink": {
                     "type": "clickhouse",


### PR DESCRIPTION
1. Removed Join Config OutputStream, left & right consumer names from pipeline config
2. Changes in join_runner to get it from operator passed args
3. Updates in tests and docker orchestrator to match k8s behavior.