### PR TITLE
ETL-1028: Add back pressure retry to dedup streaming component

### DIFF
--- a/glassflow-api/internal/processor/streaming_component.go
+++ b/glassflow-api/internal/processor/streaming_component.go
@@ -10,6 +10,7 @@ import (
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal"
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/batch"
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/models"
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/stream"
 )
 
 // streamingState encapsulates all streaming-specific state
@@ -163,6 +164,70 @@ func (sc *StreamingComponent) Shutdown() {
 	})
 }
 
+// writeWithBackpressure calls WriteBatch and retries back-pressure failures with
+// exponential backoff. Hard failures are routed to the DLQ. While retrying it
+// calls InProgress() on the upstream JetStream messages so AckWait does not
+// expire and trigger redelivery.
+func (sc *StreamingComponent) writeWithBackpressure(ctx context.Context, upstream []models.Message, messages []models.Message) error {
+	backoff := internal.IngestorBackpressureInitialDelay
+	for {
+		failed := sc.writer.WriteBatch(ctx, messages)
+		if len(failed) == 0 {
+			return nil
+		}
+
+		var backpressure []models.FailedMessage
+		var hard []models.FailedMessage
+		for _, fm := range failed {
+			if stream.IsBackpressureErr(fm.Error) {
+				backpressure = append(backpressure, fm)
+			} else {
+				hard = append(hard, fm)
+			}
+		}
+
+		if len(hard) > 0 {
+			if err := sc.writeFailedBatch(ctx, hard); err != nil {
+				return fmt.Errorf("write failed batch: %w", err)
+			}
+		}
+
+		if len(backpressure) == 0 {
+			return nil
+		}
+
+		// Extend AckWait on upstream JetStream messages so the broker does not
+		// redeliver them while we wait for the output stream to drain.
+		for _, msg := range upstream {
+			if msg.JetstreamMsgOriginal == nil {
+				continue
+			}
+			if ipErr := msg.JetstreamMsgOriginal.InProgress(); ipErr != nil {
+				sc.log.WarnContext(ctx, "failed to extend ack-wait during back-pressure", "error", ipErr)
+			}
+		}
+
+		sc.log.WarnContext(ctx, "output stream back-pressure, retrying", "backoff", backoff, "pending", len(backpressure))
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(backoff):
+		}
+
+		backoff *= 2
+		if backoff > internal.IngestorBackpressureMaxDelay {
+			backoff = internal.IngestorBackpressureMaxDelay
+		}
+
+		// Retry only the back-pressure messages.
+		messages = make([]models.Message, 0, len(backpressure))
+		for _, fm := range backpressure {
+			messages = append(messages, fm.Message)
+		}
+	}
+}
+
 func (sc *StreamingComponent) writeFailedBatch(ctx context.Context, failedMessages []models.FailedMessage) error {
 	messages := make([]models.Message, 0, len(failedMessages))
 	for _, failedMessage := range failedMessages {
@@ -208,12 +273,8 @@ func (sc *StreamingComponent) ProcessBatch(ctx context.Context, batch []models.M
 		return sc.reader.Ack(ctx, batch)
 	}
 
-	failedMessages := sc.writer.WriteBatch(ctx, messages)
-	if len(failedMessages) > 0 {
-		err = sc.writeFailedBatch(ctx, failedMessages)
-		if err != nil {
-			return fmt.Errorf("write failed batch: %w", err)
-		}
+	if err = sc.writeWithBackpressure(ctx, batch, messages); err != nil {
+		return fmt.Errorf("write batch: %w", err)
 	}
 
 	for i, commit := range commits {

--- a/glassflow-api/internal/processor/streaming_component_test.go
+++ b/glassflow-api/internal/processor/streaming_component_test.go
@@ -1,0 +1,132 @@
+package processor
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/models"
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/stream"
+)
+
+// stubWriter is a BatchWriter whose WriteBatch behaviour is controlled per call.
+type stubWriter struct {
+	calls    [][]models.FailedMessage // response to return on call[i]; cycles on last entry
+	callsN   int
+	written  [][]models.Message
+	closeErr error
+}
+
+func (s *stubWriter) WriteBatch(_ context.Context, msgs []models.Message) []models.FailedMessage {
+	s.written = append(s.written, msgs)
+	idx := s.callsN
+	if idx >= len(s.calls) {
+		idx = len(s.calls) - 1
+	}
+	s.callsN++
+	return s.calls[idx]
+}
+
+func (s *stubWriter) Close() error { return s.closeErr }
+
+func failedMsg(msg models.Message, err error) models.FailedMessage {
+	return models.FailedMessage{Message: msg, Error: err}
+}
+
+func makeMsg(payload string) models.Message {
+	return models.NewNatsMessage([]byte(payload), nil)
+}
+
+// newTestComponent builds a minimal StreamingComponent with the given writer and dlqWriter.
+func newTestComponent(writer, dlqWriter *stubWriter) *StreamingComponent {
+	return &StreamingComponent{
+		writer:    writer,
+		dlqWriter: dlqWriter,
+		log:       slog.Default(),
+		role:      "test",
+		shutdown:  shutdown{doneCh: make(chan struct{})},
+	}
+}
+
+func TestWriteWithBackpressure_SucceedsFirstTry(t *testing.T) {
+	writer := &stubWriter{calls: [][]models.FailedMessage{nil}}
+	dlq := &stubWriter{calls: [][]models.FailedMessage{nil}}
+	sc := newTestComponent(writer, dlq)
+
+	msgs := []models.Message{makeMsg(`{"id":1}`)}
+	err := sc.writeWithBackpressure(context.Background(), msgs, msgs)
+	require.NoError(t, err)
+	assert.Equal(t, 1, writer.callsN)
+	assert.Equal(t, 0, dlq.callsN)
+}
+
+func TestWriteWithBackpressure_RetriesOnBackpressure(t *testing.T) {
+	msg := makeMsg(`{"id":1}`)
+	// First call returns back-pressure failure; second call succeeds.
+	backpressureFailed := []models.FailedMessage{failedMsg(msg, stream.ErrStreamMaxPendingMsgs)}
+	writer := &stubWriter{calls: [][]models.FailedMessage{backpressureFailed, nil}}
+	dlq := &stubWriter{calls: [][]models.FailedMessage{nil}}
+	sc := newTestComponent(writer, dlq)
+
+	start := time.Now()
+	err := sc.writeWithBackpressure(context.Background(), []models.Message{msg}, []models.Message{msg})
+	require.NoError(t, err)
+	assert.Equal(t, 2, writer.callsN, "should have retried once")
+	assert.Equal(t, 0, dlq.callsN, "back-pressure errors must not go to DLQ")
+	// Back-off starts at 50ms; total should be under IngestorBackpressureMaxDelay.
+	assert.Less(t, time.Since(start), 5*time.Second)
+}
+
+func TestWriteWithBackpressure_HardFailureGoesToDLQ(t *testing.T) {
+	msg := makeMsg(`{"id":2}`)
+	hardErr := errors.New("connection closed")
+	writer := &stubWriter{calls: [][]models.FailedMessage{{failedMsg(msg, hardErr)}}}
+	dlq := &stubWriter{calls: [][]models.FailedMessage{nil}}
+	sc := newTestComponent(writer, dlq)
+
+	err := sc.writeWithBackpressure(context.Background(), []models.Message{msg}, []models.Message{msg})
+	require.NoError(t, err)
+	assert.Equal(t, 1, writer.callsN)
+	assert.Equal(t, 1, dlq.callsN, "hard failure should be written to DLQ")
+}
+
+func TestWriteWithBackpressure_BackpressureThenHardFailureRoutesCorrectly(t *testing.T) {
+	msg1 := makeMsg(`{"id":1}`)
+	msg2 := makeMsg(`{"id":2}`)
+	bpErr := stream.ErrStreamMaxPendingMsgs
+	hardErr := errors.New("stream not found")
+
+	// First call: msg1 back-pressure, msg2 hard failure.
+	// Second call (retry for msg1): succeeds.
+	firstCall := []models.FailedMessage{failedMsg(msg1, bpErr), failedMsg(msg2, hardErr)}
+	writer := &stubWriter{calls: [][]models.FailedMessage{firstCall, nil}}
+	dlq := &stubWriter{calls: [][]models.FailedMessage{nil}}
+	sc := newTestComponent(writer, dlq)
+
+	err := sc.writeWithBackpressure(context.Background(), []models.Message{msg1, msg2}, []models.Message{msg1, msg2})
+	require.NoError(t, err)
+	assert.Equal(t, 2, writer.callsN)
+	assert.Equal(t, 1, dlq.callsN, "only the hard failure should reach DLQ")
+}
+
+func TestWriteWithBackpressure_ContextCancelledDuringRetry(t *testing.T) {
+	msg := makeMsg(`{"id":3}`)
+	// Always return back-pressure so it would loop forever without cancellation.
+	writer := &stubWriter{calls: [][]models.FailedMessage{
+		{failedMsg(msg, stream.ErrStreamMaxPendingMsgs)},
+	}}
+	dlq := &stubWriter{calls: [][]models.FailedMessage{nil}}
+	sc := newTestComponent(writer, dlq)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 80*time.Millisecond)
+	defer cancel()
+
+	err := sc.writeWithBackpressure(ctx, []models.Message{msg}, []models.Message{msg})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, context.DeadlineExceeded))
+}


### PR DESCRIPTION
Route back-pressure failures through exponential-backoff retry instead of immediately sending to DLQ; call InProgress() on upstream JetStream messages to extend AckWait while the output stream drains.