### PR TITLE
ETL-985: Update filter docs to reflect reversed behaviour

### DIFF
--- a/docs/app/architecture/data-flow/page.mdx
+++ b/docs/app/architecture/data-flow/page.mdx
@@ -60,7 +60,7 @@ The **Transformations** stage runs in a single pod and can apply up to three ope
 
 #### Filter
 
-If a **filter** is configured for the pipeline, filter expressions are evaluated on messages read from NATS JetStream. Events that match the filter expression are **dropped** and not forwarded to downstream components. Events that do not match the filter expression continue through deduplication, stateless transformations, join, and sink.
+If a **filter** is configured for the pipeline, filter expressions are evaluated on messages read from NATS JetStream. Events that match the filter expression **pass through** and continue through deduplication, stateless transformations, join, and sink. Events that do not match the filter expression are **dropped** and not forwarded to downstream components.
 
 If the filter expression cannot be evaluated for a message (for example, due to a type error), that message is sent to the DLQ with the error details and then acknowledged so it is not retried endlessly. Other messages in the batch that pass the filter continue through the pipeline.
 

--- a/docs/app/configuration/transformations/filter/page.mdx
+++ b/docs/app/configuration/transformations/filter/page.mdx
@@ -6,20 +6,24 @@ import { Callout, Tabs } from 'nextra/components'
 
 # Filter
 
-The **Filter** transformation allows you to selectively drop events based on configurable expressions. Events that match the filter expression are **dropped** and not processed further. Events that do not match the filter expression continue through the rest of the pipeline.
+The **Filter** transformation allows you to selectively keep events based on configurable expressions. Events where the filter expression evaluates to `true` **pass through** and continue to be processed. Events where the expression evaluates to `false` are **dropped** and not processed further.
+
+<Callout type="warning">
+  **Breaking change:** In versions previous to 3.0.0, the filter expression defined a **drop** condition — events matching the expression were discarded. Starting with the current release, the filter expression defines a **keep** condition — events matching the expression pass through. If you are upgrading, you need to invert your existing filter expressions (for example, change `status == 'error'` to `status != 'error'` if your intent was to drop errors).
+</Callout>
 
 ## How It Works
 
-Filtering in GlassFlow runs in the **Transform stage** (Stage 3), the same stage as deduplication and stateless transformations. Events are read from NATS JetStream and evaluated against the filter expression before deduplication or stateless transforms run. The filter uses expression-based evaluation to determine whether an event should be processed.
+Filtering in GlassFlow runs in the **Transform stage** (Stage 3), the same stage as deduplication and stateless transformations. Events are read from NATS JetStream and evaluated against the filter expression before deduplication or stateless transforms run. The filter uses expression-based evaluation to determine whether an event should continue through the pipeline.
 
 ### Internal Process
 
 1. **Event Reception**: Events are read from NATS JetStream (after the Ingestor stage)
 2. **Expression Evaluation**: Each event is evaluated against the configured filter expression
 3. **Filtering Decision**:
-   - If the expression evaluates to `true`, the event is **dropped** and not processed further
-   - If the expression evaluates to `false`, the event **passes through** to the rest of the pipeline
-4. **Processing**: Only events where the expression evaluated to `false` continue through the pipeline (deduplication, stateless transformations, join, sink)
+   - If the expression evaluates to `true`, the event **passes through** to the rest of the pipeline
+   - If the expression evaluates to `false`, the event is **dropped** and not processed further
+4. **Processing**: Only events where the expression evaluated to `true` continue through the pipeline (deduplication, stateless transformations, join, sink)
 
 ### Expression Language
 
@@ -33,7 +37,7 @@ GlassFlow uses the [expr](https://github.com/expr-lang/expr) expression language
 
 ## Configuration
 
-Filter is configured at the pipeline level. The `expression` field defines the **drop condition**: events for which the expression evaluates to `true` are discarded, and events for which it evaluates to `false` pass through.
+Filter is configured at the pipeline level. The `expression` field defines the **keep condition**: events for which the expression evaluates to `true` pass through, and events for which it evaluates to `false` are discarded.
 
 <Tabs items={['Web UI', 'Pipeline JSON']} defaultIndex="0" storageKey="client_preference">
   <Tabs.Tab>
@@ -73,11 +77,11 @@ Filter expressions use field names from your event schema and support the follow
 
 #### Examples
 
-<Callout type="warning">
-  The filter expression defines the **drop condition**. When the expression evaluates to `true`, the event is dropped. When it evaluates to `false`, the event passes through. Write your expression to match the events you want to **exclude**, not the events you want to keep.
+<Callout type="info">
+  The filter expression defines the **keep condition**. When the expression evaluates to `true`, the event passes through. When it evaluates to `false`, the event is dropped. Write your expression to match the events you want to **keep**.
 </Callout>
 
-**Drop events where `status` equals `'active'` (string comparison):**
+**Keep only events where `status` equals `'active'` (string comparison):**
 <Tabs items={['Web UI', 'Pipeline JSON']} defaultIndex="0" storageKey="client_preference">
   <Tabs.Tab>
     <img alt="String Comparison" src="/assets/ui_filter_string_comparison.png" />
@@ -94,7 +98,7 @@ Filter expressions use field names from your event schema and support the follow
   </Tabs.Tab>
 </Tabs>
 
-**Drop events where `age` is greater than 18 (numeric comparison):**
+**Keep only events where `age` is greater than 18 (numeric comparison):**
 <Tabs items={['Web UI', 'Pipeline JSON']} defaultIndex="0" storageKey="client_preference">
   <Tabs.Tab>
     <img alt="Numeric Comparison" src="/assets/ui_filter_numeric_comparison.png" />
@@ -111,7 +115,7 @@ Filter expressions use field names from your event schema and support the follow
   </Tabs.Tab>
 </Tabs>
 
-**Drop events where `is_premium` is `true` (boolean field):**
+**Keep only events where `is_premium` is `true` (boolean field):**
 <Tabs items={['Web UI', 'Pipeline JSON']} defaultIndex="0" storageKey="client_preference">
   <Tabs.Tab>
     <img alt="Boolean Field" src="/assets/ui_filter_boolean_field.png" />
@@ -128,7 +132,7 @@ Filter expressions use field names from your event schema and support the follow
   </Tabs.Tab>
 </Tabs>
 
-**Drop events matching multiple conditions with AND:**
+**Keep only events matching multiple conditions with AND:**
 <Tabs items={['Web UI', 'Pipeline JSON']} defaultIndex="0" storageKey="client_preference">
   <Tabs.Tab>
     <img alt="Multiple Conditions with AND" src="/assets/ui_filter_multiple_conditions_with_and.png" />
@@ -145,7 +149,7 @@ Filter expressions use field names from your event schema and support the follow
   </Tabs.Tab>
 </Tabs>
 
-**Drop events matching any condition with OR:**
+**Keep events matching any condition with OR:**
 <Tabs items={['Web UI', 'Pipeline JSON']} defaultIndex="0" storageKey="client_preference">
   <Tabs.Tab>
     <img alt="Multiple Conditions with OR" src="/assets/ui_filter_multiple_conditions_with_or.png" />
@@ -162,7 +166,7 @@ Filter expressions use field names from your event schema and support the follow
   </Tabs.Tab>
 </Tabs>
 
-**Drop events matching a complex expression with parentheses:**
+**Keep events matching a complex expression with parentheses:**
 <Tabs items={['Web UI', 'Pipeline JSON']} defaultIndex="0" storageKey="client_preference">
   <Tabs.Tab>
     <img alt="Complex Expression with Parentheses" src="/assets/ui_filter_complex_expression_with_parentheses.png" />
@@ -179,7 +183,7 @@ Filter expressions use field names from your event schema and support the follow
   </Tabs.Tab>
 </Tabs>
 
-**Drop events using nested field access:**
+**Keep only events using nested field access:**
 <Tabs items={['Web UI', 'Pipeline JSON']} defaultIndex="0" storageKey="client_preference">
   <Tabs.Tab>
     <img alt="Nested Field Access" src="/assets/ui_filter_nested_field_access.png" />
@@ -200,7 +204,7 @@ Filter expressions use field names from your event schema and support the follow
 
 ### Expression Design
 
-- **Write drop conditions**: The expression defines what to discard, not what to keep. If you want to keep events where `status == 'active'`, write the expression as `status != 'active'` to drop everything else.
+- **Write keep conditions**: The expression defines what to keep. For example, to keep only active users, write `status == 'active'`.
 - **Keep expressions simple**: Complex expressions can be harder to maintain and debug
 - **Use parentheses**: Explicitly group conditions with parentheses for clarity
 - **Test expressions**: Validate filter expressions before deploying to production
@@ -220,7 +224,7 @@ Filter expressions use field names from your event schema and support the follow
 
 ## Example Configuration
 
-Here's a complete example of a pipeline with filtering enabled. In this example, events where `age > 18` **and** `status == 'active'` are **dropped**. Events that do not meet both conditions pass through to ClickHouse.
+Here's a complete example of a pipeline with filtering enabled. In this example, only events where `age > 18` **and** `status == 'active'` **pass through** to ClickHouse. Events that do not meet both conditions are dropped.
 
 ```json
 {

--- a/docs/app/configuration/transformations/page.mdx
+++ b/docs/app/configuration/transformations/page.mdx
@@ -12,14 +12,14 @@ GlassFlow supports several transformations that can be applied to your data as i
 
 - [**Deduplication**](/configuration/transformations/deduplication) — Remove duplicate events from your data stream based on a unique identifier field.
 - [**Join**](/configuration/transformations/join) — Combine data from multiple Kafka topics based on join keys and time windows.
-- [**Filter**](/configuration/transformations/filter) — Drop events that match a configurable expression. Events that do not match the expression pass through the pipeline.
+- [**Filter**](/configuration/transformations/filter) — Keep events that match a configurable expression. Events that do not match the expression are dropped.
 - [**Stateless Transformation**](/configuration/transformations/stateless-transformation) — Reshape event payloads on the fly using expression-based mappings.
 
 ## Transformation Order
 
 Transformations are applied in the following order within a pipeline:
 
-1. **Filter** — Applied in the Transform stage, alongside deduplication and stateless transformations. Events that match the filter expression are dropped before deduplication or stateless transforms run.
+1. **Filter** — Applied in the Transform stage, alongside deduplication and stateless transformations. Events that match the filter expression are kept; non-matching events are dropped before deduplication or stateless transforms run.
 2. **Deduplication** — Applied in the Transform stage, after filtering.
 3. **Stateless Transformation** — Applied in the Transform stage, after deduplication.
 4. **Join** — Applied after the Transform stage, before sinking to ClickHouse.

--- a/docs/app/page.mdx
+++ b/docs/app/page.mdx
@@ -45,8 +45,8 @@ GlassFlow is an open-source streaming ETL for Kafka to Clickhouse streams. It ha
 - Produce joined streams ready for ClickHouse ingestion
 
 ### Filter
-- Expression-based filtering to drop unwanted events before they reach downstream processing ([Filter](/configuration/transformations/filter))
-- Configure filter expressions at the pipeline level; events that match the expression are dropped, non-matching events continue through the pipeline
+- Expression-based filtering to keep only the events you need before they reach downstream processing ([Filter](/configuration/transformations/filter))
+- Configure filter expressions at the pipeline level; events that match the expression pass through the pipeline, non-matching events are dropped
 - Uses the expr language for type-safe, field-based conditions
 
 ### Stateless Transformations

--- a/docs/app/usage-guide/web-ui/page.mdx
+++ b/docs/app/usage-guide/web-ui/page.mdx
@@ -105,14 +105,14 @@ The system will:
 
 This step is optional. Skip it if you do not need to filter records before they reach ClickHouse.
 
-Toggle the filter on to define a condition that identifies records to drop. Records that match the expression are excluded from the pipeline; records that do not match are passed through.
+Toggle the filter on to define a condition that identifies records to keep. Records that match the expression pass through the pipeline; records that do not match are dropped.
 
 **Filter Configuration**
 
-- **Filter Expression**: Enter a JSON-based condition that describes the records you want to drop
-  - Example: `{"status": "aborted"}` drops every record where `status` equals `"cancelled"`
+- **Filter Expression**: Enter a JSON-based condition that describes the records you want to keep
+  - Example: `{"status": "active"}` keeps every record where `status` equals `"active"`
   - Conditions can reference any field present in the topic schema
-  - Only records that match the expression are dropped; all others continue downstream
+  - Only records that match the expression pass through; all others are dropped
 
 ![Filter Configuration](/assets/ui_filter_config.png)
 


### PR DESCRIPTION
docs: update filter docs to reflect reversed keep-condition semantics

Filter expressions now define a keep condition (like SQL WHERE) instead of a drop condition. Updated all filter references across 5 doc pages to match the new behavior introduced in #657 