### PR TITLE
fix: read sink source_id from sink_configs instead of connections.config ETL-1035

### DIFF
--- a/glassflow-api/internal/storage/postgres/component_configs.go
+++ b/glassflow-api/internal/storage/postgres/component_configs.go
@@ -272,6 +272,23 @@ func (s *PostgresStorage) getSinkConfig(ctx context.Context, tx pgx.Tx, pipeline
 	return &result, nil
 }
 
+// getSinkSourceID returns the source_id stored in sink_configs for the given pipeline.
+// Used as a fallback when SinkComponentConfig.SourceID is not populated in connections.config
+// (e.g. pipelines migrated from v2 where source_id was not stored there).
+func (s *PostgresStorage) getSinkSourceID(ctx context.Context, tx pgx.Tx, pipelineID string) (string, error) {
+	var sourceID string
+	err := tx.QueryRow(ctx, `
+		SELECT source_id FROM sink_configs WHERE pipeline_id = $1 LIMIT 1
+	`, pipelineID).Scan(&sourceID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return "", models.ErrRecordNotFound
+		}
+		return "", fmt.Errorf("get sink source_id: %w", err)
+	}
+	return sourceID, nil
+}
+
 func (s *PostgresStorage) GetStatelessTransformationConfig(ctx context.Context, pipelineID, sourceID, sourceSchemaVersion string) (*models.TransformationConfig, error) {
 	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{
 		IsoLevel: pgx.ReadCommitted,

--- a/glassflow-api/internal/storage/postgres/entities.go
+++ b/glassflow-api/internal/storage/postgres/entities.go
@@ -609,7 +609,7 @@ func (s *PostgresStorage) getTransformations(ctx context.Context, transIDs []uui
 		return make(map[string]Transformation), nil
 	}
 
-	query := `SELECT type, config FROM transformations WHERE id = ANY($1)`
+	query := `SELECT id, type, config FROM transformations WHERE id = ANY($1)`
 	rows, err := s.pool.Query(ctx, query, uuidsToArrayArg(transIDs))
 	if err != nil {
 		return nil, fmt.Errorf("query transformations: %w", err)
@@ -618,13 +618,14 @@ func (s *PostgresStorage) getTransformations(ctx context.Context, transIDs []uui
 
 	transformations := make(map[string]Transformation)
 	for rows.Next() {
-		var transType string
+		var transID, transType string
 		var configJSON []byte
-		if err := rows.Scan(&transType, &configJSON); err != nil {
+		if err := rows.Scan(&transID, &transType, &configJSON); err != nil {
 			return nil, fmt.Errorf("scan transformation: %w", err)
 		}
 
 		transformations[transType] = Transformation{
+			ID:     transID,
 			Type:   transType,
 			Config: configJSON,
 		}

--- a/glassflow-api/internal/storage/postgres/pipelines.go
+++ b/glassflow-api/internal/storage/postgres/pipelines.go
@@ -25,6 +25,7 @@ const (
 
 // Transformation represents a pipeline transformation with its type and configuration
 type Transformation struct {
+	ID     string
 	Type   string
 	Config json.RawMessage
 }

--- a/glassflow-api/internal/storage/postgres/pipelines.go
+++ b/glassflow-api/internal/storage/postgres/pipelines.go
@@ -862,7 +862,6 @@ func (s *PostgresStorage) insertClickHouseSink(ctx context.Context, tx pgx.Tx, p
 	sinkConnConfig := models.SinkComponentConfig{
 		ClickHouseConnectionParams: p.Sink.ClickHouseConnectionParams,
 		Batch:                      p.Sink.Batch,
-		SourceID:                   p.Sink.SourceID,
 		Type:                       p.Sink.Type,
 		NATSConsumerName:           p.Sink.NATSConsumerName,
 	}
@@ -890,7 +889,6 @@ func (s *PostgresStorage) updateClickHouseSink(ctx context.Context, tx pgx.Tx, c
 	sinkConnConfig := models.SinkComponentConfig{
 		ClickHouseConnectionParams: p.Sink.ClickHouseConnectionParams,
 		Batch:                      p.Sink.Batch,
-		SourceID:                   p.Sink.SourceID,
 		NATSConsumerName:           p.Sink.NATSConsumerName,
 		Type:                       p.Sink.Type,
 	}
@@ -1309,6 +1307,12 @@ func (s *PostgresStorage) loadConfigsAndSchemaVersionsWithSelection(
 
 		pipelineCfg.SchemaVersions[pipelineCfg.Join.ID] = outputSchema
 	}
+
+	sinkSourceID, err := s.getSinkSourceID(ctx, tx, pipelineCfg.ID)
+	if err != nil {
+		return fmt.Errorf("get sink source ID: %w", err)
+	}
+	pipelineCfg.Sink.SourceID = sinkSourceID
 
 	sinkSourceSchema, found := pipelineCfg.SchemaVersions[pipelineCfg.Sink.SourceID]
 	if !found {

--- a/glassflow-api/internal/storage/postgres/reconstruct.go
+++ b/glassflow-api/internal/storage/postgres/reconstruct.go
@@ -171,6 +171,8 @@ func reconstructJoinConfig(transformations map[string]Transformation) (models.Jo
 		if err := json.Unmarshal(joinTrans.Config, &joinConfig); err != nil {
 			return joinConfig, fmt.Errorf("unmarshal join config: %w", err)
 		}
+		// The v2 config blob may not contain the ID — always use the DB row ID as source of truth.
+		joinConfig.ID = joinTrans.ID
 	}
 	return joinConfig, nil
 }
@@ -193,6 +195,8 @@ func reconstructStatelessTransformationConfig(transformations map[string]Transfo
 		if err := json.Unmarshal(statelessTrans.Config, &statelessConfig); err != nil {
 			return statelessConfig, fmt.Errorf("unmarshal stateless transformation config: %w", err)
 		}
+		// Always use the DB row ID — the v2 config blob may store a string alias, not the UUID.
+		statelessConfig.ID = statelessTrans.ID
 	}
 	return statelessConfig, nil
 }


### PR DESCRIPTION
## Summary

- `source_id` was incorrectly stored in the `connections.config` JSONB blob alongside ClickHouse connection params during pipeline creation
- On load, `Sink.SourceID` was read from `connections.config` — worked for newly created v3 pipelines but failed for pipelines migrated from v2 (where `source_id` is only in `sink_configs`)
- Remove `SourceID` from `SinkComponentConfig` written to `connections.config`
- Always read `source_id` from `sink_configs` at load time via a new `getSinkSourceID` helper