### PR TITLE
ETL-1057: Process kafka batch with nats stream back pressure

### DIFF
--- a/glassflow-api/internal/constants.go
+++ b/glassflow-api/internal/constants.go
@@ -179,6 +179,11 @@ const (
 	IngestorMaxRetryDelay     = 5 * time.Second
 	IngestorMaxRetryWait      = 10 * time.Minute
 
+	// Backoff between iterations of processBatchAsync's internal retry loop
+	// when the batch is not yet fully published due to backpressure.
+	IngestorBackpressureInitialDelay = 50 * time.Millisecond
+	IngestorBackpressureMaxDelay     = 5 * time.Second
+
 	// Orchestrator constants
 	ShutdownTimeout = 30 * time.Second
 

--- a/glassflow-api/internal/ingestor/processor.go
+++ b/glassflow-api/internal/ingestor/processor.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"strconv"
 	"sync/atomic"
+	"time"
 
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
@@ -18,15 +19,23 @@ import (
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal"
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/componentsignals"
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/models"
-	schemav2 "github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/schema_v2"
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/stream"
 )
+
+// SchemaValidator is the subset of schema_v2.Schema that the ingestor uses.
+// Defining it as an interface here keeps the processor unit-testable without
+// a real schema registry.
+type SchemaValidator interface {
+	Validate(ctx context.Context, data []byte) (string, error)
+	Get(ctx context.Context, versionID, key string, data []byte) (any, error)
+	IsExternal() bool
+}
 
 type KafkaMsgProcessor struct {
 	pipelineID      string
 	publisher       stream.Publisher
 	dlqPublisher    stream.Publisher
-	schema          *schemav2.Schema
+	schema          SchemaValidator
 	topic           models.KafkaTopicsConfig
 	signalPublisher *componentsignals.ComponentSignalPublisher
 	log             *slog.Logger
@@ -45,7 +54,7 @@ type KafkaMsgProcessor struct {
 func NewKafkaMsgProcessor(
 	pipelineID string,
 	publisher, dlqPublisher stream.Publisher,
-	schema *schemav2.Schema,
+	schema SchemaValidator,
 	topic models.KafkaTopicsConfig,
 	runtimeCfg models.IngestorRuntimeConfig,
 	signalPublisher *componentsignals.ComponentSignalPublisher,
@@ -300,85 +309,262 @@ func (k *KafkaMsgProcessor) processBatchSync(ctx context.Context, batch []*kgo.R
 	return lastProcessed, nil
 }
 
-func (k *KafkaMsgProcessor) processBatchAsync(_ context.Context, batch []*kgo.Record) (*kgo.Record, error) {
-	ctx := context.Background()
+// pendingPublish pairs an in-flight PubAck future with the index of its
+// originating record in the original batch.
+type pendingPublish struct {
+	future jetstream.PubAckFuture
+	idx    int
+}
 
-	type futureWithRecord struct {
-		future jetstream.PubAckFuture
-		record *kgo.Record
+// asyncBatchState holds per-call state for the internal retry loop in
+// processBatchAsync. None of this state survives across calls — each batch is
+// driven to completion (or to a fatal/ctx-cancel cleanup) within one call.
+type asyncBatchState struct {
+	batch        []*kgo.Record
+	cachedMsgs   []*nats.Msg // index → prepared *nats.Msg (nil = not prepared yet OR DLQ-at-prepare)
+	completed    []bool      // index → true when record is acked or DLQ-accepted
+	backpressure []int       // indices waiting for retry (their cachedMsgs entry is non-nil)
+	dlqOnExit    []int       // indices to DLQ on cleanup (fatal classification)
+	cursor       int         // next batch index to publish from
+	lastAckedIdx int         // -1 means nothing acked yet
+	savedErr     error       // first non-backpressure error; triggers cleanup path
+	outBytes     int64
+	retries      map[int]int // hook for a future per-record retry cap (currently uncapped)
+}
+
+// processBatchAsync drives the batch to completion via an internal retry loop.
+// It returns only when:
+//   - the whole batch is done (ack, DLQ-at-prepare, or DLQ-on-cleanup): err == nil
+//   - a fatal error fires (returns lastProcessed + the error)
+//   - ctx cancels (returns lastProcessed + ctx.Err)
+//
+// Records past a backpressured record may be successfully published to NATS in
+// the same pass — they are not re-published. lastProcessed reflects the
+// highest contiguous-acked record by original batch position.
+func (k *KafkaMsgProcessor) processBatchAsync(ctx context.Context, batch []*kgo.Record) (*kgo.Record, error) {
+	if len(batch) == 0 {
+		return nil, nil
 	}
 
-	futures := make([]futureWithRecord, 0, len(batch))
-	var lastProcessed *kgo.Record
-
-	for _, msg := range batch {
-		natsMsg, err := k.prepareMesssage(ctx, msg)
-		if err != nil {
-			k.log.Error("Failed to prepare message",
-				slog.Any("error", err),
-				slog.String("topic", msg.Topic),
-				slog.Int("partition", int(msg.Partition)))
-
-			return lastProcessed, fmt.Errorf("failed to prepare message: %w", err)
-		}
-		if natsMsg == nil {
-			// Message was pushed to DLQ, count as processed
-			lastProcessed = msg
-			continue
-		}
-
-		fut, err := k.publisher.PublishNatsMsgAsync(ctx, natsMsg, k.pendingPublishesLimit)
-		if err != nil {
-			k.log.Error("Failed to publish message async to NATS",
-				slog.Any("error", err),
-				slog.String("topic", msg.Topic),
-				slog.Int("partition", int(msg.Partition)))
-
-			dlqErr := k.pushMsgToDLQ(ctx, msg.Value, err)
-			if dlqErr != nil {
-				k.log.Error("Failed to push failed message to DLQ",
-					slog.Any("error", dlqErr),
-					slog.String("topic", msg.Topic),
-					slog.Int("partition", int(msg.Partition)))
-				return lastProcessed, fmt.Errorf("failed to publish async to NATS: %w", err)
-			}
-
-			lastProcessed = msg
-			continue
-		}
-
-		futures = append(futures, futureWithRecord{future: fut, record: msg})
-		lastProcessed = msg
+	s := &asyncBatchState{
+		batch:        batch,
+		cachedMsgs:   make([]*nats.Msg, len(batch)),
+		completed:    make([]bool, len(batch)),
+		cursor:       0,
+		lastAckedIdx: -1,
+		retries:      make(map[int]int),
 	}
+	backoff := internal.IngestorBackpressureInitialDelay
 
-	// Wait for all futures to complete
-	<-k.publisher.WaitForAsyncPublishAcks()
+	var futures []pendingPublish
 
-	var outBytes int64
-	for _, f := range futures {
+	for {
+		// 1. Re-publish records sitting in the backpressure carry slice.
+		futures = k.publishBackpressureSlice(ctx, s, futures)
+
+		// 2. Continue publishing fresh records from the cursor.
+		futures = k.publishFromCursor(ctx, s, futures)
+
+		// 3. Wait for in-flight publishes to settle, then classify.
+		if len(futures) > 0 {
+			<-k.publisher.WaitForAsyncPublishAcks()
+			k.classifyFutures(s, futures)
+			futures = futures[:0]
+		}
+
+		// 4. Walk the contiguous-acked prefix forward.
+		k.advanceLastAckedIdx(s)
+
+		// 5. Termination.
+		if s.savedErr != nil {
+			return k.cleanupAndReturn(ctx, s, s.savedErr)
+		}
+		if ctx.Err() != nil {
+			return k.cleanupAndReturn(ctx, s, ctx.Err())
+		}
+		if s.cursor == len(s.batch) && len(s.backpressure) == 0 {
+			observability.RecordBytesProcessed(ctx, "ingestor", "out", s.outBytes)
+			return s.batch[len(s.batch)-1], nil
+		}
+
+		// 6. Backoff before the next iteration. Interruptible by ctx.
 		select {
-		case <-f.future.Ok():
-			// Successfully published
-			outBytes += int64(len(f.future.Msg().Data))
-			lastProcessed = f.record
-			continue
-		case err := <-f.future.Err():
-			k.log.Error("Failed to receive async publish ack",
-				slog.Any("error", err),
-				slog.String("subject", f.future.Msg().Subject))
-
-			dlqErr := k.pushMsgToDLQ(ctx, f.future.Msg().Data, err)
-			if dlqErr != nil {
-				k.log.Error("Failed to push failed message to DLQ",
-					slog.Any("error", dlqErr),
-					slog.String("subject", f.future.Msg().Subject))
-				return lastProcessed, fmt.Errorf("push mesage to the DLQ %w", dlqErr)
+		case <-ctx.Done():
+			return k.cleanupAndReturn(ctx, s, ctx.Err())
+		case <-time.After(backoff):
+			if backoff < internal.IngestorBackpressureMaxDelay {
+				backoff *= 2
+				if backoff > internal.IngestorBackpressureMaxDelay {
+					backoff = internal.IngestorBackpressureMaxDelay
+				}
 			}
-			lastProcessed = f.record
 		}
 	}
+}
 
-	observability.RecordBytesProcessed(ctx, "ingestor", "out", outBytes)
+// publishBackpressureSlice retries the records carried over from earlier
+// iterations. Each entry's *nats.Msg is already cached. Indices that hit the
+// throttle again are kept in the slice; fatal errors set savedErr and route
+// the index to dlqOnExit.
+func (k *KafkaMsgProcessor) publishBackpressureSlice(ctx context.Context, s *asyncBatchState, futures []pendingPublish) []pendingPublish {
+	if len(s.backpressure) == 0 {
+		return futures
+	}
+	carry := s.backpressure[:0]
+	for _, idx := range s.backpressure {
+		if s.savedErr != nil {
+			carry = append(carry, idx)
+			continue
+		}
+		fut, err := k.publisher.PublishNatsMsgAsync(ctx, s.cachedMsgs[idx], k.pendingPublishesLimit)
+		if err != nil {
+			if stream.IsBackpressureErr(err) {
+				carry = append(carry, idx)
+				continue
+			}
+			// Any non-backpressure error from the publish call is treated as
+			// fatal: connection closed, stream not found, ctx cancellation,
+			// or anything unclassified. The record stays around for cleanup
+			// to DLQ.
+			s.savedErr = err
+			s.dlqOnExit = append(s.dlqOnExit, idx)
+			continue
+		}
+		futures = append(futures, pendingPublish{future: fut, idx: idx})
+	}
+	s.backpressure = carry
+	return futures
+}
 
-	return lastProcessed, nil
+// publishFromCursor walks fresh records starting at the cursor. prepareMessage
+// runs at most once per record and the result is cached so retries skip
+// re-validation. The cursor only advances when a record is committed to its
+// fate (cached and queued, or DLQ'd at prepare, or routed to dlqOnExit).
+func (k *KafkaMsgProcessor) publishFromCursor(ctx context.Context, s *asyncBatchState, futures []pendingPublish) []pendingPublish {
+	for s.cursor < len(s.batch) && s.savedErr == nil {
+		rec := s.batch[s.cursor]
+
+		msg := s.cachedMsgs[s.cursor]
+		if msg == nil {
+			prepared, err := k.prepareMesssage(ctx, rec)
+			if err != nil {
+				// prepareMessage errors are fatal: schema-incompatible
+				// (signal sent), or DLQ-push failure. Record is not added to
+				// dlqOnExit because we couldn't even DLQ it; surface the
+				// error and let the runner fail the pipeline.
+				s.savedErr = err
+				return futures
+			}
+			if prepared == nil {
+				// prepareMessage already pushed to DLQ inline.
+				s.completed[s.cursor] = true
+				s.cursor++
+				continue
+			}
+			s.cachedMsgs[s.cursor] = prepared
+			msg = prepared
+		}
+
+		fut, err := k.publisher.PublishNatsMsgAsync(ctx, msg, k.pendingPublishesLimit)
+		if err != nil {
+			if stream.IsBackpressureErr(err) {
+				// Throttle hit. Don't advance cursor — try again next iter.
+				return futures
+			}
+			s.savedErr = err
+			s.dlqOnExit = append(s.dlqOnExit, s.cursor)
+			s.cursor++
+			return futures
+		}
+		futures = append(futures, pendingPublish{future: fut, idx: s.cursor})
+		s.cursor++
+	}
+	return futures
+}
+
+// classifyFutures inspects each in-flight future, marks completed indices, and
+// routes failures into either backpressure (retry) or dlqOnExit (fatal).
+func (k *KafkaMsgProcessor) classifyFutures(s *asyncBatchState, futures []pendingPublish) {
+	for _, p := range futures {
+		select {
+		case <-p.future.Ok():
+			s.completed[p.idx] = true
+			if msg := s.cachedMsgs[p.idx]; msg != nil {
+				s.outBytes += int64(len(msg.Data))
+			}
+		case err := <-p.future.Err():
+			if stream.IsBackpressureErr(err) {
+				s.backpressure = append(s.backpressure, p.idx)
+				s.retries[p.idx]++
+				continue
+			}
+			k.log.Error("Async publish ack failed",
+				slog.Any("error", err),
+				slog.String("subject", p.future.Msg().Subject))
+			if s.savedErr == nil {
+				s.savedErr = err
+			}
+			s.dlqOnExit = append(s.dlqOnExit, p.idx)
+		}
+	}
+}
+
+func (k *KafkaMsgProcessor) advanceLastAckedIdx(s *asyncBatchState) {
+	for i := s.lastAckedIdx + 1; i < len(s.batch); i++ {
+		if !s.completed[i] {
+			break
+		}
+		s.lastAckedIdx = i
+	}
+}
+
+// cleanupAndReturn DLQs every still-pending record (backpressure carry + the
+// fatal-but-DLQable set) so lastProcessed can advance through them and the
+// consumer commits a clean Kafka offset. Records past a backpressured one
+// that already PubAck'd to NATS would otherwise be re-delivered on restart
+// and republished — DLQ'ing the blocker avoids those duplicates.
+//
+// On a DLQ-push failure we stop advancing through the pending set: returning
+// partial progress is better than silently losing track of which records were
+// actually DLQ'd.
+func (k *KafkaMsgProcessor) cleanupAndReturn(ctx context.Context, s *asyncBatchState, cause error) (*kgo.Record, error) {
+	// When the cleanup is triggered by ctx cancellation, the same ctx will
+	// fail on every DLQ push. Use a fresh, bounded ctx so we can still drain.
+	dlqCtx := ctx
+	if errors.Is(cause, context.Canceled) || errors.Is(cause, context.DeadlineExceeded) {
+		var cancel context.CancelFunc
+		dlqCtx, cancel = context.WithTimeout(context.Background(), internal.DefaultComponentShutdownTimeout)
+		defer cancel()
+	}
+
+	pending := make([]int, 0, len(s.backpressure)+len(s.dlqOnExit))
+	pending = append(pending, s.backpressure...)
+	pending = append(pending, s.dlqOnExit...)
+
+	var dlqErr error
+	for _, idx := range pending {
+		if s.completed[idx] {
+			continue
+		}
+		err := k.pushMsgToDLQ(dlqCtx, s.batch[idx].Value, fmt.Errorf("ingestor cleanup: %w", cause))
+		if err != nil {
+			dlqErr = err
+			break
+		}
+		s.completed[idx] = true
+	}
+
+	k.advanceLastAckedIdx(s)
+
+	observability.RecordBytesProcessed(ctx, "ingestor", "out", s.outBytes)
+
+	var lastProcessed *kgo.Record
+	if s.lastAckedIdx >= 0 {
+		lastProcessed = s.batch[s.lastAckedIdx]
+	}
+
+	if dlqErr != nil {
+		return lastProcessed, errors.Join(cause, dlqErr)
+	}
+	return lastProcessed, cause
 }

--- a/glassflow-api/internal/ingestor/processor_test.go
+++ b/glassflow-api/internal/ingestor/processor_test.go
@@ -1,0 +1,317 @@
+package ingestor_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kgo"
+
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal"
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/ingestor"
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/models"
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/stream"
+)
+
+// fakeSchema satisfies ingestor.SchemaValidator with a no-op validation that
+// always returns version "v1", non-external, dedup-disabled. The processor's
+// prepareMessage path produces a valid nats.Msg without touching a real
+// schema store.
+type fakeSchema struct{}
+
+func (fakeSchema) Validate(_ context.Context, _ []byte) (string, error) { return "v1", nil }
+func (fakeSchema) Get(_ context.Context, _, _ string, _ []byte) (any, error) {
+	return nil, errors.New("not used")
+}
+func (fakeSchema) IsExternal() bool { return false }
+
+// fakeFuture mirrors jetstream.PubAckFuture with controllable Ok/Err
+// channels. Exactly one of okCh / errCh is signalled at construction time so
+// drain reads return immediately.
+type fakeFuture struct {
+	msg   *nats.Msg
+	okCh  chan *jetstream.PubAck
+	errCh chan error
+}
+
+func newOkFuture(msg *nats.Msg) *fakeFuture {
+	f := &fakeFuture{msg: msg, okCh: make(chan *jetstream.PubAck, 1), errCh: make(chan error, 1)}
+	f.okCh <- &jetstream.PubAck{Stream: "test", Sequence: 1}
+	return f
+}
+
+func newErrFuture(msg *nats.Msg, err error) *fakeFuture {
+	f := &fakeFuture{msg: msg, okCh: make(chan *jetstream.PubAck, 1), errCh: make(chan error, 1)}
+	f.errCh <- err
+	return f
+}
+
+func (f *fakeFuture) Ok() <-chan *jetstream.PubAck { return f.okCh }
+func (f *fakeFuture) Err() <-chan error            { return f.errCh }
+func (f *fakeFuture) Msg() *nats.Msg               { return f.msg }
+
+// fakePublisher implements stream.Publisher with programmable per-call
+// behaviour for PublishNatsMsgAsync. dlqCalls counts Publish() invocations,
+// which the processor uses for DLQ writes.
+type fakePublisher struct {
+	subject string
+
+	mu        sync.Mutex
+	publishFn func(callIdx int, msg *nats.Msg) (jetstream.PubAckFuture, error)
+	dlqFn     func(data []byte) error // optional override for the DLQ path
+
+	publishCalls atomic.Int32
+	dlqCalls     atomic.Int32
+	ackDoneCh    chan struct{}
+}
+
+func newFakePublisher(subject string) *fakePublisher {
+	ch := make(chan struct{})
+	close(ch) // PublishAsyncComplete returns a closed channel since fakes resolve synchronously
+	return &fakePublisher{subject: subject, ackDoneCh: ch}
+}
+
+func (f *fakePublisher) setPublish(fn func(callIdx int, msg *nats.Msg) (jetstream.PubAckFuture, error)) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.publishFn = fn
+}
+
+func (f *fakePublisher) Publish(_ context.Context, data []byte) error {
+	f.dlqCalls.Add(1)
+	f.mu.Lock()
+	fn := f.dlqFn
+	f.mu.Unlock()
+	if fn != nil {
+		return fn(data)
+	}
+	return nil
+}
+func (f *fakePublisher) GetSubject() string { return f.subject }
+func (f *fakePublisher) PublishNatsMsg(_ context.Context, _ *nats.Msg, _ ...stream.PublishOpt) error {
+	return nil
+}
+func (f *fakePublisher) PublishNatsMsgAsync(_ context.Context, msg *nats.Msg, _ int) (jetstream.PubAckFuture, error) {
+	idx := int(f.publishCalls.Add(1)) - 1
+	f.mu.Lock()
+	fn := f.publishFn
+	f.mu.Unlock()
+	return fn(idx, msg)
+}
+func (f *fakePublisher) WaitForAsyncPublishAcks() <-chan struct{} { return f.ackDoneCh }
+
+// makeBatch returns N kgo.Records with offsets 0..N-1 and a small payload.
+func makeBatch(n int) []*kgo.Record {
+	batch := make([]*kgo.Record, n)
+	for i := range batch {
+		batch[i] = &kgo.Record{
+			Offset:    int64(i),
+			Topic:     "test",
+			Partition: 0,
+			Value:     []byte(`{"k":"v"}`),
+		}
+	}
+	return batch
+}
+
+func newProcessor(t *testing.T, pub stream.Publisher) *ingestor.KafkaMsgProcessor {
+	t.Helper()
+	p, err := ingestor.NewKafkaMsgProcessor(
+		"pipeline-test",
+		pub,
+		pub, // dlq publisher: reuse so we can count Publish() calls as DLQ writes
+		fakeSchema{},
+		models.KafkaTopicsConfig{Name: "test", Replicas: 1},
+		models.IngestorRuntimeConfig{
+			OutputSubject:     "out",
+			TotalSubjectCount: 1,
+		},
+		nil, // signalPublisher: not invoked on the success path
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+	require.NoError(t, err)
+	return p
+}
+
+func streamFullErr() error {
+	return &jetstream.APIError{
+		ErrorCode:   stream.JSErrCodeStreamStoreFailed,
+		Description: "maximum messages exceeded",
+		Code:        503,
+	}
+}
+
+func TestProcessBatch_AllAck(t *testing.T) {
+	pub := newFakePublisher("out")
+	pub.setPublish(func(_ int, msg *nats.Msg) (jetstream.PubAckFuture, error) {
+		return newOkFuture(msg), nil
+	})
+	p := newProcessor(t, pub)
+
+	batch := makeBatch(10)
+	last, err := p.ProcessBatch(context.Background(), batch)
+
+	require.NoError(t, err)
+	require.Same(t, batch[9], last)
+	require.Equal(t, int32(0), pub.dlqCalls.Load())
+	require.Equal(t, int32(10), pub.publishCalls.Load())
+}
+
+// Throttle hits at index 30 of a 100-record batch on the first iteration.
+// On the second iteration, the throttle clears and the rest publishes
+// successfully. processBatchAsync should drive the batch to completion via
+// its internal retry loop without DLQ'ing anything.
+func TestProcessBatch_ThrottleHitClearsOnRetry(t *testing.T) {
+	pub := newFakePublisher("out")
+	const cutoff = 30
+	var firstPass atomic.Bool
+	firstPass.Store(true)
+
+	pub.setPublish(func(idx int, msg *nats.Msg) (jetstream.PubAckFuture, error) {
+		// First pass: throttle hits at and past idx==cutoff. Second pass: all ok.
+		if firstPass.Load() && idx >= cutoff {
+			// On the iteration boundary, the publisher would normally drain;
+			// flip the flag once we've returned the throttle error so the
+			// next iteration succeeds.
+			firstPass.Store(false)
+			return nil, stream.ErrStreamMaxPendingMsgs
+		}
+		return newOkFuture(msg), nil
+	})
+	p := newProcessor(t, pub)
+
+	batch := makeBatch(100)
+	last, err := p.ProcessBatch(context.Background(), batch)
+
+	require.NoError(t, err)
+	require.Same(t, batch[99], last)
+	require.Equal(t, int32(0), pub.dlqCalls.Load(),
+		"throttle should not DLQ; the records are retried in the internal loop")
+}
+
+// A server-side stream-full NAK on r3 lands in the future-drain phase. r4..r99
+// publish successfully. The contiguous-prefix walk must not advance past r2
+// until r3 is retried. On the second iteration r3 ok's and the contiguous
+// walk pulls lastProcessed forward to the end of the batch.
+func TestProcessBatch_ServerSideNakRecovers(t *testing.T) {
+	pub := newFakePublisher("out")
+	const nakAt = 3
+	var nakReturned atomic.Bool
+
+	pub.setPublish(func(idx int, msg *nats.Msg) (jetstream.PubAckFuture, error) {
+		if idx == nakAt && !nakReturned.Load() {
+			nakReturned.Store(true)
+			return newErrFuture(msg, streamFullErr()), nil
+		}
+		return newOkFuture(msg), nil
+	})
+	p := newProcessor(t, pub)
+
+	batch := makeBatch(100)
+	last, err := p.ProcessBatch(context.Background(), batch)
+
+	require.NoError(t, err)
+	require.Same(t, batch[99], last,
+		"contiguous walk must reach end of batch once r3 retries successfully")
+	require.Equal(t, int32(0), pub.dlqCalls.Load(),
+		"server-side stream-full NAK is backpressure, not DLQable")
+	// Total publish calls: 100 fresh + 1 retry of r3.
+	require.Equal(t, int32(101), pub.publishCalls.Load())
+}
+
+// A fatal future error on r5 (e.g., stream-not-found) puts r5 in the DLQ-on-
+// exit set, sets savedErr, and triggers cleanup. lastProcessed should advance
+// through the contiguous walk once r5 is DLQ'd.
+func TestProcessBatch_FatalFutureErrCleanupDLQs(t *testing.T) {
+	pub := newFakePublisher("out")
+	const fatalAt = 5
+	fatalErr := errors.New("stream gone")
+
+	pub.setPublish(func(idx int, msg *nats.Msg) (jetstream.PubAckFuture, error) {
+		if idx == fatalAt {
+			return newErrFuture(msg, fatalErr), nil
+		}
+		return newOkFuture(msg), nil
+	})
+	p := newProcessor(t, pub)
+
+	batch := makeBatch(20)
+	last, err := p.ProcessBatch(context.Background(), batch)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, fatalErr)
+	require.Same(t, batch[19], last,
+		"after r5 is DLQ'd in cleanup, contiguous walk should reach the end")
+	require.Equal(t, int32(1), pub.dlqCalls.Load(),
+		"only the fatal-classified record goes to DLQ, not the backpressure-class siblings")
+}
+
+// ctx cancellation during the backoff sleep returns within bounded time.
+// All records take server-side NAKs so they sit in the backpressure carry
+// slice; cleanup DLQs them so lastProcessed can advance through the
+// contiguous walk to the end of the batch.
+func TestProcessBatch_CtxCancelDuringBackoffDLQsCarry(t *testing.T) {
+	pub := newFakePublisher("out")
+	pub.setPublish(func(_ int, msg *nats.Msg) (jetstream.PubAckFuture, error) {
+		return newErrFuture(msg, streamFullErr()), nil
+	})
+	p := newProcessor(t, pub)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	t0 := time.Now()
+	batch := makeBatch(3)
+	last, err := p.ProcessBatch(ctx, batch)
+	elapsed := time.Since(t0)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Less(t, elapsed, internal.IngestorBackpressureMaxDelay,
+		"ctx cancel during backoff should return well before the max delay")
+	require.Equal(t, int32(3), pub.dlqCalls.Load(),
+		"every record in the carry slice should be DLQ'd on cleanup")
+	require.Same(t, batch[2], last,
+		"contiguous walk should reach the end after cleanup DLQs the carry")
+}
+
+// If a DLQ push fails during cleanup, processBatchAsync should expose the DLQ
+// error in the wrapped error chain and return the partial lastProcessed (the
+// contiguous prefix it was able to DLQ before the failure).
+func TestProcessBatch_DLQFailureDuringCleanup(t *testing.T) {
+	pub := newFakePublisher("out")
+	pub.setPublish(func(_ int, msg *nats.Msg) (jetstream.PubAckFuture, error) {
+		return newErrFuture(msg, streamFullErr()), nil
+	})
+	dlqErr := errors.New("dlq stream down")
+	pub.mu.Lock()
+	pub.dlqFn = func(_ []byte) error { return dlqErr }
+	pub.mu.Unlock()
+	p := newProcessor(t, pub)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	last, err := p.ProcessBatch(ctx, makeBatch(3))
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, dlqErr,
+		"the wrapped error should expose the DLQ failure to the caller")
+	// First DLQ push fails so nothing is marked completed; lastProcessed
+	// stays nil.
+	require.Nil(t, last)
+}

--- a/glassflow-api/internal/kafka/consumer.go
+++ b/glassflow-api/internal/kafka/consumer.go
@@ -251,6 +251,16 @@ func (c *Consumer) consumeLoop(ctx context.Context) error {
 }
 
 func (c *Consumer) handleBatchMessages(ctx context.Context) error {
+	// Don't poll while a batch is still in flight: franz-go's polled cursor
+	// advances on every successful poll, so polling past unprocessed records
+	// would let CommitUncommittedOffsets advance past records the processor
+	// hasn't yet acked. processBatch clears c.batch on both success and
+	// failure, so this branch is defensive — but the invariant is load-
+	// bearing for offset correctness, so the check stays.
+	if len(c.batch) > 0 {
+		return c.processBatch(ctx)
+	}
+
 	// Poll for messages
 	pollCtx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
@@ -330,6 +340,10 @@ func (c *Consumer) processBatch(ctx context.Context) error {
 	return nil
 }
 
+// commitBatch commits the franz-go polled cursor. Safe only because
+// handleBatchMessages refuses to poll while c.batch is non-empty — that
+// invariant guarantees the polled cursor never extends past records the
+// processor hasn't yet driven to completion.
 func (c *Consumer) commitBatch(ctx context.Context) error {
 	if err := c.client.CommitUncommittedOffsets(ctx); err != nil {
 		c.log.Error("Failed to commit offsets", slog.Any("error", err))

--- a/glassflow-api/internal/stream/errors_test.go
+++ b/glassflow-api/internal/stream/errors_test.go
@@ -1,0 +1,66 @@
+package stream_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/stream"
+)
+
+func TestIsBackpressureErr(t *testing.T) {
+	streamFullAPIErr := &jetstream.APIError{
+		ErrorCode:   stream.JSErrCodeStreamStoreFailed,
+		Description: "maximum messages exceeded",
+		Code:        503,
+	}
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"sentinel", stream.ErrStreamMaxPendingMsgs, true},
+		{"wrapped sentinel", fmt.Errorf("publish: %w", stream.ErrStreamMaxPendingMsgs), true},
+		{"stream-store-failed APIError", streamFullAPIErr, true},
+		{"wrapped stream-store-failed", fmt.Errorf("ack: %w", streamFullAPIErr), true},
+		{"unrelated APIError", &jetstream.APIError{ErrorCode: jetstream.JSErrCodeStreamNotFound}, false},
+		{"connection closed", nats.ErrConnectionClosed, false},
+		{"random", errors.New("boom"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, stream.IsBackpressureErr(tt.err))
+		})
+	}
+}
+
+func TestIsFatalPublishErr(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"connection closed", nats.ErrConnectionClosed, true},
+		{"wrapped connection closed", fmt.Errorf("publish: %w", nats.ErrConnectionClosed), true},
+		{"stream not found", jetstream.ErrStreamNotFound, true},
+		{"context cancelled is not fatal", context.Canceled, false},
+		{"deadline exceeded is not fatal", context.DeadlineExceeded, false},
+		{"backpressure sentinel is not fatal", stream.ErrStreamMaxPendingMsgs, false},
+		{"random", errors.New("boom"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, stream.IsFatalPublishErr(tt.err))
+		})
+	}
+}


### PR DESCRIPTION
# ETL-1057: Ingestor backpressure-aware batch processing

  ## What's broken today

  When the downstream NATS stream is full (e.g. `discard:new` policy hits its limit, or the client-side `MaxPending` window is
  exhausted), the ingestor mishandles the resulting backpressure in two ways that violate the offset/PubAck contract:

  1. **`processBatchAsync` swaps the caller's ctx for `context.Background()`** — stop signals never reach the publish path.
  2. **Server-side stream-full PubAck NAKs are DLQ'd and `lastProcessed` is advanced past them** — the Kafka committed offset moves
  past records that were never acked by NATS. On crash/restart, those records are not redelivered and are silently lost from the main
  pipeline.

  PR1 (ETL-1056, already merged) added the error helpers (`ErrStreamMaxPendingMsgs`, `IsBackpressureErr`, `IsFatalPublishErr`) and
  plumbed ctx through the publisher. This PR is the behavioural fix.

  ## What this PR does

  Rewrites `processBatchAsync` around an internal retry loop with per-record completion tracking, so that:

  - The Kafka committed offset never advances past a record whose publish hasn't been PubAck'd by NATS.
  - Server-side stream-full NAKs are retained for retry inside the same call, not DLQ'd.
  - The function exits cleanly within bounded time on ctx cancellation, with no goroutine leaks.
  - Multi-stream non-contiguous completion is handled correctly: when r3 NAKs but r4..r99 ack out-of-order, `lastProcessed` holds at r2
   until r3 retries successfully, then the contiguous-prefix walk pulls it forward.

  ### Design

  `processBatchAsync` runs an internal loop until: the batch is fully done, a fatal error fires, or ctx cancels. Per-call state:

  - `completed []bool` indexed by batch position — set on Ok or DLQ-accepted.
  - `cachedMsgs []*nats.Msg` — `prepareMessage` runs at most once per record; retries reuse the cached message (skip re-validation).
  - `backpressure []int` — record indices whose future returned a backpressure-class error; retried on the next iteration with their
  cached message.
  - `dlqOnExit []int` — fatal-but-DLQable indices; deferred to cleanup.
  - `cursor int`, `lastAckedIdx int` (default `-1`) — `lastAckedIdx` advances via a contiguous-prefix walk over `completed[]`.
  - `retries map[int]int` — hook for a per-record retry cap (currently uncapped; value to be decided in a follow-up).

  Each loop iteration: retry the carry slice, publish from cursor, drain in-flight futures via `WaitForAsyncPublishAcks`, classify each
   future via `stream.IsBackpressureErr`, advance the contiguous prefix, then either terminate or sleep with exponential backoff (`50ms
   → 5s`, ctx-interruptible).

  ### Cleanup on shutdown / fatal

  When ctx cancels or a fatal error fires while records are still pending, those records are **DLQ'd** before returning. Rationale:
  out-of-order successes past a blocked record are already in NATS; if we left the blocker uncommitted to Kafka and crashed, restart
  would redeliver and republish them. DLQ'ing the blocker lets `lastProcessed` advance through the contiguous walk, producing a clean
  Kafka commit and no redelivery of the already-published successors. If a DLQ push itself fails, the function returns the partial
  `lastProcessed` with `errors.Join(cause, dlqErr)` — partial progress is preserved.

  ### Consumer changes

  - `handleBatchMessages` now early-returns into `processBatch` when `c.batch` is non-empty, refusing to poll new records while a batch
   is in flight. With the internal-loop design this is defensive (the batch is always cleared on each return), but the invariant is
  load-bearing for `CommitUncommittedOffsets` correctness — without it, franz-go's polled cursor could extend past unprocessed records.
  - A comment near `commitBatch` documents this invariant.

  ### Schema interface

  Introduced an `ingestor.SchemaValidator` interface (subset of `*schema_v2.Schema` — `Validate` / `Get` / `IsExternal`) so the
  processor is unit-testable without a real schema registry. `*schema_v2.Schema` satisfies it without changes; no caller updates
  required.

  ## Tests

  Added `internal/ingestor/processor_test.go` with a fake `stream.Publisher` driving:

  - **Happy path** — 10 records, all ack, returns `batch[9]`, no DLQ writes.
  - **Throttle hit clears on retry** — 100 records, throttle returns at idx 30 on first pass, clears on second pass; whole batch
  completes via the internal loop, zero DLQ writes.
  - **Server-side NAK recovers** — r3 returns `JSErrCodeStreamStoreFailed` on first attempt; r4..r99 ack out-of-order. Asserts
  `lastProcessed = batch[99]` and zero DLQ writes (101 publish calls = 100 fresh + 1 retry of r3).
  - **Fatal future error** — r5 returns a non-backpressure error; cleanup DLQs r5 only; `lastProcessed = batch[19]`.
  - **ctx cancel during backoff** — 3 records all NAK, ctx cancels at 20ms; cleanup DLQs the carry slice (3 DLQ writes); returns within
   `IngestorBackpressureMaxDelay`.
  - **DLQ failure during cleanup** — DLQ publisher returns an error; processor returns `errors.Join(ctx.Canceled, dlqErr)` with
  `lastProcessed = nil`.

  ## Known gaps (tracked separately)

  - **Per-record retry cap** — the `retries` counter is in place but uncapped. A future ticket will decide the value and promote stuck
  records to fatal.
  - **`kgo.OnPartitionsRevoked`** — not wired up in this PR. Single-consumer-per-group makes rebalances rare but not impossible (broker
   reconnect, k8s eviction). With the current design, an in-memory backpressure carry slice can become stale on revocation. To be added
   in a follow-up.
  - **`<-WaitForAsyncPublishAcks()` is ctx-blind** — drain time on shutdown is bounded by NATS server-side timeouts (~30s default), not
   by ctx. Acceptable for now; can add ctx-aware draining later.

  ## Operational note

  Without a downstream consumer making progress, the ingestor will sit in the internal retry loop indefinitely while continuing to
  heartbeat to its consumer group. This is correct behaviour, not a hang — Kafka offsets stay where they are, no data is lost, and the
  loop exits cleanly when ctx cancels.