### PR TITLE
docs(otlp): document back-pressure behaviour and configuration

### DIFF
--- a/docs/app/configuration/metrics/page.mdx
+++ b/docs/app/configuration/metrics/page.mdx
@@ -436,6 +436,10 @@ The OTLP receiver components (otlp.logs, otlp.metrics, otlp.traces) export:
 - `{namespace}_gfm_receiver_request_duration_seconds` - Receiver request duration by transport and status
 - `{namespace}_gfm_bytes_processed_total` - Bytes processed (in/out)
 
+<Callout type="info">
+The `gfm_ingestor_backpressure_*` and `gfm_stream_depth*` metrics are emitted by the Kafka ingestor and are **not** available for OTLP source pipelines.
+</Callout>
+
 ### UI
 The UI exports interaction and performance metrics via OTLP:
 - `gfm_ui_page_views_total` - Page view counts
@@ -560,7 +564,7 @@ The `job` label in your metrics comes from the `job_name` field in your Promethe
    - `rate({namespace}_gfm_receiver_request_count{status="error"}[5m])` - OTLP receiver error rate
    - `histogram_quantile(0.95, rate({namespace}_gfm_receiver_request_duration_seconds_bucket[5m]))` - 95th percentile receiver latency
 
-5. **Back-Pressure Metrics** (Ingestor / OTLP receiver):
+5. **Back-Pressure Metrics** (Kafka ingestor pipelines only):
    - `{namespace}_gfm_ingestor_backpressure_active` - Currently in back-pressure (`1`) or not (`0`)
    - `rate({namespace}_gfm_ingestor_backpressure_events_total[5m])` - Rate of new back-pressure episodes
    - `histogram_quantile(0.95, rate({namespace}_gfm_ingestor_backpressure_duration_seconds_bucket[5m]))` - 95th percentile episode duration

--- a/docs/app/configuration/metrics/page.mdx
+++ b/docs/app/configuration/metrics/page.mdx
@@ -264,6 +264,65 @@ HTTP server metrics do not include `component` or `pipeline_id` labels. They are
 
 **Histogram Buckets**: Same as `processing_duration_seconds` (0.001 to 10.0).
 
+### Back-Pressure Metrics
+
+These metrics are emitted by the ingestor component and the NATS stream sampler. They help identify whether back-pressure is active and how long episodes last.
+
+#### `{namespace}_gfm_ingestor_backpressure_active`
+- **Type**: Gauge (Int64)
+- **Description**: Set to `1` while the ingestor is blocked waiting for NATS to drain; `0` otherwise
+- **Unit**: —
+- **Components**: Ingestor
+- **Labels**:
+  - `pipeline_id`: Unique pipeline identifier - *Added by GlassFlow*
+  - `instance`: Instance identifier - *Added by Prometheus*
+  - `job`: Job identifier - *Added by Prometheus*
+
+#### `{namespace}_gfm_ingestor_backpressure_events_total`
+- **Type**: Counter
+- **Description**: Total number of times the ingestor entered a back-pressure episode
+- **Unit**: Events
+- **Components**: Ingestor
+- **Labels**:
+  - `pipeline_id`: Unique pipeline identifier - *Added by GlassFlow*
+  - `instance`: Instance identifier - *Added by Prometheus*
+  - `job`: Job identifier - *Added by Prometheus*
+
+#### `{namespace}_gfm_ingestor_backpressure_duration_seconds`
+- **Type**: Histogram
+- **Description**: Duration of each ingestor back-pressure episode in seconds
+- **Unit**: Seconds
+- **Components**: Ingestor
+- **Labels**:
+  - `pipeline_id`: Unique pipeline identifier - *Added by GlassFlow*
+  - `instance`: Instance identifier - *Added by Prometheus*
+  - `job`: Job identifier - *Added by Prometheus*
+  - `le`: Histogram bucket boundary - *Added by Prometheus*
+
+**Histogram Buckets**: 0.1, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 600, 1800 seconds (second-to-minute scale, unlike the millisecond-scale default buckets used by request/processing histograms).
+
+#### `{namespace}_gfm_stream_depth`
+- **Type**: Gauge (Int64)
+- **Description**: Number of messages currently stored in a JetStream stream
+- **Unit**: Messages
+- **Components**: Ingestor
+- **Labels**:
+  - `pipeline_id`: Unique pipeline identifier - *Added by GlassFlow*
+  - `stream`: JetStream stream name - *Added by GlassFlow*
+  - `instance`: Instance identifier - *Added by Prometheus*
+  - `job`: Job identifier - *Added by Prometheus*
+
+#### `{namespace}_gfm_stream_depth_ratio`
+- **Type**: Gauge (Float64)
+- **Description**: Stream depth divided by `max_messages`; ranges from `0.0` to `1.0`. Sustained values near `1.0` indicate the stream is near capacity and back-pressure is likely
+- **Unit**: Ratio (0.0–1.0)
+- **Components**: Ingestor
+- **Labels**:
+  - `pipeline_id`: Unique pipeline identifier - *Added by GlassFlow*
+  - `stream`: JetStream stream name - *Added by GlassFlow*
+  - `instance`: Instance identifier - *Added by Prometheus*
+  - `job`: Job identifier - *Added by Prometheus*
+
 ## UI Metrics
 
 UI metrics are exported via OTLP (not Prometheus scraping). All UI metrics use the `gfm_ui_` prefix.
@@ -333,6 +392,11 @@ The Ingestor component primarily exports:
 - `{namespace}_gfm_processor_messages_total` - Message counts by status
 - `{namespace}_gfm_bytes_processed_total` - Bytes processed (in/out)
 - `{namespace}_gfm_dlq_records_written_total` - Records sent to DLQ on processing errors
+- `{namespace}_gfm_ingestor_backpressure_active` - 1 while blocked on NATS back-pressure
+- `{namespace}_gfm_ingestor_backpressure_events_total` - Count of back-pressure episodes
+- `{namespace}_gfm_ingestor_backpressure_duration_seconds` - Duration of each back-pressure episode
+- `{namespace}_gfm_stream_depth` - Current message count in the JetStream stream
+- `{namespace}_gfm_stream_depth_ratio` - Stream fill ratio (0.0–1.0)
 
 ### Sink Component
 The Sink component primarily exports:
@@ -368,7 +432,7 @@ The API server exports HTTP metrics when metrics are enabled:
 
 ### OTLP Receiver
 The OTLP receiver components (otlp.logs, otlp.metrics, otlp.traces) export:
-- `{namespace}_gfm_receiver_request_count` - Receiver request count by transport and status
+- `{namespace}_gfm_receiver_request_count` - Receiver request count by transport (`http`/`grpc`) and status (`ok`/`error`)
 - `{namespace}_gfm_receiver_request_duration_seconds` - Receiver request duration by transport and status
 - `{namespace}_gfm_bytes_processed_total` - Bytes processed (in/out)
 
@@ -401,6 +465,7 @@ These labels are added by the GlassFlow application code:
 | `status` | Outcome (processor messages), request result (receiver), or HTTP status code (HTTP/UI metrics) | `success`, `error`, `filtered`, `duplicate`, `out`, `ok`, or HTTP code e.g. `200` |
 | `direction` | Data flow direction (for `bytes_processed_total`) | `in`, `out` |
 | `transport` | Transport protocol (for receiver metrics) | `http`, `grpc` |
+| `stream` | JetStream stream name (for stream depth metrics) | pipeline stream name |
 | `method` | HTTP method (HTTP and UI API metrics) | `GET`, `POST`, `PUT`, `DELETE` |
 | `path` | Route path template (HTTP and UI metrics) | `/api/v1/pipelines`, `/health` |
 
@@ -494,6 +559,13 @@ The `job` label in your metrics comes from the `job_name` field in your Promethe
 4. **Receiver Metrics**:
    - `rate({namespace}_gfm_receiver_request_count{status="error"}[5m])` - OTLP receiver error rate
    - `histogram_quantile(0.95, rate({namespace}_gfm_receiver_request_duration_seconds_bucket[5m]))` - 95th percentile receiver latency
+
+5. **Back-Pressure Metrics** (Ingestor / OTLP receiver):
+   - `{namespace}_gfm_ingestor_backpressure_active` - Currently in back-pressure (`1`) or not (`0`)
+   - `rate({namespace}_gfm_ingestor_backpressure_events_total[5m])` - Rate of new back-pressure episodes
+   - `histogram_quantile(0.95, rate({namespace}_gfm_ingestor_backpressure_duration_seconds_bucket[5m]))` - 95th percentile episode duration
+   - `{namespace}_gfm_stream_depth_ratio` - Stream fill ratio; alert when sustained near `1.0`
+   - `{namespace}_gfm_stream_depth` - Absolute message backlog in stream
 
 5. **Health Metrics**:
    - `{namespace}_up` - Service availability

--- a/docs/app/installation/kubernetes/helm-values/page.mdx
+++ b/docs/app/installation/kubernetes/helm-values/page.mdx
@@ -313,6 +313,61 @@ glassflow-operator:
 
 The `dedup.storage` field provisions a PersistentVolumeClaim for the deduplication state store. Set `storage.size` based on your expected deduplication key volume and `storage.className` to a StorageClass name if you need a specific provisioner.
 
+## OTLP Receiver
+
+The OTLP receiver accepts OpenTelemetry data directly over gRPC (port 4317) and HTTP (port 4318), enabling OTLP source pipelines without a Kafka cluster. It is disabled by default.
+
+```yaml
+sources:
+  otlpReceiver:
+    enabled: false
+    replicas: 1
+
+    image:
+      repository: glassflow-etl-otlp-receiver
+      tag: v3.1.0
+      pullPolicy: IfNotPresent
+
+    resources:
+      requests:
+        memory: "256Mi"
+        cpu: "250m"
+      limits:
+        memory: "512Mi"
+        cpu: "500m"
+
+    service:
+      type: ClusterIP
+      grpcPort: 4317
+      httpPort: 4318
+
+    # Max concurrent in-flight batches before shedding load (HTTP 429 / gRPC ResourceExhausted)
+    maxConcurrentRequests: 50
+
+    # Max messages per NATS async-publish chunk
+    natsChunkSize: 1000
+
+    # Additional environment variables
+    env: []
+```
+
+### OTLP Receiver Configuration Options
+
+| Setting | Description | Default | Production Recommendation |
+|---------|-------------|---------|---------------------------|
+| `enabled` | Deploy the OTLP receiver | `false` | Set to `true` when using OTLP source pipelines |
+| `replicas` | Number of receiver pods | `1` | Increase to distribute ingest load across pods |
+| `resources.requests` | Minimum resources per pod | `256Mi / 250m` | Scale with ingest volume |
+| `resources.limits` | Maximum resources per pod | `512Mi / 500m` | Keep headroom above `maxConcurrentRequests × 4 MiB` |
+| `maxConcurrentRequests` | Max in-flight batches before back-pressure | `50` | Increase with spare CPU/memory; `peak_memory ≈ maxConcurrentRequests × 4 MiB` |
+| `natsChunkSize` | Messages per NATS async-publish chunk | `1000` | Lower if individual messages are large |
+| `service.grpcPort` | gRPC listener port | `4317` | Standard OTLP/gRPC port |
+| `service.httpPort` | HTTP listener port | `4318` | Standard OTLP/HTTP port |
+
+<Callout type="info">
+When the receiver reaches `maxConcurrentRequests` it returns `429 Too Many Requests` (HTTP) or `ResourceExhausted` (gRPC). Standard OTel Collector exporters retry these responses automatically. See [Back-Pressure](/sources/otlp/back-pressure) for tuning guidance.
+</Callout>
+
 ## NATS Configuration
 
 NATS is the messaging system used for internal communication between GlassFlow components. 

--- a/docs/app/sources/otlp/_meta.tsx
+++ b/docs/app/sources/otlp/_meta.tsx
@@ -1,5 +1,6 @@
 export default {
     'examples': '',
     'sending-data': '',
-    'schema-reference': ''
+    'schema-reference': '',
+    'back-pressure': ''
 }

--- a/docs/app/sources/otlp/back-pressure/page.mdx
+++ b/docs/app/sources/otlp/back-pressure/page.mdx
@@ -95,17 +95,17 @@ Back-pressure is a signal that your **sink is slower than your ingest rate**. To
 
 ### Scale up the sink
 
-Increase the sink replica count so more ClickHouse writers are running in parallel:
+Increase the sink replica count so more ClickHouse writers are running in parallel. Set `resources.sink.replicas` when creating or updating the pipeline via the API:
 
-```yaml
-# values.yaml (operator-managed pipelines inherit this)
-glassflow-operator:
-  components:
-    sink:
-      replicas: 3   # increase from default
+```json
+"resources": {
+  "sink": {
+    "replicas": 3
+  }
+}
 ```
 
-Or update it per-pipeline in the pipeline resource `spec.sink.replicas`.
+The default is `1`. You can update an existing pipeline by sending a `PATCH /api/v1/pipeline/{id}` request with the new `resources` value.
 
 ### Scale up ClickHouse capacity
 

--- a/docs/app/sources/otlp/back-pressure/page.mdx
+++ b/docs/app/sources/otlp/back-pressure/page.mdx
@@ -132,8 +132,11 @@ The following metrics help identify which gate is triggering back-pressure:
 
 | Metric | Description |
 |---|---|
-| `gfm_receiver_request_count{status="backpressure"}` | Requests rejected due to either back-pressure gate |
+| `gfm_receiver_request_count{status="error"}` | Requests that failed (includes back-pressure rejections and other errors) |
 | `gfm_stream_depth_ratio{stream="..."}` | Stream fill ratio (0.0–1.0); sustained values near 1.0 indicate stream-full back-pressure |
-| `gfm_ingestor_backpressure_active` | 1 while the ingestor is in back-pressure waiting for NATS to drain |
+| `gfm_stream_depth{stream="..."}` | Absolute message count in the stream |
+| `gfm_ingestor_backpressure_active` | 1 while the ingestor is blocked waiting for NATS to drain; 0 otherwise |
+| `gfm_ingestor_backpressure_events_total` | Total number of back-pressure episodes entered |
+| `gfm_ingestor_backpressure_duration_seconds` | Duration histogram of each back-pressure episode |
 
 See the [Metrics Reference](/configuration/metrics) for the full list of available metrics and how to access them.

--- a/docs/app/sources/otlp/back-pressure/page.mdx
+++ b/docs/app/sources/otlp/back-pressure/page.mdx
@@ -128,15 +128,17 @@ sources:
 
 ## Monitoring Back-Pressure
 
-The following metrics help identify which gate is triggering back-pressure:
+The following metrics help identify which gate is triggering back-pressure. All are emitted by the **OTLP receiver** pod.
 
 | Metric | Description |
 |---|---|
-| `gfm_receiver_request_count{status="error"}` | Requests that failed (includes back-pressure rejections and other errors) |
-| `gfm_stream_depth_ratio{stream="..."}` | Stream fill ratio (0.0–1.0); sustained values near 1.0 indicate stream-full back-pressure |
-| `gfm_stream_depth{stream="..."}` | Absolute message count in the stream |
-| `gfm_ingestor_backpressure_active` | 1 while the ingestor is blocked waiting for NATS to drain; 0 otherwise |
-| `gfm_ingestor_backpressure_events_total` | Total number of back-pressure episodes entered |
-| `gfm_ingestor_backpressure_duration_seconds` | Duration histogram of each back-pressure episode |
+| `gfm_receiver_request_count{status="error"}` | Requests that failed — includes both concurrency-limit and stream-full rejections |
+| `gfm_receiver_request_duration_seconds` | Request latency; rising p99 often precedes sustained back-pressure |
+
+<Callout type="info">
+The `gfm_ingestor_backpressure_*` and `gfm_stream_depth*` metrics are emitted by the **Kafka ingestor** component, which is not present in OTLP source pipelines. They do not apply here.
+</Callout>
+
+To distinguish concurrency-limit back-pressure from stream-full back-pressure, check the receiver pod logs — each rejection is logged with a `reason` field (`overloaded` or `stream_backpressure`).
 
 See the [Metrics Reference](/configuration/metrics) for the full list of available metrics and how to access them.

--- a/docs/app/sources/otlp/back-pressure/page.mdx
+++ b/docs/app/sources/otlp/back-pressure/page.mdx
@@ -1,0 +1,139 @@
+---
+title: 'Back-Pressure'
+description: 'How the GlassFlow OTLP receiver signals back-pressure to upstream collectors and how to tune or resolve it'
+---
+import { Callout } from 'nextra/components'
+
+# OTLP Receiver Back-Pressure
+
+When the GlassFlow OTLP receiver cannot keep up with incoming data it signals back-pressure to the upstream OTel Collector or SDK instead of silently dropping events or consuming unbounded memory.
+
+## How Back-Pressure Works
+
+The receiver has two independent back-pressure gates:
+
+### Concurrency Limit
+
+Each receiver pod enforces a maximum number of **concurrent in-flight requests**. When that limit is reached, any new request is rejected immediately with:
+
+- **HTTP** — `429 Too Many Requests` + `Retry-After: 1`
+- **gRPC** — `ResourceExhausted`
+
+OTel Collector exporters and SDK exporters treat both responses as retryable and will back off automatically.
+
+### NATS Stream Full
+
+Each pipeline's internal NATS stream has a configurable capacity. When the stream is full — typically because the sink is writing to ClickHouse more slowly than the receiver is ingesting — publish retries will exhaust and the request is rejected with the same signals:
+
+- **HTTP** — `429 Too Many Requests` + `Retry-After: 1`
+- **gRPC** — `ResourceExhausted`
+
+<Callout type="info">
+  Both back-pressure conditions surface as the same protocol-level response (`429` / `ResourceExhausted`) so upstream exporters handle them identically. The distinction matters only for tuning — see [Configuration](#configuration) below.
+</Callout>
+
+## What the Collector Sees
+
+Standard OTel Collector exporters (`otlphttp`, `otlp`) retry on both `429` and `ResourceExhausted` by default. You do not need to change your Collector config to handle back-pressure — the Collector will queue and retry the failed batch automatically.
+
+If your Collector's retry queue is exhausted (e.g. the back-pressure is sustained for longer than the Collector's configured `retry_on_failure.max_elapsed_time`), the Collector will drop the batch and log an error. Monitor your Collector's `otelcol_exporter_send_failed_spans` / `_logs` / `_metric_points` metrics to detect sustained back-pressure.
+
+## Configuration
+
+### Concurrency limit
+
+Controls the maximum number of requests processed simultaneously per receiver pod. Increase this if you have spare CPU and memory headroom on the pod; decrease it to protect a smaller pod.
+
+```yaml
+# values.yaml
+sources:
+  otlpReceiver:
+    maxConcurrentRequests: 50   # default
+```
+
+| Env var | Default | Description |
+|---|---|---|
+| `GLASSFLOW_OTLP_MAX_CONCURRENT_REQUESTS` | `50` | Max concurrent in-flight batches per pod |
+
+**Sizing guidance** — At 50 concurrent slots with the default 4 MiB request body limit, peak memory per pod is roughly 200 MiB, which fits within the default pod limit of 512 MiB. If you increase `maxConcurrentRequests`, increase the pod memory limit proportionally:
+
+```
+peak_memory ≈ maxConcurrentRequests × maxBodyBytes
+```
+
+### NATS chunk size
+
+Controls how many messages are published to NATS per async-publish round. This bounds the number of in-flight NATS futures and caps per-request memory inside the receiver.
+
+```yaml
+# values.yaml
+sources:
+  otlpReceiver:
+    natsChunkSize: 1000   # default
+```
+
+| Env var | Default | Description |
+|---|---|---|
+| `GLASSFLOW_OTLP_NATS_CHUNK_SIZE` | `1000` | Messages per NATS publish chunk |
+
+### Pipeline stream capacity
+
+The pipeline's internal NATS stream buffer controls how much data can be queued between the receiver and the sink before back-pressure is triggered. Configure this on the pipeline resource:
+
+```json
+"resources": {
+  "maxMsgs": 100000,
+  "maxBytes": 0
+}
+```
+
+A larger stream absorbs more burst traffic before back-pressure kicks in. See the [Pipeline Configuration Reference](/configuration/pipeline-config-reference) for full details.
+
+## Resolving Sustained Back-Pressure
+
+Back-pressure is a signal that your **sink is slower than your ingest rate**. To resolve it:
+
+### Scale up the sink
+
+Increase the sink replica count so more ClickHouse writers are running in parallel:
+
+```yaml
+# values.yaml (operator-managed pipelines inherit this)
+glassflow-operator:
+  components:
+    sink:
+      replicas: 3   # increase from default
+```
+
+Or update it per-pipeline in the pipeline resource `spec.sink.replicas`.
+
+### Scale up ClickHouse capacity
+
+If the sink replicas are already at a reasonable count but ClickHouse insert latency is high, increase ClickHouse resources or consider using a MergeTree table with async inserts to reduce insert pressure.
+
+### Scale out receiver pods
+
+If back-pressure is hitting the **concurrency limit** (not the stream), add more receiver pods to distribute the ingest load:
+
+```yaml
+# values.yaml
+sources:
+  otlpReceiver:
+    replicas: 3
+```
+
+<Callout type="warning">
+  Scaling out receiver pods increases total ingest throughput but does **not** help if the bottleneck is a full NATS stream — all pods share the same stream and will all hit back-pressure at the same point. Fix the downstream sink first.
+</Callout>
+
+## Monitoring Back-Pressure
+
+The following metrics help identify which gate is triggering back-pressure:
+
+| Metric | Description |
+|---|---|
+| `gfm_receiver_request_count{status="backpressure"}` | Requests rejected due to either back-pressure gate |
+| `gfm_stream_depth_ratio{stream="..."}` | Stream fill ratio (0.0–1.0); sustained values near 1.0 indicate stream-full back-pressure |
+| `gfm_ingestor_backpressure_active` | 1 while the ingestor is in back-pressure waiting for NATS to drain |
+
+See the [Metrics Reference](/configuration/metrics) for the full list of available metrics and how to access them.

--- a/docs/app/sources/otlp/page.mdx
+++ b/docs/app/sources/otlp/page.mdx
@@ -86,9 +86,16 @@ Because the OTLP receiver is a shared component that stays running across all pi
   While a pipeline is stopped or terminated, the OTLP receiver keeps buffering incoming data into NATS JetStream. If the pipeline stays in this state for an extended period, monitor the stream size against your `max_bytes` and `max_age` limits to avoid data eviction (see [Scaling Guide](/installation/kubernetes/scaling)).
 </Callout>
 
+## Back-Pressure
+
+When the receiver cannot keep up with incoming data it signals back-pressure to the upstream OTel Collector or SDK — returning `429 Too Many Requests` (HTTP) or `ResourceExhausted` (gRPC) — instead of silently dropping events. Standard OTel exporters retry these responses automatically.
+
+See [Back-Pressure](/sources/otlp/back-pressure) for how the two back-pressure gates work, how to tune them, and how to resolve sustained back-pressure.
+
 ## Next Steps
 
 - [Examples](/sources/otlp/examples) -- ClickStack-compatible tables and full pipeline configs for logs, traces, and metrics
 - [Sending Data](/sources/otlp/sending-data) -- OTel Collector configs, SDK instrumentation
 - [Schema Reference](/sources/otlp/schema-reference) -- field tables for logs, traces, and metrics
+- [Back-Pressure](/sources/otlp/back-pressure) -- concurrency limits, NATS stream capacity, tuning and scaling
 - [Pipeline Configuration Reference](/configuration/pipeline-config-reference) -- full configuration reference


### PR DESCRIPTION
## Summary

- Add `docs/app/sources/otlp/back-pressure/page.mdx` covering the two back-pressure gates (concurrency limit and NATS stream full), how upstream OTel exporters handle `429`/`ResourceExhausted`, tuning knobs, and how to resolve sustained back-pressure
- Update `docs/app/sources/otlp/page.mdx` with a Back-Pressure section and link to the new page
- Update `docs/app/sources/otlp/_meta.tsx` to include the new page in the navigation
- Update Metrics reference to add missing metrics

Closes ETL-1053 ETL-1091