### PR TITLE
feat(otlp-receiver): enforce size limits, add back pressure, chunk NATS writes (ETL-1046 ETL-1047 ETL-1048)

### DIFF
--- a/glassflow-api/cmd/glassflow/dedup_component.go
+++ b/glassflow-api/cmd/glassflow/dedup_component.go
@@ -124,11 +124,13 @@ func mainDeduplicatorV2(
 	batchWriter := batchNats.NewBatchWriter(
 		nc.JetStream(),
 		outputRouter,
+		0,
 	)
 
 	dlqWriter := batchNats.NewBatchWriter(
 		nc.JetStream(),
 		dlqSubjectRouter,
+		0,
 	)
 
 	componentSignal, err := componentsignals.NewPublisher(nc)

--- a/glassflow-api/cmd/glassflow/main.go
+++ b/glassflow-api/cmd/glassflow/main.go
@@ -88,7 +88,10 @@ type config struct {
 	UsageStatsPassword       string `default:"" split_words:"true"`
 	UsageStatsInstallationID string `default:"" split_words:"true"`
 
-	OTLPConfigFetcherBaseURL string `default:"" split_words:"true"`
+	OTLPConfigFetcherBaseURL  string `default:"" split_words:"true"`
+	OTLPMaxBodyBytes          int64  `default:"4194304" split_words:"true"` // 4 MiB
+	OTLPMaxConcurrentRequests int    `default:"50" split_words:"true"`
+	OTLPNatsChunkSize         int    `default:"1000" split_words:"true"`
 }
 
 var version = "dev"

--- a/glassflow-api/cmd/glassflow/oltp_receiver.go
+++ b/glassflow-api/cmd/glassflow/oltp_receiver.go
@@ -18,8 +18,8 @@ func mainOLTPReceiver(
 	log *slog.Logger,
 ) error {
 	fetcher := configFetcher.New(cfg.OTLPConfigFetcherBaseURL)
-	otlpDataProcessor := otlp_processor.NewProcessor(fetcher, nc)
-	r, err := oltp_receiver.New(log, otlpDataProcessor)
+	otlpDataProcessor := otlp_processor.NewProcessor(fetcher, nc, cfg.OTLPMaxConcurrentRequests, cfg.OTLPNatsChunkSize)
+	r, err := oltp_receiver.New(log, otlpDataProcessor, cfg.OTLPMaxBodyBytes)
 	if err != nil {
 		return err
 	}

--- a/glassflow-api/internal/batch/nats/nats_batch_writer.go
+++ b/glassflow-api/internal/batch/nats/nats_batch_writer.go
@@ -20,27 +20,49 @@ type subjectRouter interface {
 type BatchWriter struct {
 	js            jetstream.JetStream
 	subjectRouter subjectRouter
+	chunkSize     int
 }
 
-// NewBatchWriter creates a new NATS async batch writer
+// NewBatchWriter creates a new NATS async batch writer.
+// chunkSize controls how many messages are published per async round-trip;
+// use a value <= 0 to publish all messages in a single chunk.
 func NewBatchWriter(
 	js jetstream.JetStream,
 	subjectRouter subjectRouter,
+	chunkSize int,
 ) *BatchWriter {
-	batchWriter := &BatchWriter{
+	return &BatchWriter{
 		js:            js,
 		subjectRouter: subjectRouter,
+		chunkSize:     chunkSize,
 	}
-
-	return batchWriter
 }
 
-// WriteBatch writes a batch of messages to NATS asynchronously
-func (w *BatchWriter) WriteBatch(_ context.Context, messages []models.Message) []models.FailedMessage {
+// WriteBatch writes a batch of messages to NATS asynchronously.
+// Messages are published in chunks to cap peak memory usage from in-flight futures.
+func (w *BatchWriter) WriteBatch(ctx context.Context, messages []models.Message) []models.FailedMessage {
 	if len(messages) == 0 {
 		return nil
 	}
 
+	chunkSize := w.chunkSize
+	if chunkSize <= 0 {
+		chunkSize = len(messages)
+	}
+
+	var failedMessages []models.FailedMessage
+	for i := 0; i < len(messages); i += chunkSize {
+		end := i + chunkSize
+		if end > len(messages) {
+			end = len(messages)
+		}
+		failed := w.writeChunk(ctx, messages[i:end])
+		failedMessages = append(failedMessages, failed...)
+	}
+	return failedMessages
+}
+
+func (w *BatchWriter) writeChunk(_ context.Context, messages []models.Message) []models.FailedMessage {
 	futures := make([]jetstream.PubAckFuture, 0, len(messages))
 	var failedMessages []models.FailedMessage
 
@@ -49,7 +71,6 @@ func (w *BatchWriter) WriteBatch(_ context.Context, messages []models.Message) [
 
 		future, err := w.js.PublishMsgAsync(natsMsg)
 		if err != nil {
-			// Failed to queue for async publishing - treat as failed message
 			failedMessages = append(failedMessages, models.FailedMessage{
 				Message: models.Message{
 					Type:            models.MessageTypeNatsMsg,
@@ -67,7 +88,6 @@ func (w *BatchWriter) WriteBatch(_ context.Context, messages []models.Message) [
 		return failedMessages
 	}
 
-	// Wait for all async publishes to complete
 	<-w.js.PublishAsyncComplete()
 
 	for _, future := range futures {

--- a/glassflow-api/internal/batch/nats/nats_batch_writer_test.go
+++ b/glassflow-api/internal/batch/nats/nats_batch_writer_test.go
@@ -62,7 +62,7 @@ func TestBatchWriter_WriteBatch(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	writer := natsBatch.NewBatchWriter(js, subjectRouter)
+	writer := natsBatch.NewBatchWriter(js, subjectRouter, 0)
 
 	// Create test messages
 	messages := []models.Message{
@@ -121,7 +121,7 @@ func TestBatchWriter_WriteBatchWithHeaders(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	writer := natsBatch.NewBatchWriter(js, subjectRouter)
+	writer := natsBatch.NewBatchWriter(js, subjectRouter, 0)
 
 	// Create message with headers
 	messages := []models.Message{
@@ -235,7 +235,7 @@ func TestBatchWriter_WriteBatchWithJetStreamMsg(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	writer := natsBatch.NewBatchWriter(js, subjectRouter)
+	writer := natsBatch.NewBatchWriter(js, subjectRouter, 0)
 	messages := []models.Message{
 		{
 			Type:                 models.MessageTypeJetstreamMsg,

--- a/glassflow-api/internal/otlp-receiver/server/grpc/grpc.go
+++ b/glassflow-api/internal/otlp-receiver/server/grpc/grpc.go
@@ -19,12 +19,17 @@ type OTLPDataProcessor interface {
 	ProcessMetrics(ctx context.Context, pipelineID string, exportMetricsRequest *colmetricspb.ExportMetricsServiceRequest) error
 }
 
+const grpcMaxRecvMsgSize = 4 * 1024 * 1024 // 4 MiB
+
 func NewGRPCServer(
 	addr string,
 	_ *slog.Logger,
 	processor OTLPDataProcessor,
 ) (*grpc.Server, *health.Server, net.Listener, error) {
-	grpcServer := grpc.NewServer(grpc.UnaryInterceptor(otlpMetricsInterceptor))
+	grpcServer := grpc.NewServer(
+		grpc.UnaryInterceptor(otlpMetricsInterceptor),
+		grpc.MaxRecvMsgSize(grpcMaxRecvMsgSize),
+	)
 
 	grpcHealth := health.NewServer()
 	grpcHealth.SetServingStatus("", healthpb.HealthCheckResponse_NOT_SERVING)

--- a/glassflow-api/internal/otlp-receiver/server/grpc/logs.go
+++ b/glassflow-api/internal/otlp-receiver/server/grpc/logs.go
@@ -2,6 +2,7 @@ package grpc
 
 import (
 	"context"
+	"errors"
 
 	collogspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
 	"google.golang.org/grpc/codes"
@@ -9,6 +10,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal"
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/otlp-receiver/server/processor"
 )
 
 type logServiceServer struct {
@@ -29,6 +31,9 @@ func (s *logServiceServer) Export(
 		return nil, status.Error(codes.InvalidArgument, "missing x-glassflow-pipeline-id header")
 	}
 	if err := s.processor.ProcessLogs(ctx, vals[0], req); err != nil {
+		if errors.Is(err, processor.ErrReceiverOverloaded) {
+			return nil, status.Error(codes.ResourceExhausted, err.Error())
+		}
 		return nil, status.Errorf(codes.Internal, "processing logs: %v", err)
 	}
 	return &collogspb.ExportLogsServiceResponse{}, nil

--- a/glassflow-api/internal/otlp-receiver/server/grpc/metrics.go
+++ b/glassflow-api/internal/otlp-receiver/server/grpc/metrics.go
@@ -2,6 +2,7 @@ package grpc
 
 import (
 	"context"
+	"errors"
 
 	colmetricspb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	"google.golang.org/grpc/codes"
@@ -9,6 +10,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal"
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/otlp-receiver/server/processor"
 )
 
 type metricServiceServer struct {
@@ -29,6 +31,9 @@ func (s *metricServiceServer) Export(
 		return nil, status.Error(codes.InvalidArgument, "missing x-glassflow-pipeline-id header")
 	}
 	if err := s.processor.ProcessMetrics(ctx, vals[0], req); err != nil {
+		if errors.Is(err, processor.ErrReceiverOverloaded) {
+			return nil, status.Error(codes.ResourceExhausted, err.Error())
+		}
 		return nil, status.Errorf(codes.Internal, "processing metrics: %v", err)
 	}
 	return &colmetricspb.ExportMetricsServiceResponse{}, nil

--- a/glassflow-api/internal/otlp-receiver/server/grpc/traces.go
+++ b/glassflow-api/internal/otlp-receiver/server/grpc/traces.go
@@ -2,6 +2,7 @@ package grpc
 
 import (
 	"context"
+	"errors"
 
 	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	"google.golang.org/grpc/codes"
@@ -9,6 +10,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal"
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/otlp-receiver/server/processor"
 )
 
 type traceServiceServer struct {
@@ -29,6 +31,9 @@ func (s *traceServiceServer) Export(
 		return nil, status.Error(codes.InvalidArgument, "missing x-glassflow-pipeline-id header")
 	}
 	if err := s.processor.ProcessTraces(ctx, vals[0], req); err != nil {
+		if errors.Is(err, processor.ErrReceiverOverloaded) {
+			return nil, status.Error(codes.ResourceExhausted, err.Error())
+		}
 		return nil, status.Errorf(codes.Internal, "processing traces: %v", err)
 	}
 	return &coltracepb.ExportTraceServiceResponse{}, nil

--- a/glassflow-api/internal/otlp-receiver/server/http/http.go
+++ b/glassflow-api/internal/otlp-receiver/server/http/http.go
@@ -27,6 +27,7 @@ type handler struct {
 	ready             *atomic.Bool
 	log               *slog.Logger
 	otlpDataProcessor OTLPDataProcessor
+	maxBodyBytes      int64
 }
 
 type healthResponse struct {
@@ -43,6 +44,7 @@ func NewHTTPServer(
 	ready *atomic.Bool,
 	log *slog.Logger,
 	otlpDataProcessor OTLPDataProcessor,
+	maxBodyBytes int64,
 ) *server.Server {
 	r := mux.NewRouter()
 
@@ -58,6 +60,7 @@ func NewHTTPServer(
 		ready:             ready,
 		log:               log,
 		otlpDataProcessor: otlpDataProcessor,
+		maxBodyBytes:      maxBodyBytes,
 	}
 	registerHumaHandler("/healthz", h.healthz, healthzOperation(), humaAPI)
 	registerHumaHandler("/readyz", h.readyz, readyzOperation(), humaAPI)

--- a/glassflow-api/internal/otlp-receiver/server/http/logs.go
+++ b/glassflow-api/internal/otlp-receiver/server/http/logs.go
@@ -1,11 +1,13 @@
 package http
 
 import (
+	"errors"
 	nethttp "net/http"
 
 	collogspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
 
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal"
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/otlp-receiver/server/processor"
 )
 
 func (h handler) exportLogs(w nethttp.ResponseWriter, r *nethttp.Request) {
@@ -16,12 +18,21 @@ func (h handler) exportLogs(w nethttp.ResponseWriter, r *nethttp.Request) {
 	}
 
 	req := &collogspb.ExportLogsServiceRequest{}
-	if err := decodeOTLPRequest(r, req); err != nil {
+	if err := decodeOTLPRequest(r, h.maxBodyBytes, req); err != nil {
+		if errors.Is(err, errRequestTooLarge) {
+			nethttp.Error(w, err.Error(), nethttp.StatusRequestEntityTooLarge)
+			return
+		}
 		nethttp.Error(w, err.Error(), nethttp.StatusBadRequest)
 		return
 	}
 
 	if err := h.otlpDataProcessor.ProcessLogs(r.Context(), pipelineID, req); err != nil {
+		if errors.Is(err, processor.ErrReceiverOverloaded) {
+			w.Header().Set("Retry-After", "1")
+			nethttp.Error(w, err.Error(), nethttp.StatusServiceUnavailable)
+			return
+		}
 		nethttp.Error(w, err.Error(), nethttp.StatusInternalServerError)
 		return
 	}

--- a/glassflow-api/internal/otlp-receiver/server/http/metrics.go
+++ b/glassflow-api/internal/otlp-receiver/server/http/metrics.go
@@ -1,11 +1,13 @@
 package http
 
 import (
+	"errors"
 	nethttp "net/http"
 
 	colmetricspb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal"
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/otlp-receiver/server/processor"
 )
 
 func (h handler) exportMetrics(w nethttp.ResponseWriter, r *nethttp.Request) {
@@ -16,12 +18,21 @@ func (h handler) exportMetrics(w nethttp.ResponseWriter, r *nethttp.Request) {
 	}
 
 	req := &colmetricspb.ExportMetricsServiceRequest{}
-	if err := decodeOTLPRequest(r, req); err != nil {
+	if err := decodeOTLPRequest(r, h.maxBodyBytes, req); err != nil {
+		if errors.Is(err, errRequestTooLarge) {
+			nethttp.Error(w, err.Error(), nethttp.StatusRequestEntityTooLarge)
+			return
+		}
 		nethttp.Error(w, err.Error(), nethttp.StatusBadRequest)
 		return
 	}
 
 	if err := h.otlpDataProcessor.ProcessMetrics(r.Context(), pipelineID, req); err != nil {
+		if errors.Is(err, processor.ErrReceiverOverloaded) {
+			w.Header().Set("Retry-After", "1")
+			nethttp.Error(w, err.Error(), nethttp.StatusServiceUnavailable)
+			return
+		}
 		nethttp.Error(w, err.Error(), nethttp.StatusInternalServerError)
 		return
 	}

--- a/glassflow-api/internal/otlp-receiver/server/http/otlp.go
+++ b/glassflow-api/internal/otlp-receiver/server/http/otlp.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"errors"
 	"io"
 	nethttp "net/http"
 	"strings"
@@ -14,10 +15,17 @@ const (
 	contentTypeJSON     = "application/json"
 )
 
-func decodeOTLPRequest(r *nethttp.Request, req proto.Message) error {
-	body, err := io.ReadAll(r.Body)
+var errRequestTooLarge = errors.New("request body exceeds maximum allowed size")
+
+func decodeOTLPRequest(r *nethttp.Request, maxBodyBytes int64, req proto.Message) error {
+	// Read up to maxBodyBytes+1; if we get more, the request is too large.
+	lr := io.LimitReader(r.Body, maxBodyBytes+1)
+	body, err := io.ReadAll(lr)
 	if err != nil {
 		return err
+	}
+	if int64(len(body)) > maxBodyBytes {
+		return errRequestTooLarge
 	}
 
 	if strings.HasPrefix(r.Header.Get("Content-Type"), contentTypeProtobuf) {

--- a/glassflow-api/internal/otlp-receiver/server/http/traces.go
+++ b/glassflow-api/internal/otlp-receiver/server/http/traces.go
@@ -1,11 +1,13 @@
 package http
 
 import (
+	"errors"
 	nethttp "net/http"
 
 	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal"
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/otlp-receiver/server/processor"
 )
 
 func (h handler) exportTraces(w nethttp.ResponseWriter, r *nethttp.Request) {
@@ -16,12 +18,21 @@ func (h handler) exportTraces(w nethttp.ResponseWriter, r *nethttp.Request) {
 	}
 
 	req := &coltracepb.ExportTraceServiceRequest{}
-	if err := decodeOTLPRequest(r, req); err != nil {
+	if err := decodeOTLPRequest(r, h.maxBodyBytes, req); err != nil {
+		if errors.Is(err, errRequestTooLarge) {
+			nethttp.Error(w, err.Error(), nethttp.StatusRequestEntityTooLarge)
+			return
+		}
 		nethttp.Error(w, err.Error(), nethttp.StatusBadRequest)
 		return
 	}
 
 	if err := h.otlpDataProcessor.ProcessTraces(r.Context(), pipelineID, req); err != nil {
+		if errors.Is(err, processor.ErrReceiverOverloaded) {
+			w.Header().Set("Retry-After", "1")
+			nethttp.Error(w, err.Error(), nethttp.StatusServiceUnavailable)
+			return
+		}
 		nethttp.Error(w, err.Error(), nethttp.StatusInternalServerError)
 		return
 	}

--- a/glassflow-api/internal/otlp-receiver/server/processor/logs_test.go
+++ b/glassflow-api/internal/otlp-receiver/server/processor/logs_test.go
@@ -55,7 +55,7 @@ func TestProcessLogs(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	proc := processor.NewProcessor(&stubOTLPConfigFetcher{}, nc)
+	proc := processor.NewProcessor(&stubOTLPConfigFetcher{}, nc, 50, 1000)
 
 	req := &collogspb.ExportLogsServiceRequest{
 		ResourceLogs: []*logsv1.ResourceLogs{

--- a/glassflow-api/internal/otlp-receiver/server/processor/metrics_test.go
+++ b/glassflow-api/internal/otlp-receiver/server/processor/metrics_test.go
@@ -42,7 +42,7 @@ func TestProcessMetrics(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	proc := processor.NewProcessor(&stubOTLPConfigFetcher{}, nc)
+	proc := processor.NewProcessor(&stubOTLPConfigFetcher{}, nc, 50, 1000)
 
 	value := 42.5
 	req := &colmetricspb.ExportMetricsServiceRequest{

--- a/glassflow-api/internal/otlp-receiver/server/processor/processor.go
+++ b/glassflow-api/internal/otlp-receiver/server/processor/processor.go
@@ -20,6 +20,9 @@ import (
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/pkg/observability"
 )
 
+// ErrReceiverOverloaded is returned when the processor has reached its concurrency limit.
+var ErrReceiverOverloaded = errors.New("receiver overloaded, try again later")
+
 type OTLPConfigFetcher interface {
 	GetOTLPConfig(ctx context.Context, pipelineID string) (models.OTLPConfig, error)
 }
@@ -27,12 +30,31 @@ type OTLPConfigFetcher interface {
 func NewProcessor(
 	otlpConfigFetcher OTLPConfigFetcher,
 	nc *client.NATSClient,
+	maxConcurrent int,
+	natsChunkSize int,
 ) *Processor {
 	return &Processor{
 		otlpConfigFetcher: otlpConfigFetcher,
 		natsWriterCache:   make(map[string]writerConfig),
 		nc:                nc,
+		sem:               make(chan struct{}, maxConcurrent),
+		natsChunkSize:     natsChunkSize,
 	}
+}
+
+// acquire tries to take a semaphore slot without blocking.
+// Returns false if the processor is at capacity.
+func (p *Processor) acquire() bool {
+	select {
+	case p.sem <- struct{}{}:
+		return true
+	default:
+		return false
+	}
+}
+
+func (p *Processor) release() {
+	<-p.sem
 }
 
 const natsWriterCacheTTL = 60 * time.Second
@@ -48,6 +70,8 @@ type Processor struct {
 	natsWriterCache   map[string]writerConfig
 	natsWriterMu      sync.RWMutex
 	nc                *client.NATSClient
+	sem               chan struct{}
+	natsChunkSize     int
 }
 
 func (p *Processor) getWriterConfig(
@@ -71,7 +95,7 @@ func (p *Processor) getWriterConfig(
 		return writerConfig{}, fmt.Errorf("subjectrouter.New: %w", err)
 	}
 
-	newWriterConfig := nats.NewBatchWriter(p.nc.JetStream(), subjectRouter)
+	newWriterConfig := nats.NewBatchWriter(p.nc.JetStream(), subjectRouter, p.natsChunkSize)
 
 	p.natsWriterMu.Lock()
 	defer p.natsWriterMu.Unlock()
@@ -105,6 +129,11 @@ func (p *Processor) sendBatch(
 	pipelineID string,
 	messages []models.Message,
 ) error {
+	if !p.acquire() {
+		return ErrReceiverOverloaded
+	}
+	defer p.release()
+
 	err := retry.Do(
 		func() error {
 			cfg, err := p.getWriterConfig(ctx, pipelineID)

--- a/glassflow-api/internal/otlp-receiver/server/processor/traces_test.go
+++ b/glassflow-api/internal/otlp-receiver/server/processor/traces_test.go
@@ -42,7 +42,7 @@ func TestProcessTraces(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	proc := processor.NewProcessor(&stubOTLPConfigFetcher{}, nc)
+	proc := processor.NewProcessor(&stubOTLPConfigFetcher{}, nc, 50, 1000)
 
 	req := &coltracepb.ExportTraceServiceRequest{
 		ResourceSpans: []*tracev1.ResourceSpans{

--- a/glassflow-api/internal/otlp-receiver/server/receiver.go
+++ b/glassflow-api/internal/otlp-receiver/server/receiver.go
@@ -36,6 +36,7 @@ type Receiver struct {
 func New(
 	log *slog.Logger,
 	otlpDataProcessor *processor.Processor,
+	maxBodyBytes int64,
 ) (*Receiver, error) {
 	grpcServer, grpcHealth, grpcLis, err := grpcQ.NewGRPCServer(grpcAddr, log, otlpDataProcessor)
 	if err != nil {
@@ -50,7 +51,7 @@ func New(
 		done:       make(chan struct{}),
 	}
 
-	r.httpServer = httpQ.NewHTTPServer(httpAddr, &r.ready, log, otlpDataProcessor)
+	r.httpServer = httpQ.NewHTTPServer(httpAddr, &r.ready, log, otlpDataProcessor, maxBodyBytes)
 
 	return r, nil
 }

--- a/glassflow-api/tests/dedup_test.go
+++ b/glassflow-api/tests/dedup_test.go
@@ -172,7 +172,7 @@ func createComponent(
 		Type:          models.RoutingTypeName,
 	})
 	require.NoError(t, err)
-	writer := batchNats.NewBatchWriter(js, subjectRouter)
+	writer := batchNats.NewBatchWriter(js, subjectRouter, 0)
 
 	var dlqWriter batch.BatchWriter
 	if dlqSubject != nil {
@@ -182,7 +182,7 @@ func createComponent(
 		})
 		require.NoError(t, err)
 
-		dlqWriter = batchNats.NewBatchWriter(js, dlqSubjectRouter)
+		dlqWriter = batchNats.NewBatchWriter(js, dlqSubjectRouter, 0)
 	}
 
 	role := internal.RoleDeduplicator

--- a/glassflow-api/tests/streaming_component_test.go
+++ b/glassflow-api/tests/streaming_component_test.go
@@ -50,7 +50,7 @@ func createStreamingComponent(
 		Type:          models.RoutingTypeName,
 	})
 	require.NoError(t, err)
-	writer := batchNats.NewBatchWriter(js, subjectRouter)
+	writer := batchNats.NewBatchWriter(js, subjectRouter, 0)
 
 	var dlqWriter batch.BatchWriter
 	if dlqSubject != nil {
@@ -60,7 +60,7 @@ func createStreamingComponent(
 		})
 		require.NoError(t, err)
 
-		dlqWriter = batchNats.NewBatchWriter(js, dlqSubjectRouter)
+		dlqWriter = batchNats.NewBatchWriter(js, dlqSubjectRouter, 0)
 	}
 
 	role := internal.RoleDeduplicator


### PR DESCRIPTION
## Summary

Fixes three reliability issues in the OTLP HTTP/gRPC receiver:

- **ETL-1046 — Request size limits**: HTTP receiver now rejects bodies larger than 4 MiB via `io.LimitReader` (returns 413). gRPC server now has an explicit `MaxRecvMsgSize(4 MiB)` option (was relying on gRPC's implicit default). This was not an OTLP library bug — the receiver is custom-built and the fix is in our own code.

- **ETL-1047 — Back pressure**: `Processor` now holds a non-blocking semaphore (buffered channel). When all slots are occupied, new requests get HTTP 503 + `Retry-After: 1` (or gRPC `ResourceExhausted`) immediately rather than accumulating goroutines and hammering NATS under load.

- **ETL-1048 — NATS batch chunking**: `WriteBatch` now publishes in chunks (default 1000 messages per round-trip) and waits for `PublishAsyncComplete` between chunks. This caps peak in-flight futures regardless of OTLP batch size.

## Configuration

All limits are tunable via env vars (operators should increase pod resources alongside):

| Env var | Default | Rationale |
|---|---|---|
| `GLASSFLOW_OTLP_MAX_BODY_BYTES` | `4194304` (4 MiB) | 4× typical SDK batch (512 spans × ~2 KB) |
| `GLASSFLOW_OTLP_MAX_CONCURRENT_REQUESTS` | `50` | Little's Law: 1000 req/s × 50ms latency; 200 MB peak body buffers |
| `GLASSFLOW_OTLP_NATS_CHUNK_SIZE` | `1000` | Stays well under JetStream 4096 async-pending default |

## Test plan

- [ ] Existing processor and NATS batch writer unit tests pass (`go test ./internal/otlp-receiver/... ./internal/batch/nats/... -race`)
- [ ] Send an oversized HTTP payload → expect 413
- [ ] Send > 50 concurrent requests while NATS is slow → expect 503 on overflow
- [ ] Send a large OTLP batch (>1000 spans) → verify it publishes successfully in chunks