### PR TITLE
ETL-1020: add MaxMsgs to NatsStreamResources pipeline config

### DIFF
--- a/glassflow-api/go.mod
+++ b/glassflow-api/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/dgraph-io/badger/v4 v4.8.0
 	github.com/docker/go-connections v0.6.0
 	github.com/expr-lang/expr v1.17.7
-	github.com/glassflow/glassflow-etl-k8s-operator v1.9.1-0.20260330111818-3c5d7bf686bc
+	github.com/glassflow/glassflow-etl-k8s-operator v1.9.1-0.20260428094045-49ae7481a5fa
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0

--- a/glassflow-api/go.sum
+++ b/glassflow-api/go.sum
@@ -83,6 +83,8 @@ github.com/fxamacker/cbor/v2 v2.8.0 h1:fFtUGXUzXPHTIUdne5+zzMPTfffl3RD5qYnkY40vt
 github.com/fxamacker/cbor/v2 v2.8.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/glassflow/glassflow-etl-k8s-operator v1.9.1-0.20260330111818-3c5d7bf686bc h1:fvj5kJPmwZVhj0cSk4vWEZa3eAVqnFnwflVtls//FJo=
 github.com/glassflow/glassflow-etl-k8s-operator v1.9.1-0.20260330111818-3c5d7bf686bc/go.mod h1:EK8L9I3zDKSfg8wObeE2P/L08mGJxOsOfxGw5j2bwiI=
+github.com/glassflow/glassflow-etl-k8s-operator v1.9.1-0.20260428094045-49ae7481a5fa h1:6r8RoUuzXSIE8TpSBPbTttK0IQyLR9V8An7gB7YF6rw=
+github.com/glassflow/glassflow-etl-k8s-operator v1.9.1-0.20260428094045-49ae7481a5fa/go.mod h1:CF/+kFFDv+6P9DRNk5wg0GW8J0WwsQ4lNGmUbPonNlQ=
 github.com/go-faster/city v1.0.1 h1:4WAxSZ3V2Ws4QRDrscLEDcibJY8uf41H6AhXDrNDcGw=
 github.com/go-faster/city v1.0.1/go.mod h1:jKcUJId49qdW3L1qKHH/3wPeUstCVpVSXTM6vO3VcTw=
 github.com/go-faster/errors v0.7.1 h1:MkJTnDoEdi9pDabt1dpWf7AA8/BaSYZqibYyhZ20AYg=

--- a/glassflow-api/internal/models/resources.go
+++ b/glassflow-api/internal/models/resources.go
@@ -69,12 +69,25 @@ func newDefaultIngestorComponentResources(replicas *int64) *ComponentResources {
 	}
 }
 
+// defaultNATSMaxMsgs returns the default stream message limit for a pipeline.
+// It is set to 8× the sink batch size (2× MaxAckPending) so the stream can buffer
+// enough messages for the slowest consumer without starving it.
+// Both 0 and -1 mean unlimited in NATS; we always return a positive value here.
+func defaultNATSMaxMsgs(sinkBatchSize int) int64 {
+	if sinkBatchSize > 0 {
+		return int64(sinkBatchSize) * 8
+	}
+	// Fallback: should not happen since batch size is validated before resources are created.
+	return 500_000
+}
+
 func NewDefaultPipelineResources(cfg *PipelineConfig) PipelineResources {
 	r := PipelineResources{
 		Nats: &NatsResources{
 			Stream: &NatsStreamResources{
 				MaxAge:   getEnvOrDefault("NATS_MAX_STREAM_AGE", "24h"),
 				MaxBytes: getEnvOrDefault("NATS_MAX_STREAM_BYTES", "0"),
+				MaxMsgs:  defaultNATSMaxMsgs(cfg.Sink.Batch.MaxBatchSize),
 			},
 		},
 		Sink: &ComponentResources{

--- a/glassflow-api/internal/models/resources.go
+++ b/glassflow-api/internal/models/resources.go
@@ -138,6 +138,9 @@ type NatsResources struct {
 type NatsStreamResources struct {
 	MaxAge   string `json:"maxAge,omitempty"`
 	MaxBytes string `json:"maxBytes,omitempty"`
+	// MaxMsgs is the maximum number of messages per stream. Both 0 and -1 mean unlimited in NATS;
+	// omitting this field (zero value) means use the operator default.
+	MaxMsgs int64 `json:"maxMsgs,omitempty"`
 }
 
 type IngestorResources struct {
@@ -180,6 +183,7 @@ func NewPipelineResourcesWithPolicy(cfg *PipelineConfig, resources PipelineResou
 var PipelineResourcesImmutable = []string{
 	"nats/stream/maxAge",
 	"nats/stream/maxBytes",
+	"nats/stream/maxMsgs",
 	"transform/storage/size",
 }
 
@@ -218,6 +222,9 @@ func validateNatsResources(n *NatsResources) error {
 		if _, err := ParseNATSMaxBytesQuantity(n.Stream.MaxBytes); err != nil {
 			return fmt.Errorf("invalid nats stream maxBytes %q: %w", n.Stream.MaxBytes, err)
 		}
+	}
+	if n.Stream.MaxMsgs < -1 {
+		return fmt.Errorf("invalid nats stream maxMsgs %d: must be -1 (unlimited), 0 (operator default), or a positive value", n.Stream.MaxMsgs)
 	}
 	return nil
 }

--- a/glassflow-api/internal/models/resources_test.go
+++ b/glassflow-api/internal/models/resources_test.go
@@ -172,3 +172,32 @@ func TestParseNATSMaxBytesQuantity(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateNatsResources_MaxMsgs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		maxMsgs int64
+		wantErr bool
+	}{
+		{name: "zero (operator default)", maxMsgs: 0, wantErr: false},
+		{name: "positive value", maxMsgs: 500_000, wantErr: false},
+		{name: "-1 (unlimited)", maxMsgs: -1, wantErr: false},
+		{name: "below -1 is invalid", maxMsgs: -2, wantErr: true},
+		{name: "large negative invalid", maxMsgs: -1_000_000, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			n := &NatsResources{
+				Stream: &NatsStreamResources{MaxMsgs: tt.maxMsgs},
+			}
+			err := validateNatsResources(n)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateNatsResources() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/glassflow-api/internal/models/resources_test.go
+++ b/glassflow-api/internal/models/resources_test.go
@@ -173,6 +173,30 @@ func TestParseNATSMaxBytesQuantity(t *testing.T) {
 	}
 }
 
+func TestDefaultNATSMaxMsgs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		sinkBatchSize int
+		want          int64
+	}{
+		{name: "50k batch (dedup default)", sinkBatchSize: 50_000, want: 400_000},
+		{name: "10k batch (typical sink)", sinkBatchSize: 10_000, want: 80_000},
+		{name: "1k batch (small)", sinkBatchSize: 1_000, want: 8_000},
+		{name: "zero falls back to 500k", sinkBatchSize: 0, want: 500_000},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := defaultNATSMaxMsgs(tt.sinkBatchSize); got != tt.want {
+				t.Errorf("defaultNATSMaxMsgs(%d) = %d, want %d", tt.sinkBatchSize, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestValidateNatsResources_MaxMsgs(t *testing.T) {
 	t.Parallel()
 

--- a/glassflow-api/internal/orchestrator/k8s.go
+++ b/glassflow-api/internal/orchestrator/k8s.go
@@ -703,6 +703,9 @@ func toOperatorNatsResources(n *models.NatsResources) (*operator.NatsResources, 
 			}
 			stream.MaxBytes = maxBytes
 		}
+		if n.Stream.MaxMsgs != 0 {
+			stream.MaxMsgs = n.Stream.MaxMsgs
+		}
 		res.Stream = stream
 	}
 	return res, nil


### PR DESCRIPTION
## Summary

- Adds `maxMsgs` field to `NatsStreamResources` in `models/resources.go` so pipelines can declare a per-stream message cap via the API
- Validates that `maxMsgs` is `>= -1`; both `0` and `-1` mean unlimited in NATS — `0` is the zero-value sentinel for "use operator default", `-1` is an explicit unlimited override
- Adds `nats/stream/maxMsgs` to `PipelineResourcesImmutable` (consistent with `maxAge`/`maxBytes` — cannot be changed after pipeline creation)
- Maps the value through `toOperatorNatsResources` in the k8s orchestrator so the operator CRD carries the limit

## Dependencies

**Blocked on operator PR:** glassflow/glassflow-etl-k8s-operator#172

The vendored operator types need to be updated (`go get` + `go mod vendor`) once that PR is merged and a new operator version is cut. The local vendor edit is not committed (vendor is gitignored).

## Test plan

- [ ] `go test ./internal/models/... -run TestValidateNatsResources_MaxMsgs` — 5 cases pass (0, positive, -1, -2, large negative)
- [ ] `go build ./...` — clean

Closes ETL-1020