### PR TITLE
feat(nats): chunk NATS batch writer to cap per-request memory usage

### DIFF
--- a/glassflow-api/cmd/glassflow/dedup_component.go
+++ b/glassflow-api/cmd/glassflow/dedup_component.go
@@ -124,11 +124,13 @@ func mainDeduplicatorV2(
 	batchWriter := batchNats.NewBatchWriter(
 		nc.JetStream(),
 		outputRouter,
+		0,
 	)
 
 	dlqWriter := batchNats.NewBatchWriter(
 		nc.JetStream(),
 		dlqSubjectRouter,
+		0,
 	)
 
 	componentSignal, err := componentsignals.NewPublisher(nc)

--- a/glassflow-api/cmd/glassflow/main.go
+++ b/glassflow-api/cmd/glassflow/main.go
@@ -89,6 +89,7 @@ type config struct {
 	UsageStatsInstallationID string `default:"" split_words:"true"`
 
 	OTLPConfigFetcherBaseURL string `default:"" split_words:"true"`
+	OTLPNatsChunkSize        int    `default:"1000" split_words:"true"`
 }
 
 var version = "dev"

--- a/glassflow-api/cmd/glassflow/oltp_receiver.go
+++ b/glassflow-api/cmd/glassflow/oltp_receiver.go
@@ -18,7 +18,7 @@ func mainOLTPReceiver(
 	log *slog.Logger,
 ) error {
 	fetcher := configFetcher.New(cfg.OTLPConfigFetcherBaseURL)
-	otlpDataProcessor := otlp_processor.NewProcessor(fetcher, nc)
+	otlpDataProcessor := otlp_processor.NewProcessor(fetcher, nc, cfg.OTLPNatsChunkSize)
 	r, err := oltp_receiver.New(log, otlpDataProcessor)
 	if err != nil {
 		return err

--- a/glassflow-api/internal/batch/nats/nats_batch_writer.go
+++ b/glassflow-api/internal/batch/nats/nats_batch_writer.go
@@ -20,27 +20,49 @@ type subjectRouter interface {
 type BatchWriter struct {
 	js            jetstream.JetStream
 	subjectRouter subjectRouter
+	chunkSize     int
 }
 
-// NewBatchWriter creates a new NATS async batch writer
+// NewBatchWriter creates a new NATS async batch writer.
+// chunkSize controls how many messages are published per async round-trip;
+// use a value <= 0 to publish all messages in a single chunk.
 func NewBatchWriter(
 	js jetstream.JetStream,
 	subjectRouter subjectRouter,
+	chunkSize int,
 ) *BatchWriter {
-	batchWriter := &BatchWriter{
+	return &BatchWriter{
 		js:            js,
 		subjectRouter: subjectRouter,
+		chunkSize:     chunkSize,
 	}
-
-	return batchWriter
 }
 
-// WriteBatch writes a batch of messages to NATS asynchronously
-func (w *BatchWriter) WriteBatch(_ context.Context, messages []models.Message) []models.FailedMessage {
+// WriteBatch writes a batch of messages to NATS asynchronously.
+// Messages are published in chunks to cap peak memory usage from in-flight futures.
+func (w *BatchWriter) WriteBatch(ctx context.Context, messages []models.Message) []models.FailedMessage {
 	if len(messages) == 0 {
 		return nil
 	}
 
+	chunkSize := w.chunkSize
+	if chunkSize <= 0 {
+		chunkSize = len(messages)
+	}
+
+	var failedMessages []models.FailedMessage
+	for i := 0; i < len(messages); i += chunkSize {
+		end := i + chunkSize
+		if end > len(messages) {
+			end = len(messages)
+		}
+		failed := w.writeChunk(ctx, messages[i:end])
+		failedMessages = append(failedMessages, failed...)
+	}
+	return failedMessages
+}
+
+func (w *BatchWriter) writeChunk(_ context.Context, messages []models.Message) []models.FailedMessage {
 	futures := make([]jetstream.PubAckFuture, 0, len(messages))
 	var failedMessages []models.FailedMessage
 
@@ -49,7 +71,6 @@ func (w *BatchWriter) WriteBatch(_ context.Context, messages []models.Message) [
 
 		future, err := w.js.PublishMsgAsync(natsMsg)
 		if err != nil {
-			// Failed to queue for async publishing - treat as failed message
 			failedMessages = append(failedMessages, models.FailedMessage{
 				Message: models.Message{
 					Type:            models.MessageTypeNatsMsg,
@@ -67,7 +88,6 @@ func (w *BatchWriter) WriteBatch(_ context.Context, messages []models.Message) [
 		return failedMessages
 	}
 
-	// Wait for all async publishes to complete
 	<-w.js.PublishAsyncComplete()
 
 	for _, future := range futures {

--- a/glassflow-api/internal/batch/nats/nats_batch_writer_test.go
+++ b/glassflow-api/internal/batch/nats/nats_batch_writer_test.go
@@ -62,7 +62,7 @@ func TestBatchWriter_WriteBatch(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	writer := natsBatch.NewBatchWriter(js, subjectRouter)
+	writer := natsBatch.NewBatchWriter(js, subjectRouter, 0)
 
 	// Create test messages
 	messages := []models.Message{
@@ -121,7 +121,7 @@ func TestBatchWriter_WriteBatchWithHeaders(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	writer := natsBatch.NewBatchWriter(js, subjectRouter)
+	writer := natsBatch.NewBatchWriter(js, subjectRouter, 0)
 
 	// Create message with headers
 	messages := []models.Message{
@@ -235,7 +235,7 @@ func TestBatchWriter_WriteBatchWithJetStreamMsg(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	writer := natsBatch.NewBatchWriter(js, subjectRouter)
+	writer := natsBatch.NewBatchWriter(js, subjectRouter, 0)
 	messages := []models.Message{
 		{
 			Type:                 models.MessageTypeJetstreamMsg,

--- a/glassflow-api/internal/otlp-receiver/server/processor/logs_test.go
+++ b/glassflow-api/internal/otlp-receiver/server/processor/logs_test.go
@@ -55,7 +55,7 @@ func TestProcessLogs(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	proc := processor.NewProcessor(&stubOTLPConfigFetcher{}, nc)
+	proc := processor.NewProcessor(&stubOTLPConfigFetcher{}, nc, 1000)
 
 	req := &collogspb.ExportLogsServiceRequest{
 		ResourceLogs: []*logsv1.ResourceLogs{

--- a/glassflow-api/internal/otlp-receiver/server/processor/metrics_test.go
+++ b/glassflow-api/internal/otlp-receiver/server/processor/metrics_test.go
@@ -42,7 +42,7 @@ func TestProcessMetrics(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	proc := processor.NewProcessor(&stubOTLPConfigFetcher{}, nc)
+	proc := processor.NewProcessor(&stubOTLPConfigFetcher{}, nc, 1000)
 
 	value := 42.5
 	req := &colmetricspb.ExportMetricsServiceRequest{

--- a/glassflow-api/internal/otlp-receiver/server/processor/processor.go
+++ b/glassflow-api/internal/otlp-receiver/server/processor/processor.go
@@ -27,11 +27,13 @@ type OTLPConfigFetcher interface {
 func NewProcessor(
 	otlpConfigFetcher OTLPConfigFetcher,
 	nc *client.NATSClient,
+	natsChunkSize int,
 ) *Processor {
 	return &Processor{
 		otlpConfigFetcher: otlpConfigFetcher,
 		natsWriterCache:   make(map[string]writerConfig),
 		nc:                nc,
+		natsChunkSize:     natsChunkSize,
 	}
 }
 
@@ -48,6 +50,7 @@ type Processor struct {
 	natsWriterCache   map[string]writerConfig
 	natsWriterMu      sync.RWMutex
 	nc                *client.NATSClient
+	natsChunkSize     int
 }
 
 func (p *Processor) getWriterConfig(
@@ -71,7 +74,7 @@ func (p *Processor) getWriterConfig(
 		return writerConfig{}, fmt.Errorf("subjectrouter.New: %w", err)
 	}
 
-	newWriterConfig := nats.NewBatchWriter(p.nc.JetStream(), subjectRouter)
+	newWriterConfig := nats.NewBatchWriter(p.nc.JetStream(), subjectRouter, p.natsChunkSize)
 
 	p.natsWriterMu.Lock()
 	defer p.natsWriterMu.Unlock()

--- a/glassflow-api/internal/otlp-receiver/server/processor/traces_test.go
+++ b/glassflow-api/internal/otlp-receiver/server/processor/traces_test.go
@@ -42,7 +42,7 @@ func TestProcessTraces(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	proc := processor.NewProcessor(&stubOTLPConfigFetcher{}, nc)
+	proc := processor.NewProcessor(&stubOTLPConfigFetcher{}, nc, 1000)
 
 	req := &coltracepb.ExportTraceServiceRequest{
 		ResourceSpans: []*tracev1.ResourceSpans{

--- a/glassflow-api/tests/dedup_test.go
+++ b/glassflow-api/tests/dedup_test.go
@@ -172,7 +172,7 @@ func createComponent(
 		Type:          models.RoutingTypeName,
 	})
 	require.NoError(t, err)
-	writer := batchNats.NewBatchWriter(js, subjectRouter)
+	writer := batchNats.NewBatchWriter(js, subjectRouter, 0)
 
 	var dlqWriter batch.BatchWriter
 	if dlqSubject != nil {
@@ -182,7 +182,7 @@ func createComponent(
 		})
 		require.NoError(t, err)
 
-		dlqWriter = batchNats.NewBatchWriter(js, dlqSubjectRouter)
+		dlqWriter = batchNats.NewBatchWriter(js, dlqSubjectRouter, 0)
 	}
 
 	role := internal.RoleDeduplicator

--- a/glassflow-api/tests/streaming_component_test.go
+++ b/glassflow-api/tests/streaming_component_test.go
@@ -50,7 +50,7 @@ func createStreamingComponent(
 		Type:          models.RoutingTypeName,
 	})
 	require.NoError(t, err)
-	writer := batchNats.NewBatchWriter(js, subjectRouter)
+	writer := batchNats.NewBatchWriter(js, subjectRouter, 0)
 
 	var dlqWriter batch.BatchWriter
 	if dlqSubject != nil {
@@ -60,7 +60,7 @@ func createStreamingComponent(
 		})
 		require.NoError(t, err)
 
-		dlqWriter = batchNats.NewBatchWriter(js, dlqSubjectRouter)
+		dlqWriter = batchNats.NewBatchWriter(js, dlqSubjectRouter, 0)
 	}
 
 	role := internal.RoleDeduplicator


### PR DESCRIPTION
Fixes ETL-1048.

## Summary

- `NewBatchWriter` now takes a `chunkSize int` parameter
- `WriteBatch` iterates in fixed-size chunks, calling `PublishAsyncComplete` between each — so peak in-flight NATS futures are bounded regardless of batch size
- `chunkSize <= 0` preserves the previous single-chunk behaviour for all non-OTLP callers (dedup component, tests)
- OTLP receiver sets chunk size via `GLASSFLOW_OTLP_NATS_CHUNK_SIZE` (default **1000**), keeping peak futures well under JetStream's 4096 async-pending default

## Why this matters

A large OTLP batch (e.g. 10k spans) previously scheduled all 10k `PubAckFuture` handles at once. With chunking at 1000, peak futures in-flight is capped at 1000 and memory is released between chunks.

## Configuration

| Env var | Default |
|---|---|
| `GLASSFLOW_OTLP_NATS_CHUNK_SIZE` | `1000` |

## Test plan

- [ ] `go test ./internal/batch/nats/... -race` passes
- [ ] Send a large OTLP batch (>1000 spans) → verify it publishes successfully in multiple chunks
- [ ] Dedup component behaviour unchanged (chunk size 0 = single chunk)