### PR TITLE
fix: flaky e2e tests (ETL-925)

### DIFF
--- a/glassflow-api/tests/testutils/containers.go
+++ b/glassflow-api/tests/testutils/containers.go
@@ -339,8 +339,10 @@ func StartPostgresContainer(ctx context.Context) (*PostgresContainer, error) {
 			"POSTGRES_USER":     "testuser",
 			"POSTGRES_PASSWORD": "testpass",
 		},
-		WaitingFor: wait.ForListeningPort(PostgresPort).
-			WithStartupTimeout(30 * time.Second),
+		WaitingFor: wait.ForAll(
+			wait.ForListeningPort(PostgresPort).WithStartupTimeout(30*time.Second),
+			wait.ForLog("database system is ready to accept connections").WithStartupTimeout(30*time.Second),
+		),
 	}
 
 	container, err := testcontainers.GenericContainer(ctx,


### PR DESCRIPTION
wait.ForListeningPort only checks that port 5432 is open at the TCP level, but PostgreSQL briefly opens the port before finishing its initialization. When migrations try to connect in that tiny window, they get
  connection reset by peer.
  
  ex - https://github.com/glassflow/clickhouse-etl/actions/runs/23496055315
