### PR TITLE
ETL-1021: [Observability] Emit back-pressure event metrics

### DIFF
--- a/glassflow-api/internal/constants.go
+++ b/glassflow-api/internal/constants.go
@@ -184,6 +184,10 @@ const (
 	IngestorBackpressureInitialDelay = 50 * time.Millisecond
 	IngestorBackpressureMaxDelay     = 5 * time.Second
 
+	// Period between JetStream StreamInfo samples used for the
+	// gfm_stream_depth and gfm_stream_depth_ratio gauges.
+	IngestorStreamDepthSampleInterval = 10 * time.Second
+
 	// Orchestrator constants
 	ShutdownTimeout = 30 * time.Second
 

--- a/glassflow-api/internal/ingestor/processor.go
+++ b/glassflow-api/internal/ingestor/processor.go
@@ -49,6 +49,11 @@ type KafkaMsgProcessor struct {
 	singleDedupSubject  string
 
 	pendingPublishesLimit int
+
+	// Back-pressure episode state. Mutated only from the single-goroutine
+	// processor driver, so no synchronization is needed.
+	activeBackpressure  bool
+	backpressureStartTS time.Time
 }
 
 func NewKafkaMsgProcessor(
@@ -129,11 +134,6 @@ func (k *KafkaMsgProcessor) setDedupHeader(headers nats.Header, dedupKeyStr stri
 		return
 	}
 
-	k.log.Debug("Setting deduplication header",
-		slog.String("topic", k.topic.Name),
-		slog.String("dedupKey", k.topic.Deduplication.ID),
-		slog.String("keyValue", dedupKeyStr),
-	)
 	headers.Set("Nats-Msg-Id", dedupKeyStr)
 }
 
@@ -176,11 +176,6 @@ func (k *KafkaMsgProcessor) getSubjectAndDedupKey(ctx context.Context, version s
 
 func (k *KafkaMsgProcessor) prepareMesssage(ctx context.Context, msg *kgo.Record) (*nats.Msg, error) {
 	version, err := k.schema.Validate(ctx, msg.Value)
-	k.log.Debug("Schema validation result",
-		slog.String("topic", k.topic.Name),
-		slog.String("version", version),
-		slog.Any("error", err))
-
 	if err != nil {
 		if models.IsIncompatibleSchemaError(err) || errors.Is(err, models.ErrSchemaNotFound) {
 			k.log.Error("Schema validation error has been detected for message",
@@ -240,6 +235,34 @@ func (k *KafkaMsgProcessor) prepareMesssage(ctx context.Context, msg *kgo.Record
 	k.setDedupHeader(nMsg.Header, dedupKeyStr)
 
 	return nMsg, nil
+}
+
+// bpStart marks the beginning of a back-pressure episode. Idempotent — extra
+// calls inside an active episode are no-ops, so the histogram observes one
+// duration per episode regardless of how many BP errors happen along the way.
+func (k *KafkaMsgProcessor) bpStart(ctx context.Context) {
+	if k.activeBackpressure {
+		return
+	}
+	k.activeBackpressure = true
+	k.backpressureStartTS = time.Now()
+	observability.RecordIngestorBackpressureStart(ctx)
+	k.log.InfoContext(ctx, "ingestor backpressure: start",
+		slog.String("pipeline_id", k.pipelineID))
+}
+
+// bpStop ends an active back-pressure episode and observes its duration.
+// No-op when no episode is active.
+func (k *KafkaMsgProcessor) bpStop(ctx context.Context) {
+	if !k.activeBackpressure {
+		return
+	}
+	dur := time.Since(k.backpressureStartTS).Seconds()
+	k.activeBackpressure = false
+	observability.RecordIngestorBackpressureStop(ctx, dur)
+	k.log.InfoContext(ctx, "ingestor backpressure: stop",
+		slog.String("pipeline_id", k.pipelineID),
+		slog.Float64("duration_seconds", dur))
 }
 
 func (k *KafkaMsgProcessor) ProcessBatch(ctx context.Context, batch []*kgo.Record) (*kgo.Record, error) {
@@ -368,7 +391,7 @@ func (k *KafkaMsgProcessor) processBatchAsync(ctx context.Context, batch []*kgo.
 		// 3. Wait for in-flight publishes to settle, then classify.
 		if len(futures) > 0 {
 			<-k.publisher.WaitForAsyncPublishAcks()
-			k.classifyFutures(s, futures)
+			k.classifyFutures(ctx, s, futures)
 			futures = futures[:0]
 		}
 
@@ -383,6 +406,7 @@ func (k *KafkaMsgProcessor) processBatchAsync(ctx context.Context, batch []*kgo.
 			return k.cleanupAndReturn(ctx, s, ctx.Err())
 		}
 		if s.cursor == len(s.batch) && len(s.backpressure) == 0 {
+			k.bpStop(ctx)
 			observability.RecordBytesProcessed(ctx, "ingestor", "out", s.outBytes)
 			return s.batch[len(s.batch)-1], nil
 		}
@@ -419,6 +443,7 @@ func (k *KafkaMsgProcessor) publishBackpressureSlice(ctx context.Context, s *asy
 		fut, err := k.publisher.PublishNatsMsgAsync(ctx, s.cachedMsgs[idx], k.pendingPublishesLimit)
 		if err != nil {
 			if stream.IsBackpressureErr(err) {
+				k.bpStart(ctx)
 				carry = append(carry, idx)
 				continue
 			}
@@ -469,6 +494,7 @@ func (k *KafkaMsgProcessor) publishFromCursor(ctx context.Context, s *asyncBatch
 		if err != nil {
 			if stream.IsBackpressureErr(err) {
 				// Throttle hit. Don't advance cursor — try again next iter.
+				k.bpStart(ctx)
 				return futures
 			}
 			s.savedErr = err
@@ -484,7 +510,7 @@ func (k *KafkaMsgProcessor) publishFromCursor(ctx context.Context, s *asyncBatch
 
 // classifyFutures inspects each in-flight future, marks completed indices, and
 // routes failures into either backpressure (retry) or dlqOnExit (fatal).
-func (k *KafkaMsgProcessor) classifyFutures(s *asyncBatchState, futures []pendingPublish) {
+func (k *KafkaMsgProcessor) classifyFutures(ctx context.Context, s *asyncBatchState, futures []pendingPublish) {
 	for _, p := range futures {
 		select {
 		case <-p.future.Ok():
@@ -494,6 +520,7 @@ func (k *KafkaMsgProcessor) classifyFutures(s *asyncBatchState, futures []pendin
 			}
 		case err := <-p.future.Err():
 			if stream.IsBackpressureErr(err) {
+				k.bpStart(ctx)
 				s.backpressure = append(s.backpressure, p.idx)
 				s.retries[p.idx]++
 				continue
@@ -528,6 +555,10 @@ func (k *KafkaMsgProcessor) advanceLastAckedIdx(s *asyncBatchState) {
 // partial progress is better than silently losing track of which records were
 // actually DLQ'd.
 func (k *KafkaMsgProcessor) cleanupAndReturn(ctx context.Context, s *asyncBatchState, cause error) (*kgo.Record, error) {
+	// Flush any active back-pressure episode so the duration histogram still
+	// gets observed when we exit on a fatal error or ctx cancellation.
+	k.bpStop(ctx)
+
 	// When the cleanup is triggered by ctx cancellation, the same ctx will
 	// fail on every DLQ push. Use a fresh, bounded ctx so we can still drain.
 	dlqCtx := ctx

--- a/glassflow-api/internal/ingestor/processor_test.go
+++ b/glassflow-api/internal/ingestor/processor_test.go
@@ -1,4 +1,4 @@
-package ingestor_test
+package ingestor
 
 import (
 	"context"
@@ -16,7 +16,6 @@ import (
 	"github.com/twmb/franz-go/pkg/kgo"
 
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal"
-	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/ingestor"
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/models"
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/stream"
 )
@@ -122,9 +121,9 @@ func makeBatch(n int) []*kgo.Record {
 	return batch
 }
 
-func newProcessor(t *testing.T, pub stream.Publisher) *ingestor.KafkaMsgProcessor {
+func newProcessor(t *testing.T, pub stream.Publisher) *KafkaMsgProcessor {
 	t.Helper()
-	p, err := ingestor.NewKafkaMsgProcessor(
+	p, err := NewKafkaMsgProcessor(
 		"pipeline-test",
 		pub,
 		pub, // dlq publisher: reuse so we can count Publish() calls as DLQ writes
@@ -314,4 +313,60 @@ func TestProcessBatch_DLQFailureDuringCleanup(t *testing.T) {
 	// First DLQ push fails so nothing is marked completed; lastProcessed
 	// stays nil.
 	require.Nil(t, last)
+}
+
+// One BP cycle: throttle hits on the first publish call and clears on retry.
+// activeBackpressure must end up false once the batch fully drains.
+func TestProcessBatchAsync_BackpressureStartStop(t *testing.T) {
+	pub := newFakePublisher("out")
+	var firstPass atomic.Bool
+	firstPass.Store(true)
+
+	pub.setPublish(func(idx int, msg *nats.Msg) (jetstream.PubAckFuture, error) {
+		if firstPass.Load() && idx == 0 {
+			firstPass.Store(false)
+			return nil, stream.ErrStreamMaxPendingMsgs
+		}
+		return newOkFuture(msg), nil
+	})
+	p := newProcessor(t, pub)
+
+	require.False(t, p.activeBackpressure, "tracker should start clean")
+
+	batch := makeBatch(3)
+	last, err := p.ProcessBatch(context.Background(), batch)
+
+	require.NoError(t, err)
+	require.Same(t, batch[2], last)
+	require.False(t, p.activeBackpressure,
+		"episode must be closed once batch fully drains")
+	require.Equal(t, int32(0), pub.dlqCalls.Load(),
+		"throttle is retryable, never DLQ'd")
+}
+
+// Server-side NAK (stream-full) classified as backpressure during the future
+// drain phase exercises the classifyFutures hook. After the retry succeeds,
+// the tracker must end clean.
+func TestProcessBatchAsync_BackpressureFromAckNak(t *testing.T) {
+	pub := newFakePublisher("out")
+	const nakAt = 1
+	var nakReturned atomic.Bool
+
+	pub.setPublish(func(idx int, msg *nats.Msg) (jetstream.PubAckFuture, error) {
+		if idx == nakAt && !nakReturned.Load() {
+			nakReturned.Store(true)
+			return newErrFuture(msg, streamFullErr()), nil
+		}
+		return newOkFuture(msg), nil
+	})
+	p := newProcessor(t, pub)
+
+	batch := makeBatch(5)
+	last, err := p.ProcessBatch(context.Background(), batch)
+
+	require.NoError(t, err)
+	require.Same(t, batch[4], last)
+	require.False(t, p.activeBackpressure,
+		"NAK-driven episode must close after the retried record acks")
+	require.Equal(t, int32(0), pub.dlqCalls.Load())
 }

--- a/glassflow-api/internal/service/ingestor_runner.go
+++ b/glassflow-api/internal/service/ingestor_runner.go
@@ -27,6 +27,8 @@ type IngestorRunner struct {
 	component component.Component
 	c         chan error
 	doneCh    chan struct{}
+
+	samplerCancel context.CancelFunc
 }
 
 func NewIngestorRunner(
@@ -151,6 +153,8 @@ func (i *IngestorRunner) Start(ctx context.Context) error {
 
 	i.component = component
 
+	i.startStreamSamplers(ctx)
+
 	go func() {
 		component.Start(ctx, i.c)
 		close(i.c)
@@ -160,6 +164,68 @@ func (i *IngestorRunner) Start(ctx context.Context) error {
 	}()
 
 	return nil
+}
+
+// startStreamSamplers resolves the streams the ingestor publishes into from
+// its runtime config, then spawns one StreamSampler per unique stream. Each
+// sampler runs until samplerCancel is called from Shutdown.
+//
+// Subjects map onto streams differently across orchestrators (local: one
+// stream covers all sharded subjects; K8s: one stream per replica), so the
+// stream set is discovered via JetStream's StreamNameBySubject rather than
+// inferred from naming conventions.
+func (i *IngestorRunner) startStreamSamplers(ctx context.Context) {
+	subjects := ingestorOutputSubjects(i.runtimeCfg)
+	if len(subjects) == 0 {
+		return
+	}
+
+	samplerCtx, cancel := context.WithCancel(ctx)
+	i.samplerCancel = cancel
+
+	js := i.nc.JetStream()
+	streams := make(map[string]struct{}, len(subjects))
+	for _, subj := range subjects {
+		name, err := js.StreamNameBySubject(samplerCtx, subj)
+		if err != nil {
+			i.log.WarnContext(ctx, "stream sampler: skipping subject (no stream bound)",
+				slog.String("subject", subj),
+				slog.Any("error", err))
+			continue
+		}
+		streams[name] = struct{}{}
+	}
+
+	for name := range streams {
+		s := stream.NewStreamSampler(js, name, i.log)
+		go s.Run(samplerCtx)
+		i.log.InfoContext(ctx, "stream sampler started",
+			slog.String("stream", name),
+			slog.String("pipeline_id", i.pipelineCfg.Status.PipelineID))
+	}
+}
+
+// ingestorOutputSubjects returns every distinct subject the ingestor will
+// publish to under the given runtime config.
+func ingestorOutputSubjects(c models.IngestorRuntimeConfig) []string {
+	if c.DedupSubjectCount > 0 && c.DedupSubjectPrefix != "" {
+		out := make([]string, c.DedupSubjectCount)
+		for i := range out {
+			out[i] = fmt.Sprintf("%s.%d", c.DedupSubjectPrefix, i)
+		}
+		return out
+	}
+	if c.TotalSubjectCount > 1 && c.OutputSubjectPrefix != "" {
+		out := make([]string, c.TotalSubjectCount)
+		for i := range out {
+			out[i] = fmt.Sprintf("%s.%d", c.OutputSubjectPrefix, i)
+		}
+		return out
+	}
+	if c.OutputSubject == "" {
+		return nil
+	}
+	return []string{c.OutputSubject}
 }
 
 func (i *IngestorRunner) getTopicConfig() (models.KafkaTopicsConfig, error) {
@@ -174,6 +240,10 @@ func (i *IngestorRunner) getTopicConfig() (models.KafkaTopicsConfig, error) {
 
 func (i *IngestorRunner) Shutdown() {
 	i.log.Debug("Stopping ingestor", slog.String("pipelineId", i.pipelineCfg.Status.PipelineID), slog.String("topic", i.topicName))
+	if i.samplerCancel != nil {
+		i.samplerCancel()
+		i.samplerCancel = nil
+	}
 	if i.component != nil {
 		i.component.Stop(component.WithNoWait(true))
 	}

--- a/glassflow-api/internal/stream/sampler.go
+++ b/glassflow-api/internal/stream/sampler.go
@@ -1,0 +1,68 @@
+package stream
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal"
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/pkg/observability"
+)
+
+// StreamSampler periodically reads JetStream StreamInfo for a single stream
+// and emits depth / depth-ratio gauges. One sampler instance per stream.
+type StreamSampler struct {
+	js         jetstream.JetStream
+	streamName string
+	interval   time.Duration
+	log        *slog.Logger
+}
+
+func NewStreamSampler(js jetstream.JetStream, streamName string, log *slog.Logger) *StreamSampler {
+	return &StreamSampler{
+		js:         js,
+		streamName: streamName,
+		interval:   internal.IngestorStreamDepthSampleInterval,
+		log:        log,
+	}
+}
+
+// Run blocks until ctx is cancelled, sampling on every tick. Errors are logged
+// at debug and skipped — sampling failures must not crash the ingestor.
+func (s *StreamSampler) Run(ctx context.Context) {
+	t := time.NewTicker(s.interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			s.sample(ctx)
+		}
+	}
+}
+
+func (s *StreamSampler) sample(ctx context.Context) {
+	str, err := s.js.Stream(ctx, s.streamName)
+	if err != nil {
+		s.log.DebugContext(ctx, "stream sampler: stream lookup failed",
+			slog.String("stream", s.streamName),
+			slog.Any("error", err))
+		return
+	}
+	info, err := str.Info(ctx)
+	if err != nil {
+		s.log.DebugContext(ctx, "stream sampler: info failed",
+			slog.String("stream", s.streamName),
+			slog.Any("error", err))
+		return
+	}
+	depth := int64(info.State.Msgs) //nolint:gosec // depth is bounded by stream limits
+	observability.RecordStreamDepth(ctx, s.streamName, depth)
+	if info.Config.MaxMsgs > 0 {
+		observability.RecordStreamDepthRatio(ctx, s.streamName,
+			float64(depth)/float64(info.Config.MaxMsgs))
+	}
+}

--- a/glassflow-api/internal/stream/sampler_test.go
+++ b/glassflow-api/internal/stream/sampler_test.go
@@ -1,0 +1,97 @@
+package stream
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats-server/v2/server"
+	natsTest "github.com/nats-io/nats-server/v2/test"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// Internal-package test so we can drive sampler.sample() directly without
+// waiting on the ticker.
+
+func runEmbeddedNATSForSampler(t *testing.T) (jetstream.JetStream, *nats.Conn) {
+	t.Helper()
+
+	srv := natsTest.RunServer(&server.Options{
+		Host:      "127.0.0.1",
+		Port:      -1,
+		NoLog:     true,
+		NoSigs:    true,
+		JetStream: true,
+	})
+
+	nc, err := nats.Connect(srv.ClientURL())
+	require.NoError(t, err)
+
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		nc.Close()
+		srv.Shutdown()
+	})
+
+	return js, nc
+}
+
+// sample() against a real stream with a known message count must not error,
+// and must not panic when MaxMsgs is unset (ratio path is skipped).
+func TestStreamSampler_SampleHappyPath(t *testing.T) {
+	js, _ := runEmbeddedNATSForSampler(t)
+	ctx := context.Background()
+
+	const subject = "sampler.test"
+	_, err := js.CreateStream(ctx, jetstream.StreamConfig{
+		Name:     "sampler-happy",
+		Subjects: []string{subject},
+		Storage:  jetstream.MemoryStorage,
+		MaxMsgs:  100,
+	})
+	require.NoError(t, err)
+
+	for range 5 {
+		_, err = js.Publish(ctx, subject, []byte("x"))
+		require.NoError(t, err)
+	}
+
+	s := NewStreamSampler(js, "sampler-happy", slog.New(slog.NewTextHandler(io.Discard, nil)))
+	s.sample(ctx)
+}
+
+// Missing stream must not panic — the sampler logs and returns.
+func TestStreamSampler_SampleMissingStream(t *testing.T) {
+	js, _ := runEmbeddedNATSForSampler(t)
+
+	s := NewStreamSampler(js, "does-not-exist", slog.New(slog.NewTextHandler(io.Discard, nil)))
+	s.sample(context.Background())
+}
+
+// Run() returns promptly when ctx is cancelled before the first tick fires.
+func TestStreamSampler_RunStopsOnCancel(t *testing.T) {
+	js, _ := runEmbeddedNATSForSampler(t)
+
+	s := NewStreamSampler(js, "irrelevant", slog.New(slog.NewTextHandler(io.Discard, nil)))
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		s.Run(ctx)
+		close(done)
+	}()
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("sampler did not exit after ctx cancel")
+	}
+}

--- a/glassflow-api/pkg/observability/meter.go
+++ b/glassflow-api/pkg/observability/meter.go
@@ -40,6 +40,12 @@ var (
 	BytesProcessed           metric.Int64Counter
 	ReceiverRequestCount     metric.Int64Counter
 	ReceiverRequestDuration  metric.Float64Histogram
+
+	IngestorBackpressureActive   metric.Int64Gauge
+	IngestorBackpressureEvents   metric.Int64Counter
+	IngestorBackpressureDuration metric.Float64Histogram
+	StreamDepth                  metric.Int64Gauge
+	StreamDepthRatio             metric.Float64Gauge
 )
 
 // pipelineID is set once at component startup (not used by the API which handles multiple pipelines).
@@ -110,6 +116,18 @@ func InitMetrics(cfg *Config) error {
 	ReceiverRequestDuration = mustCreateHistogram(m, GfMetricPrefix+"_"+"receiver_request_duration_seconds",
 		"Duration of receiver requests in seconds")
 
+	IngestorBackpressureActive = mustCreateInt64Gauge(m, GfMetricPrefix+"_"+"ingestor_backpressure_active",
+		"1 while the ingestor is in back-pressure, 0 otherwise")
+	IngestorBackpressureEvents = mustCreateCounter(m, GfMetricPrefix+"_"+"ingestor_backpressure_events_total",
+		"Total number of times the ingestor entered back-pressure")
+	IngestorBackpressureDuration = mustCreateBackpressureDurationHistogram(m,
+		GfMetricPrefix+"_"+"ingestor_backpressure_duration_seconds",
+		"Duration of each ingestor back-pressure episode in seconds")
+	StreamDepth = mustCreateInt64Gauge(m, GfMetricPrefix+"_"+"stream_depth",
+		"Number of messages currently stored in a JetStream stream")
+	StreamDepthRatio = mustCreateGauge(m, GfMetricPrefix+"_"+"stream_depth_ratio",
+		"Stream depth divided by max_messages, 0.0-1.0")
+
 	return nil
 }
 
@@ -127,6 +145,31 @@ func mustCreateGauge(m metric.Meter, name, description string) metric.Float64Gau
 		panic(fmt.Sprintf("failed to create gauge %s: %v", name, err))
 	}
 	return gauge
+}
+
+func mustCreateInt64Gauge(m metric.Meter, name, description string) metric.Int64Gauge {
+	gauge, err := m.Int64Gauge(name, metric.WithDescription(description), metric.WithUnit("1"))
+	if err != nil {
+		panic(fmt.Sprintf("failed to create int64 gauge %s: %v", name, err))
+	}
+	return gauge
+}
+
+// mustCreateBackpressureDurationHistogram uses seconds-to-minutes buckets so
+// that long episodes are observable. The default histogram factory uses
+// millisecond-scale buckets, which would clip every backpressure observation
+// at the top bucket.
+func mustCreateBackpressureDurationHistogram(m metric.Meter, name, description string) metric.Float64Histogram {
+	histogram, err := m.Float64Histogram(name,
+		metric.WithDescription(description),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(
+			0.1, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 600, 1800,
+		))
+	if err != nil {
+		panic(fmt.Sprintf("failed to create histogram %s: %v", name, err))
+	}
+	return histogram
 }
 
 func mustCreateHistogram(m metric.Meter, name, description string) metric.Float64Histogram {
@@ -274,4 +317,42 @@ func RecordReceiverRequest(ctx context.Context, component, transport, status, pi
 	if ReceiverRequestDuration != nil {
 		ReceiverRequestDuration.Record(ctx, duration, metric.WithAttributes(attrs...))
 	}
+}
+
+func RecordIngestorBackpressureStart(ctx context.Context) {
+	if IngestorBackpressureActive == nil {
+		return
+	}
+	attrs := metric.WithAttributes(attribute.String("pipeline_id", pipelineID))
+	IngestorBackpressureActive.Record(ctx, 1, attrs)
+	IngestorBackpressureEvents.Add(ctx, 1, attrs)
+}
+
+func RecordIngestorBackpressureStop(ctx context.Context, duration float64) {
+	if IngestorBackpressureActive == nil {
+		return
+	}
+	attrs := metric.WithAttributes(attribute.String("pipeline_id", pipelineID))
+	IngestorBackpressureActive.Record(ctx, 0, attrs)
+	IngestorBackpressureDuration.Record(ctx, duration, attrs)
+}
+
+func RecordStreamDepth(ctx context.Context, streamName string, depth int64) {
+	if StreamDepth == nil {
+		return
+	}
+	StreamDepth.Record(ctx, depth, metric.WithAttributes(
+		attribute.String("pipeline_id", pipelineID),
+		attribute.String("stream", streamName),
+	))
+}
+
+func RecordStreamDepthRatio(ctx context.Context, streamName string, ratio float64) {
+	if StreamDepthRatio == nil {
+		return
+	}
+	StreamDepthRatio.Record(ctx, ratio, metric.WithAttributes(
+		attribute.String("pipeline_id", pipelineID),
+		attribute.String("stream", streamName),
+	))
 }


### PR DESCRIPTION
 ## Summary

  - Adds five OTel instruments to `pkg/observability` for back-pressure visibility:
    - `gfm_ingestor_backpressure_active` (gauge 0|1, per `pipeline_id`)
    - `gfm_ingestor_backpressure_events_total` (counter, increments on entry)
    - `gfm_ingestor_backpressure_duration_seconds` (histogram, seconds-to-30min buckets, observed on exit)
    - `gfm_stream_depth` (gauge, per `pipeline_id`+`stream`)
    - `gfm_stream_depth_ratio` (gauge, depth/`MaxMsgs`, skipped when stream is unbounded)
  - Hooks back-pressure entry/exit into the existing async-publish error sites in `KafkaMsgProcessor`. State is sticky across batches:
  `bpStart` is idempotent and `bpStop` fires only when the batch fully drains (or on cleanup) — one histogram observation per episode.
  Logs `info`-level on enter/exit with `pipeline_id` and `duration_seconds`.
  - Adds `stream.StreamSampler` — a per-stream goroutine ticking every 10s, calling `Stream(...).Info(...)` and emitting depth/ratio.
  - Wires sampler(s) from `IngestorRunner`: discovers the stream set via `js.StreamNameBySubject` over the subjects the ingestor
  publishes to (derived from `IngestorRuntimeConfig`). This handles both topologies — one stream covering all sharded subjects (local)
  and one stream per replica (K8s) — without baking in naming conventions.

  ## Configuration

  | Constant | Default |
  |---|---|
  | `IngestorStreamDepthSampleInterval` | `10s` |