### PR TITLE
fix(otlp-receiver): emit pipeline_id on bytes_processed and processor_messages metrics

### DIFF
--- a/glassflow-api/internal/otlp-receiver/server/processor/processor.go
+++ b/glassflow-api/internal/otlp-receiver/server/processor/processor.go
@@ -179,8 +179,8 @@ func (p *Processor) sendBatch(
 	for _, msg := range messages {
 		bytesOut += int64(len(msg.Payload()))
 	}
-	observability.RecordBytesProcessed(ctx, component.String(), "out", bytesOut)
-	observability.RecordProcessorMessages(ctx, component.String(), "out", int64(len(messages)))
+	observability.RecordBytesProcessedByPipelineID(ctx, component.String(), "out", pipelineID, bytesOut)
+	observability.RecordProcessorMessagesByPipelineID(ctx, component.String(), "out", pipelineID, int64(len(messages)))
 
 	return nil
 }

--- a/glassflow-api/pkg/observability/meter.go
+++ b/glassflow-api/pkg/observability/meter.go
@@ -279,6 +279,17 @@ func RecordBytesProcessed(ctx context.Context, component, direction string, byte
 	))
 }
 
+func RecordProcessorMessagesByPipelineID(ctx context.Context, component, status, pid string, count int64) {
+	if ProcessorMessages == nil {
+		return
+	}
+	ProcessorMessages.Add(ctx, count, metric.WithAttributes(
+		attribute.String("component", component),
+		attribute.String("pipeline_id", pid),
+		attribute.String("status", status),
+	))
+}
+
 func RecordBytesProcessedByPipelineID(ctx context.Context, component, direction, pid string, bytes int64) {
 	if BytesProcessed == nil {
 		return


### PR DESCRIPTION
## Summary

- `RecordBytesProcessed` and `RecordProcessorMessages` in the OTLP receiver processor use the package-level `pipelineID` variable, which is never set on the receiver (it handles multiple pipelines). Both metrics were emitted with an empty `pipeline_id` label.
- Added `RecordProcessorMessagesByPipelineID` to mirror the existing `RecordBytesProcessedByPipelineID`, and switched both call sites in `sendBatch` to use the per-pipeline-ID variants.

Closes ETL-992