### PR TITLE
fix: rename OTLP metrics resource field to resource_attributes

### DIFF
--- a/glassflow-api/internal/models/otlp.go
+++ b/glassflow-api/internal/models/otlp.go
@@ -149,7 +149,7 @@ type OTLPMetric struct {
 	Max                    *float64          `json:"max"`
 	BucketCounts           []uint64          `json:"bucket_counts"`
 	ExplicitBounds         []float64         `json:"explicit_bounds"`
-	Resource               map[string]string `json:"resource"`
+	ResourceAttributes     map[string]string `json:"resource_attributes"`
 	ScopeName              string            `json:"scope_name"`
 	ScopeVersion           string            `json:"scope_version,omitempty"`
 	ScopeAttributes        map[string]string `json:"scope_attributes"`
@@ -209,7 +209,7 @@ func otlpMetricsSchemaFields() []Field {
 		{Name: "max", Type: "float"},
 		{Name: "bucket_counts", Type: "array"},
 		{Name: "explicit_bounds", Type: "array"},
-		{Name: "resource", Type: "map"},
+		{Name: "resource_attributes", Type: "map"},
 		{Name: "scope_name", Type: "string"},
 		{Name: "scope_version", Type: "string"},
 		{Name: "scope_attributes", Type: "map"},

--- a/glassflow-api/internal/otlp-receiver/server/processor/flattener/metrics.go
+++ b/glassflow-api/internal/otlp-receiver/server/processor/flattener/metrics.go
@@ -39,7 +39,7 @@ func flattenMetricDataPoints(
 		MetricName:        m.GetName(),
 		MetricDescription: m.GetDescription(),
 		MetricUnit:        m.GetUnit(),
-		Resource:          resource,
+		ResourceAttributes: resource,
 		ScopeName:         scopeName,
 		ScopeVersion:      scopeVersion,
 		ScopeAttributes:   scopeAttrs,

--- a/glassflow-api/internal/otlp-receiver/server/processor/flattener/metrics.go
+++ b/glassflow-api/internal/otlp-receiver/server/processor/flattener/metrics.go
@@ -36,15 +36,15 @@ func flattenMetricDataPoints(
 	scopeAttrs map[string]string,
 ) ([]models.Message, error) {
 	base := models.OTLPMetric{
-		MetricName:        m.GetName(),
-		MetricDescription: m.GetDescription(),
-		MetricUnit:        m.GetUnit(),
+		MetricName:         m.GetName(),
+		MetricDescription:  m.GetDescription(),
+		MetricUnit:         m.GetUnit(),
 		ResourceAttributes: resource,
-		ScopeName:         scopeName,
-		ScopeVersion:      scopeVersion,
-		ScopeAttributes:   scopeAttrs,
-		BucketCounts:      []uint64{},
-		ExplicitBounds:    []float64{},
+		ScopeName:          scopeName,
+		ScopeVersion:       scopeVersion,
+		ScopeAttributes:    scopeAttrs,
+		BucketCounts:       []uint64{},
+		ExplicitBounds:     []float64{},
 	}
 
 	switch data := m.GetData().(type) {

--- a/glassflow-api/internal/otlp-receiver/server/processor/flattener/metrics_test.go
+++ b/glassflow-api/internal/otlp-receiver/server/processor/flattener/metrics_test.go
@@ -110,7 +110,7 @@ func TestFlattenMetrics_Histogram(t *testing.T) {
 		Max:                    &wantMax,
 		BucketCounts:           []uint64{120, 450, 380, 200, 80, 20},
 		ExplicitBounds:         []float64{0.005, 0.01, 0.025, 0.05, 0.1},
-		Resource:               map[string]string{"service.name": "api-gateway"},
+		ResourceAttributes:     map[string]string{"service.name": "api-gateway"},
 		ScopeName:              "go.opentelemetry.io/contrib/net/http",
 		ScopeVersion:           "0.46.0",
 		ScopeAttributes:        map[string]string{},

--- a/glassflow-api/internal/otlp-receiver/server/processor/metrics_test.go
+++ b/glassflow-api/internal/otlp-receiver/server/processor/metrics_test.go
@@ -115,7 +115,7 @@ func TestProcessMetrics(t *testing.T) {
 		ValueDouble:    &value,
 		BucketCounts:   []uint64{},
 		ExplicitBounds: []float64{},
-		Resource:        map[string]string{"service.name": "test-service"},
+		ResourceAttributes: map[string]string{"service.name": "test-service"},
 		ScopeName:      "test-scope",
 		ScopeAttributes: map[string]string{},
 		Attributes:     map[string]string{},


### PR DESCRIPTION
## Summary
- Renames `Resource` field in `OTLPMetric` struct from JSON `"resource"` to `"resource_attributes"`, matching the convention already used by logs (`OTLPLog`) and traces (`OTLPSpan`)
- Updates `otlpMetricsSchemaFields()` to expose `"resource_attributes"` instead of `"resource"`
- Updates all call sites and tests accordingly

Fixes https://linear.app/glassflow/issue/ETL-987/rename-otlp-metrics-resources