### PR TITLE
feat: add POST /api/v1/pipeline/migrate-preview endpoint (ETL-1017)

### DIFF
--- a/glassflow-api/internal/api/migrate_preview.go
+++ b/glassflow-api/internal/api/migrate_preview.go
@@ -247,11 +247,7 @@ func convertSinkMapping(v2 pipelineJSONv2) []sinkMappingEntry {
 	if len(v2.Sink.TableMapping) > 0 {
 		entries := make([]sinkMappingEntry, len(v2.Sink.TableMapping))
 		for i, m := range v2.Sink.TableMapping {
-			entries[i] = sinkMappingEntry{
-				Name:       m.Name,
-				ColumnName: m.ColumnName,
-				ColumnType: m.ColumnType,
-			}
+			entries[i] = sinkMappingEntry(m)
 		}
 		return entries
 	}

--- a/glassflow-api/internal/api/migrate_preview.go
+++ b/glassflow-api/internal/api/migrate_preview.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 
@@ -19,8 +20,11 @@ func MigratePreviewDocs() huma.Operation {
 	}
 }
 
+// MigratePreviewInput accepts raw JSON so Huma does not validate against the
+// v2 schema — v2 payloads in the wild contain fields we don't model and we
+// don't want unknown-property errors before the handler even runs.
 type MigratePreviewInput struct {
-	Body pipelineJSONv2
+	Body json.RawMessage
 }
 
 type MigratePreviewResponse struct {
@@ -28,7 +32,16 @@ type MigratePreviewResponse struct {
 }
 
 func (h *handler) migratePipelinePreview(_ context.Context, input *MigratePreviewInput) (*MigratePreviewResponse, error) {
-	out, err := convertV2ToV3(input.Body)
+	var v2 pipelineJSONv2
+	if err := json.Unmarshal(input.Body, &v2); err != nil {
+		return nil, &ErrorDetail{
+			Status:  http.StatusUnprocessableEntity,
+			Code:    "unprocessable_entity",
+			Message: "invalid v2 pipeline JSON",
+			Details: map[string]any{"error": err.Error()},
+		}
+	}
+	out, err := convertV2ToV3(v2)
 	if err != nil {
 		return nil, &ErrorDetail{
 			Status:  http.StatusUnprocessableEntity,

--- a/glassflow-api/internal/api/migrate_preview.go
+++ b/glassflow-api/internal/api/migrate_preview.go
@@ -220,8 +220,24 @@ func convertJoin(v2 pipelineJSONv2) (join, error) {
 	}, nil
 }
 
+func sinkConnParams(s clickhouseSinkV2) sinkConnectionParamsV2 {
+	if s.ConnectionParams != (sinkConnectionParamsV2{}) {
+		return s.ConnectionParams
+	}
+	return sinkConnectionParamsV2{
+		Host:                        s.Host,
+		Port:                        s.Port,
+		HttpPort:                    s.HttpPort,
+		Database:                    s.Database,
+		Username:                    s.Username,
+		Password:                    s.Password,
+		Secure:                      s.Secure,
+		SkipCertificateVerification: s.SkipCertificateVerification,
+	}
+}
+
 func convertSink(v2 pipelineJSONv2) sink {
-	cp := v2.Sink.ConnectionParams
+	cp := sinkConnParams(v2.Sink)
 	s := sink{
 		Type: v2.Sink.Kind,
 		ConnectionParams: clickhouseConnectionParams{

--- a/glassflow-api/internal/api/migrate_preview.go
+++ b/glassflow-api/internal/api/migrate_preview.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -249,6 +250,17 @@ func sinkConnParams(s clickhouseSinkV2) sinkConnectionParamsV2 {
 	}
 }
 
+// decodeBase64Password decodes a base64-encoded password back to plaintext.
+// v2 pipelines stored the ClickHouse password base64-encoded in the JSON;
+// v3 expects plaintext (the storage layer handles encryption).
+func decodeBase64Password(p string) string {
+	decoded, err := base64.StdEncoding.DecodeString(p)
+	if err != nil {
+		return p // not base64 — already plaintext
+	}
+	return string(decoded)
+}
+
 func convertSink(v2 pipelineJSONv2) sink {
 	cp := sinkConnParams(v2.Sink)
 	s := sink{
@@ -259,7 +271,7 @@ func convertSink(v2 pipelineJSONv2) sink {
 			HTTPPort:                    cp.HttpPort,
 			Database:                    cp.Database,
 			Username:                    cp.Username,
-			Password:                    cp.Password,
+			Password:                    decodeBase64Password(cp.Password),
 			Secure:                      cp.Secure,
 			SkipCertificateVerification: cp.SkipCertificateVerification,
 		},

--- a/glassflow-api/internal/api/migrate_preview.go
+++ b/glassflow-api/internal/api/migrate_preview.go
@@ -154,11 +154,15 @@ func convertTransforms(v2 pipelineJSONv2) []pipelineTransform {
 		if sourceID == "" {
 			sourceID = t.Topic
 		}
+		dedupKey := t.Deduplication.Key
+		if dedupKey == "" {
+			dedupKey = t.Deduplication.IDField
+		}
 		transforms = append(transforms, pipelineTransform{
 			Type:     transformTypeDedup,
 			SourceID: sourceID,
 			Config: transformParams{
-				Key:        t.Deduplication.Key,
+				Key:        dedupKey,
 				TimeWindow: t.Deduplication.Window,
 			},
 		})

--- a/glassflow-api/internal/api/migrate_preview.go
+++ b/glassflow-api/internal/api/migrate_preview.go
@@ -1,0 +1,283 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/models"
+)
+
+func MigratePreviewDocs() huma.Operation {
+	return huma.Operation{
+		OperationID: "migrate-pipeline-preview",
+		Method:      http.MethodPost,
+		Summary:     "Convert a v2 pipeline request to v3 format",
+		Description: "Accepts a v2 pipeline JSON and returns the equivalent v3 pipeline JSON. Pure transformation — no pipeline is created.",
+	}
+}
+
+type MigratePreviewInput struct {
+	Body pipelineJSONv2
+}
+
+type MigratePreviewResponse struct {
+	Body pipelineJSON
+}
+
+func (h *handler) migratePipelinePreview(_ context.Context, input *MigratePreviewInput) (*MigratePreviewResponse, error) {
+	out, err := convertV2ToV3(input.Body)
+	if err != nil {
+		return nil, &ErrorDetail{
+			Status:  http.StatusUnprocessableEntity,
+			Code:    "unprocessable_entity",
+			Message: "failed to convert v2 pipeline to v3",
+			Details: map[string]any{"error": err.Error()},
+		}
+	}
+	return &MigratePreviewResponse{Body: out}, nil
+}
+
+// convertV2ToV3 converts a v2 pipeline request JSON to the v3 format.
+func convertV2ToV3(v2 pipelineJSONv2) (pipelineJSON, error) {
+	sources, err := convertSources(v2)
+	if err != nil {
+		return pipelineJSON{}, err
+	}
+
+	out := pipelineJSON{
+		Version:    "v3",
+		PipelineID: v2.PipelineID,
+		Name:       v2.Name,
+		Sources:    sources,
+		Transforms: convertTransforms(v2),
+		Sink:       convertSink(v2),
+		Metadata:   v2.Metadata,
+	}
+
+	if v2.Join.Enabled {
+		j, err := convertJoin(v2)
+		if err != nil {
+			return pipelineJSON{}, err
+		}
+		out.Join = &j
+	}
+
+	return out, nil
+}
+
+func convertSources(v2 pipelineJSONv2) ([]source, error) {
+	sources := make([]source, 0, len(v2.Source.Topics))
+	for _, t := range v2.Source.Topics {
+		sourceID := t.ID
+		if sourceID == "" {
+			sourceID = t.Topic
+		}
+
+		s := source{
+			Type:                       v2.Source.Type,
+			SourceID:                   sourceID,
+			Topic:                      t.Topic,
+			ConsumerGroupInitialOffset: t.ConsumerGroupInitialOffset,
+			SchemaVersion:              t.SchemaVersion,
+			SchemaFields:               extractSchemaFields(v2.Schema.Fields, sourceID),
+		}
+
+		if t.SchemaRegistry.URL != "" {
+			sr := t.SchemaRegistry
+			s.SchemaRegistry = &models.SchemaRegistryConfig{
+				URL:       sr.URL,
+				APIKey:    sr.APIKey,
+				APISecret: sr.APISecret,
+			}
+		}
+
+		if v2.Source.ConnectionParams != nil {
+			cp := v2.Source.ConnectionParams
+			s.ConnectionParams = &kafkaConnectionParams{
+				Brokers:             cp.Brokers,
+				SASLMechanism:       cp.SASLMechanism,
+				SASLProtocol:        cp.SASLProtocol,
+				SkipAuth:            cp.SkipAuth,
+				SASLUsername:        cp.SASLUsername,
+				SASLPassword:        cp.SASLPassword,
+				SkipTLSVerification: cp.SkipTLSVerification,
+				TLSRoot:             cp.TLSRoot,
+				TLSCert:             cp.TLSCert,
+				TLSKey:              cp.TLSKey,
+				KerberosServiceName: cp.KerberosServiceName,
+				KerberosRealm:       cp.KerberosRealm,
+				KerberosKeytab:      cp.KerberosKeytab,
+				KerberosConfig:      cp.KerberosConfig,
+			}
+		}
+
+		sources = append(sources, s)
+	}
+	return sources, nil
+}
+
+func extractSchemaFields(fields []schemaFieldV2, sourceID string) []models.Field {
+	var out []models.Field
+	for _, f := range fields {
+		if f.SourceID == sourceID {
+			out = append(out, models.Field{Name: f.Name, Type: f.Type})
+		}
+	}
+	return out
+}
+
+func convertTransforms(v2 pipelineJSONv2) []pipelineTransform {
+	var transforms []pipelineTransform
+
+	for _, t := range v2.Source.Topics {
+		if !t.Deduplication.Enabled {
+			continue
+		}
+		sourceID := t.ID
+		if sourceID == "" {
+			sourceID = t.Topic
+		}
+		transforms = append(transforms, pipelineTransform{
+			Type:     transformTypeDedup,
+			SourceID: sourceID,
+			Config: transformParams{
+				Key:        t.Deduplication.Key,
+				TimeWindow: t.Deduplication.Window,
+			},
+		})
+	}
+
+	if v2.Filter.Enabled {
+		sourceID := v2FirstSourceID(v2)
+		transforms = append(transforms, pipelineTransform{
+			Type:     transformTypeFilter,
+			SourceID: sourceID,
+			Config:   transformParams{Expression: v2.Filter.Expression},
+		})
+	}
+
+	if v2.StatelessTransformation.Enabled {
+		sourceID := v2.StatelessTransformation.SourceID
+		if sourceID == "" {
+			sourceID = v2FirstSourceID(v2)
+		}
+		transforms = append(transforms, pipelineTransform{
+			Type:     transformTypeStateless,
+			SourceID: sourceID,
+			Config:   transformParams{Transforms: v2.StatelessTransformation.Config.Transform},
+		})
+	}
+
+	return transforms
+}
+
+func convertJoin(v2 pipelineJSONv2) (join, error) {
+	var leftSrc, rightSrc joinSourceV2
+	found := 0
+	for _, s := range v2.Join.Sources {
+		switch s.Orientation {
+		case "left":
+			leftSrc = s
+			found++
+		case "right":
+			rightSrc = s
+			found++
+		}
+	}
+	if found != 2 {
+		return join{}, fmt.Errorf("join requires exactly one left and one right source, found %d oriented sources", found)
+	}
+
+	outputFields := make([]joinOutputField, 0, len(v2.Schema.Fields))
+	for _, f := range v2.Schema.Fields {
+		of := joinOutputField{
+			SourceID: f.SourceID,
+			Name:     f.Name,
+		}
+		if f.ColumnName != "" {
+			of.OutputName = f.ColumnName
+		}
+		outputFields = append(outputFields, of)
+	}
+
+	return join{
+		Enabled: true,
+		Type:    v2.Join.Kind,
+		LeftSource: joinSource{
+			SourceID:   leftSrc.SourceID,
+			Key:        leftSrc.Key,
+			TimeWindow: leftSrc.Window,
+		},
+		RightSource: joinSource{
+			SourceID:   rightSrc.SourceID,
+			Key:        rightSrc.Key,
+			TimeWindow: rightSrc.Window,
+		},
+		OutputFields: outputFields,
+	}, nil
+}
+
+func convertSink(v2 pipelineJSONv2) sink {
+	cp := v2.Sink.ConnectionParams
+	s := sink{
+		Type: v2.Sink.Kind,
+		ConnectionParams: clickhouseConnectionParams{
+			Host:                        cp.Host,
+			Port:                        cp.Port,
+			HTTPPort:                    cp.HttpPort,
+			Database:                    cp.Database,
+			Username:                    cp.Username,
+			Password:                    cp.Password,
+			Secure:                      cp.Secure,
+			SkipCertificateVerification: cp.SkipCertificateVerification,
+		},
+		Table:        v2.Sink.Table,
+		MaxBatchSize: v2.Sink.MaxBatchSize,
+		MaxDelayTime: v2.Sink.MaxDelayTime,
+		Mapping:      convertSinkMapping(v2),
+	}
+	return s
+}
+
+func convertSinkMapping(v2 pipelineJSONv2) []sinkMappingEntry {
+	// Prefer explicit table_mapping (v2 newer format)
+	if len(v2.Sink.TableMapping) > 0 {
+		entries := make([]sinkMappingEntry, len(v2.Sink.TableMapping))
+		for i, m := range v2.Sink.TableMapping {
+			entries[i] = sinkMappingEntry{
+				Name:       m.Name,
+				ColumnName: m.ColumnName,
+				ColumnType: m.ColumnType,
+			}
+		}
+		return entries
+	}
+
+	// Fall back to schema fields with column mapping
+	var entries []sinkMappingEntry
+	for _, f := range v2.Schema.Fields {
+		if f.ColumnName == "" {
+			continue
+		}
+		entries = append(entries, sinkMappingEntry{
+			Name:       f.Name,
+			ColumnName: f.ColumnName,
+			ColumnType: f.ColumnType,
+		})
+	}
+	return entries
+}
+
+func v2FirstSourceID(v2 pipelineJSONv2) string {
+	if len(v2.Source.Topics) == 0 {
+		return ""
+	}
+	t := v2.Source.Topics[0]
+	if t.ID != "" {
+		return t.ID
+	}
+	return t.Topic
+}

--- a/glassflow-api/internal/api/migrate_preview_test.go
+++ b/glassflow-api/internal/api/migrate_preview_test.go
@@ -1,0 +1,322 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/models"
+)
+
+var baseConnectionParams = &sourceConnectionParamsV2{
+	Brokers:       []string{"broker:9092"},
+	SASLMechanism: "PLAIN",
+	SASLProtocol:  "SASL_PLAINTEXT",
+	SASLUsername:  "user",
+	SASLPassword:  "pass",
+}
+
+var baseSinkParams = sinkConnectionParamsV2{
+	Host:     "ch-host",
+	Port:     "9000",
+	HttpPort: "8123",
+	Database: "db",
+	Username: "default",
+	Password: "pass",
+	Secure:   false,
+}
+
+func TestConvertV2ToV3_IngestOnly(t *testing.T) {
+	v2 := pipelineJSONv2{
+		PipelineID: "pipe-1",
+		Name:       "Ingest Only",
+		Source: pipelineSourceV2{
+			Type:             "kafka",
+			ConnectionParams: baseConnectionParams,
+			Topics: []kafkaTopicV2{
+				{ID: "orders", Topic: "orders-topic"},
+			},
+		},
+		Schema: schemaV2{
+			Fields: []schemaFieldV2{
+				{SourceID: "orders", Name: "id", Type: "string", ColumnName: "id", ColumnType: "String"},
+				{SourceID: "orders", Name: "amount", Type: "float", ColumnName: "amount", ColumnType: "Float64"},
+			},
+		},
+		Sink: clickhouseSinkV2{
+			Kind:             "clickhouse",
+			ConnectionParams: baseSinkParams,
+			Table:            "orders_table",
+			MaxBatchSize:     1000,
+		},
+	}
+
+	out, err := convertV2ToV3(v2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if out.Version != "v3" {
+		t.Errorf("version = %q, want v3", out.Version)
+	}
+	if out.PipelineID != "pipe-1" {
+		t.Errorf("pipeline_id = %q, want pipe-1", out.PipelineID)
+	}
+	if len(out.Sources) != 1 {
+		t.Fatalf("len(sources) = %d, want 1", len(out.Sources))
+	}
+	src := out.Sources[0]
+	if src.SourceID != "orders" {
+		t.Errorf("source_id = %q, want orders", src.SourceID)
+	}
+	if src.Topic != "orders-topic" {
+		t.Errorf("topic = %q, want orders-topic", src.Topic)
+	}
+	if len(src.SchemaFields) != 2 {
+		t.Errorf("len(schema_fields) = %d, want 2", len(src.SchemaFields))
+	}
+	if len(out.Transforms) != 0 {
+		t.Errorf("unexpected transforms: %v", out.Transforms)
+	}
+	if out.Join != nil {
+		t.Errorf("unexpected join")
+	}
+	if len(out.Sink.Mapping) != 2 {
+		t.Errorf("len(sink.mapping) = %d, want 2", len(out.Sink.Mapping))
+	}
+}
+
+func TestConvertV2ToV3_TopicIDFallback(t *testing.T) {
+	v2 := pipelineJSONv2{
+		PipelineID: "pipe-2",
+		Source: pipelineSourceV2{
+			Type:             "kafka",
+			ConnectionParams: baseConnectionParams,
+			Topics: []kafkaTopicV2{
+				{ID: "", Topic: "events-topic"}, // empty ID — should use topic name
+			},
+		},
+		Schema: schemaV2{
+			Fields: []schemaFieldV2{
+				{SourceID: "events-topic", Name: "ts", Type: "int", ColumnName: "ts", ColumnType: "Int64"},
+			},
+		},
+		Sink: clickhouseSinkV2{Kind: "clickhouse", ConnectionParams: baseSinkParams, Table: "t"},
+	}
+
+	out, err := convertV2ToV3(v2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Sources[0].SourceID != "events-topic" {
+		t.Errorf("source_id = %q, want events-topic", out.Sources[0].SourceID)
+	}
+	if len(out.Sources[0].SchemaFields) != 1 {
+		t.Errorf("schema_fields not matched by topic name fallback")
+	}
+}
+
+func TestConvertV2ToV3_DedupPerTopic(t *testing.T) {
+	v2 := pipelineJSONv2{
+		PipelineID: "pipe-3",
+		Source: pipelineSourceV2{
+			Type:             "kafka",
+			ConnectionParams: baseConnectionParams,
+			Topics: []kafkaTopicV2{
+				{
+					ID:    "orders",
+					Topic: "orders-topic",
+					Deduplication: dedupConfigV2{
+						Enabled: true,
+						Key:     "order_id",
+						Window:  models.JSONDuration{},
+					},
+				},
+			},
+		},
+		Schema: schemaV2{Fields: []schemaFieldV2{{SourceID: "orders", Name: "order_id", Type: "string", ColumnName: "order_id", ColumnType: "String"}}},
+		Sink:   clickhouseSinkV2{Kind: "clickhouse", ConnectionParams: baseSinkParams, Table: "t"},
+	}
+
+	out, err := convertV2ToV3(v2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out.Transforms) != 1 {
+		t.Fatalf("len(transforms) = %d, want 1", len(out.Transforms))
+	}
+	tr := out.Transforms[0]
+	if tr.Type != transformTypeDedup {
+		t.Errorf("transform type = %q, want dedup", tr.Type)
+	}
+	if tr.SourceID != "orders" {
+		t.Errorf("transform source_id = %q, want orders", tr.SourceID)
+	}
+	if tr.Config.Key != "order_id" {
+		t.Errorf("transform key = %q, want order_id", tr.Config.Key)
+	}
+}
+
+func TestConvertV2ToV3_Filter(t *testing.T) {
+	v2 := pipelineJSONv2{
+		PipelineID: "pipe-4",
+		Source: pipelineSourceV2{
+			Type:             "kafka",
+			ConnectionParams: baseConnectionParams,
+			Topics:           []kafkaTopicV2{{ID: "src", Topic: "t"}},
+		},
+		Filter: pipelineFilterV2{Enabled: true, Expression: "amount > 0"},
+		Schema: schemaV2{Fields: []schemaFieldV2{{SourceID: "src", Name: "amount", Type: "float", ColumnName: "amount", ColumnType: "Float64"}}},
+		Sink:   clickhouseSinkV2{Kind: "clickhouse", ConnectionParams: baseSinkParams, Table: "t"},
+	}
+
+	out, err := convertV2ToV3(v2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out.Transforms) != 1 || out.Transforms[0].Type != transformTypeFilter {
+		t.Fatalf("expected 1 filter transform, got %v", out.Transforms)
+	}
+	if out.Transforms[0].Config.Expression != "amount > 0" {
+		t.Errorf("expression = %q, want 'amount > 0'", out.Transforms[0].Config.Expression)
+	}
+}
+
+func TestConvertV2ToV3_StatelessTransformation(t *testing.T) {
+	v2 := pipelineJSONv2{
+		PipelineID: "pipe-5",
+		Source: pipelineSourceV2{
+			Type:             "kafka",
+			ConnectionParams: baseConnectionParams,
+			Topics:           []kafkaTopicV2{{ID: "src", Topic: "t"}},
+		},
+		StatelessTransformation: models.StatelessTransformation{
+			Enabled:  true,
+			SourceID: "src",
+			Config: models.StatelessTransformationsConfig{
+				Transform: []models.Transform{{Expression: "upper(name)", OutputName: "name_upper", OutputType: "string"}},
+			},
+		},
+		Schema: schemaV2{Fields: []schemaFieldV2{{SourceID: "src", Name: "name", Type: "string", ColumnName: "name_upper", ColumnType: "String"}}},
+		Sink:   clickhouseSinkV2{Kind: "clickhouse", ConnectionParams: baseSinkParams, Table: "t"},
+	}
+
+	out, err := convertV2ToV3(v2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out.Transforms) != 1 || out.Transforms[0].Type != transformTypeStateless {
+		t.Fatalf("expected 1 stateless transform, got %v", out.Transforms)
+	}
+	if len(out.Transforms[0].Config.Transforms) != 1 {
+		t.Errorf("expected 1 transform rule")
+	}
+}
+
+func TestConvertV2ToV3_Join(t *testing.T) {
+	v2 := pipelineJSONv2{
+		PipelineID: "pipe-6",
+		Source: pipelineSourceV2{
+			Type:             "kafka",
+			ConnectionParams: baseConnectionParams,
+			Topics: []kafkaTopicV2{
+				{ID: "orders", Topic: "orders-topic"},
+				{ID: "users", Topic: "users-topic"},
+			},
+		},
+		Join: pipelineJoinV2{
+			Enabled: true,
+			Kind:    "temporal",
+			Sources: []joinSourceV2{
+				{SourceID: "orders", Key: "customer_id", Window: models.JSONDuration{}, Orientation: "left"},
+				{SourceID: "users", Key: "user_id", Window: models.JSONDuration{}, Orientation: "right"},
+			},
+		},
+		Schema: schemaV2{
+			Fields: []schemaFieldV2{
+				{SourceID: "orders", Name: "order_id", Type: "string", ColumnName: "ORDER_ID", ColumnType: "String"},
+				{SourceID: "users", Name: "name", Type: "string", ColumnName: "customer_name", ColumnType: "String"},
+			},
+		},
+		Sink: clickhouseSinkV2{Kind: "clickhouse", ConnectionParams: baseSinkParams, Table: "t"},
+	}
+
+	out, err := convertV2ToV3(v2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Join == nil {
+		t.Fatal("expected join, got nil")
+	}
+	if !out.Join.Enabled {
+		t.Error("join.enabled should be true")
+	}
+	if out.Join.LeftSource.SourceID != "orders" {
+		t.Errorf("left source = %q, want orders", out.Join.LeftSource.SourceID)
+	}
+	if out.Join.RightSource.SourceID != "users" {
+		t.Errorf("right source = %q, want users", out.Join.RightSource.SourceID)
+	}
+	if len(out.Join.OutputFields) != 2 {
+		t.Errorf("len(output_fields) = %d, want 2", len(out.Join.OutputFields))
+	}
+	if out.Join.OutputFields[0].OutputName != "ORDER_ID" {
+		t.Errorf("output_name = %q, want ORDER_ID", out.Join.OutputFields[0].OutputName)
+	}
+}
+
+func TestConvertV2ToV3_SinkMappingFromTableMapping(t *testing.T) {
+	v2 := pipelineJSONv2{
+		PipelineID: "pipe-7",
+		Source: pipelineSourceV2{
+			Type:             "kafka",
+			ConnectionParams: baseConnectionParams,
+			Topics:           []kafkaTopicV2{{ID: "src", Topic: "t"}},
+		},
+		Schema: schemaV2{Fields: []schemaFieldV2{{SourceID: "src", Name: "id", Type: "string"}}},
+		Sink: clickhouseSinkV2{
+			Kind:             "clickhouse",
+			ConnectionParams: baseSinkParams,
+			Table:            "t",
+			TableMapping: []tableMappingEntryV2{
+				{Name: "id", ColumnName: "event_id", ColumnType: "String"},
+			},
+		},
+	}
+
+	out, err := convertV2ToV3(v2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out.Sink.Mapping) != 1 {
+		t.Fatalf("len(mapping) = %d, want 1", len(out.Sink.Mapping))
+	}
+	if out.Sink.Mapping[0].ColumnName != "event_id" {
+		t.Errorf("column_name = %q, want event_id", out.Sink.Mapping[0].ColumnName)
+	}
+}
+
+func TestConvertV2ToV3_SchemaFieldsDropColumnInfo(t *testing.T) {
+	v2 := pipelineJSONv2{
+		PipelineID: "pipe-8",
+		Source: pipelineSourceV2{
+			Type:             "kafka",
+			ConnectionParams: baseConnectionParams,
+			Topics:           []kafkaTopicV2{{ID: "src", Topic: "t"}},
+		},
+		Schema: schemaV2{
+			Fields: []schemaFieldV2{
+				{SourceID: "src", Name: "id", Type: "string", ColumnName: "id", ColumnType: "String"},
+			},
+		},
+		Sink: clickhouseSinkV2{Kind: "clickhouse", ConnectionParams: baseSinkParams, Table: "t"},
+	}
+
+	out, err := convertV2ToV3(v2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// schema_fields in sources should only have name+type, no column info
+	sf := out.Sources[0].SchemaFields[0]
+	if sf.Name != "id" || sf.Type != "string" {
+		t.Errorf("schema field = {%q %q}, want {id string}", sf.Name, sf.Type)
+	}
+}

--- a/glassflow-api/internal/api/pipeline.go
+++ b/glassflow-api/internal/api/pipeline.go
@@ -173,7 +173,7 @@ type clickhouseSinkV2 struct {
 	Password                    string `json:"password,omitempty"`
 	Secure                      bool   `json:"secure,omitempty"`
 	SkipCertificateVerification bool   `json:"skip_certificate_verification,omitempty"`
-	Table            string                 `json:"table"`
+	Table        string                 `json:"table"`
 	MaxBatchSize     int                    `json:"max_batch_size"`
 	MaxDelayTime     models.JSONDuration    `json:"max_delay_time"`
 	SourceID         string                 `json:"source_id,omitempty"`

--- a/glassflow-api/internal/api/pipeline.go
+++ b/glassflow-api/internal/api/pipeline.go
@@ -163,7 +163,16 @@ type sinkConnectionParamsV2 struct {
 type clickhouseSinkV2 struct {
 	Kind             string                 `json:"type"`
 	Provider         string                 `json:"provider,omitempty"`
-	ConnectionParams sinkConnectionParamsV2 `json:"connection_params"`
+	ConnectionParams sinkConnectionParamsV2 `json:"connection_params,omitempty"`
+	// Flat fields — older v2 format stores connection params at top level
+	Host                        string `json:"host,omitempty"`
+	Port                        string `json:"port,omitempty"`
+	HttpPort                    string `json:"http_port,omitempty"`
+	Database                    string `json:"database,omitempty"`
+	Username                    string `json:"username,omitempty"`
+	Password                    string `json:"password,omitempty"`
+	Secure                      bool   `json:"secure,omitempty"`
+	SkipCertificateVerification bool   `json:"skip_certificate_verification,omitempty"`
 	Table            string                 `json:"table"`
 	MaxBatchSize     int                    `json:"max_batch_size"`
 	MaxDelayTime     models.JSONDuration    `json:"max_delay_time"`

--- a/glassflow-api/internal/api/pipeline.go
+++ b/glassflow-api/internal/api/pipeline.go
@@ -166,20 +166,20 @@ type clickhouseSinkV2 struct {
 	Provider         string                 `json:"provider,omitempty"`
 	ConnectionParams sinkConnectionParamsV2 `json:"connection_params,omitempty"`
 	// Flat fields — older v2 format stores connection params at top level
-	Host                        string `json:"host,omitempty"`
-	Port                        string `json:"port,omitempty"`
-	HttpPort                    string `json:"http_port,omitempty"`
-	Database                    string `json:"database,omitempty"`
-	Username                    string `json:"username,omitempty"`
-	Password                    string `json:"password,omitempty"`
-	Secure                      bool   `json:"secure,omitempty"`
-	SkipCertificateVerification bool   `json:"skip_certificate_verification,omitempty"`
-	Table        string                 `json:"table"`
-	MaxBatchSize     int                    `json:"max_batch_size"`
-	MaxDelayTime     models.JSONDuration    `json:"max_delay_time"`
-	SourceID         string                 `json:"source_id,omitempty"`
-	TableMapping     []tableMappingEntryV2  `json:"mapping,omitempty"`
-	TableMappingV1   []tableMappingEntryV1  `json:"table_mapping,omitempty"`
+	Host                        string                `json:"host,omitempty"`
+	Port                        string                `json:"port,omitempty"`
+	HttpPort                    string                `json:"http_port,omitempty"`
+	Database                    string                `json:"database,omitempty"`
+	Username                    string                `json:"username,omitempty"`
+	Password                    string                `json:"password,omitempty"`
+	Secure                      bool                  `json:"secure,omitempty"`
+	SkipCertificateVerification bool                  `json:"skip_certificate_verification,omitempty"`
+	Table                       string                `json:"table"`
+	MaxBatchSize                int                   `json:"max_batch_size"`
+	MaxDelayTime                models.JSONDuration   `json:"max_delay_time"`
+	SourceID                    string                `json:"source_id,omitempty"`
+	TableMapping                []tableMappingEntryV2 `json:"mapping,omitempty"`
+	TableMappingV1              []tableMappingEntryV1 `json:"table_mapping,omitempty"`
 }
 
 type tableMappingEntryV1 struct {

--- a/glassflow-api/internal/api/pipeline.go
+++ b/glassflow-api/internal/api/pipeline.go
@@ -139,6 +139,7 @@ type topicSchemaFieldV1 struct {
 type dedupConfigV2 struct {
 	Enabled bool                `json:"enabled"`
 	Key     string              `json:"key,omitempty"`
+	IDField string              `json:"id_field,omitempty"` // older v2 format used id_field instead of key
 	Window  models.JSONDuration `json:"time_window,omitempty"`
 }
 

--- a/glassflow-api/internal/api/router.go
+++ b/glassflow-api/internal/api/router.go
@@ -79,6 +79,7 @@ func NewRouter(
 	registerHumaHandler("/api/v1/pipeline/{id}/dlq/purge", h.purgeDLQ, log, PurgeDLQDocs(), humaAPI, h.usageStatsClient)
 	registerHumaHandler("/api/v1/pipeline/{id}/dlq/consume", h.consumeDLQ, log, ConsumeDLQDocs(), humaAPI, h.usageStatsClient)
 	registerHumaHandler("/api/v1/pipeline/{id}/dlq/state", h.getDLQState, log, GetDLQStateDocs(), humaAPI, h.usageStatsClient)
+	registerHumaHandler("/api/v1/pipeline/migrate-preview", h.migratePipelinePreview, log, MigratePreviewDocs(), humaAPI, h.usageStatsClient)
 	registerHumaHandler("/api/v1/pipeline", h.createPipeline, log, CreatePipelineDocs(), humaAPI, h.usageStatsClient)
 	registerHumaHandler("/api/v1/pipeline/{id}/stop", h.stopPipeline, log, StopPipelineDocs(), humaAPI, h.usageStatsClient)
 	registerHumaHandler("/api/v1/pipeline/{id}/terminate", h.terminatePipeline, log, TerminatePipelineDocs(), humaAPI, h.usageStatsClient)


### PR DESCRIPTION
## What

Adds a stateless `POST /api/v1/pipeline/migrate-preview` endpoint that converts a v2 pipeline request JSON to the v3 format. No pipeline is created — pure JSON transformation, useful for users migrating existing scripts/configs.

## Conversion

| v2 | v3 |
|---|---|
| `source.topics[]` | `sources[]` (one per topic) |
| `schema.fields[].{name,type}` per source | `sources[].schema_fields` |
| `schema.fields[].{column_name,column_type}` | `sink.mapping` |
| `topics[].deduplication` | `transforms[]` type=dedup |
| `filter` | `transforms[]` type=filter |
| `stateless_transformation` | `transforms[]` type=stateless |
| `join.sources[left/right]` | `join.{left_source,right_source}` |
| `sink.mapping` / `schema` fields | `sink.mapping` |

Topic ID falls back to topic name when `id` is empty (handles older v2 pipelines).

## Usage

```bash
curl -X POST http://localhost:8081/api/v1/pipeline/migrate-preview \
  -H 'Content-Type: application/json' \
  --data @bin/4ingest-1sink-pipeline.json
```

Returns valid v3 JSON that can be posted directly to `POST /api/v1/pipeline`.