### PR TITLE
fix: reverse filter to keep messages where expression evaluates to true

### DIFF
--- a/glassflow-api/internal/processor/filter_processor.go
+++ b/glassflow-api/internal/processor/filter_processor.go
@@ -52,8 +52,8 @@ func (fp *FilterProcessor) ProcessBatch(
 			continue
 		}
 
-		if matched {
-			// Message matches the filter expression, so it should be filtered out
+		if !matched {
+			// Message does not match the filter expression, so it should be filtered out
 			continue
 		}
 

--- a/glassflow-api/tests/dedup_test.go
+++ b/glassflow-api/tests/dedup_test.go
@@ -485,7 +485,7 @@ func TestDeduplication_BasicFiltering(t *testing.T) {
 
 	filterConfig := &models.FilterComponentConfig{
 		Enabled:    true,
-		Expression: `age < 18`, // Filter out minors
+		Expression: `age >= 18`, // Keep adults
 	}
 
 	component := createComponent(
@@ -501,7 +501,7 @@ func TestDeduplication_BasicFiltering(t *testing.T) {
 		nil,          // dlq
 	)
 
-	// Publish 3 messages: 2 match filter (dropped), 1 doesn't match (passes through)
+	// Publish 3 messages: 2 do not match filter (dropped), 1 matches (passes through)
 	for _, data := range []string{`{"age": 15}`, `{"age": 25}`, `{"age": 10}`} {
 		msg := &nats.Msg{
 			Subject: inputSubject,
@@ -540,7 +540,7 @@ func TestDeduplication_FilterWithDedupAndTransform(t *testing.T) {
 	// Filter: keep only adults (age >= 18)
 	filterConfig := &models.FilterComponentConfig{
 		Enabled:    true,
-		Expression: `age < 18`, // Filter out minors
+		Expression: `age >= 18`, // Keep adults
 	}
 
 	// Deduplication: enabled with 1 hour window
@@ -581,11 +581,11 @@ func TestDeduplication_FilterWithDedupAndTransform(t *testing.T) {
 		msgID string
 		data  string
 	}{
-		{"msg-1", `{"age": 15, "name": "alice"}`},   // Filtered out (age < 18)
+		{"msg-1", `{"age": 15, "name": "alice"}`},   // Filtered out (does not match age >= 18)
 		{"msg-2", `{"age": 25, "name": "bob"}`},     // Passes filter, deduped, transformed
 		{"msg-2", `{"age": 25, "name": "bob"}`},     // Duplicate (deduped)
 		{"msg-3", `{"age": 30, "name": "charlie"}`}, // Passes filter, deduped, transformed
-		{"msg-4", `{"age": 10, "name": "dave"}`},    // Filtered out (age < 18)
+		{"msg-4", `{"age": 10, "name": "dave"}`},    // Filtered out (does not match age >= 18)
 	}
 
 	for _, tm := range testMessages {

--- a/glassflow-api/tests/streaming_component_test.go
+++ b/glassflow-api/tests/streaming_component_test.go
@@ -132,7 +132,7 @@ func TestStreamingComponent_FilterWithDedupAndTransform(t *testing.T) {
 
 	filterConfig := &models.FilterComponentConfig{
 		Enabled:    true,
-		Expression: `age < 18`, // Filter out minors
+		Expression: `age >= 18`, // Keep adults
 	}
 
 	dedupConfig := &models.DeduplicationConfig{
@@ -178,11 +178,11 @@ func TestStreamingComponent_FilterWithDedupAndTransform(t *testing.T) {
 		msgID string
 		data  string
 	}{
-		{"msg-1", `{"age": 15, "name": "alice"}`},   // Filtered out (age < 18)
+		{"msg-1", `{"age": 15, "name": "alice"}`},   // Filtered out (age < 18, does not match age >= 18)
 		{"msg-2", `{"age": 25, "name": "bob"}`},     // Passes filter, deduped, transformed
 		{"msg-2", `{"age": 25, "name": "bob"}`},     // Duplicate (deduped)
 		{"msg-3", `{"age": 30, "name": "charlie"}`}, // Passes filter, deduped, transformed
-		{"msg-4", `{"age": 10, "name": "dave"}`},    // Filtered out (age < 18)
+		{"msg-4", `{"age": 10, "name": "dave"}`},    // Filtered out (age < 18, does not match age >= 18)
 	}
 
 	for _, tm := range testMessages {


### PR DESCRIPTION
Fixes ETL-774.

Previously, the filter kept messages where the expression evaluated to `false` and dropped messages where it evaluated to `true` — the opposite of how filters work everywhere else (SQL `WHERE`, Flink, etc.).

Now, messages are kept when the expression is `true` and dropped when it's `false`, consistent with standard filter semantics.