### PR TITLE
fix(consumers): set MaxDeliver=10 and AckWait=30s on pipeline JetStream consumers

### DIFF
--- a/glassflow-api/cmd/glassflow/dedup_component.go
+++ b/glassflow-api/cmd/glassflow/dedup_component.go
@@ -109,8 +109,9 @@ func mainDeduplicatorV2(
 			Name:          consumerName,
 			Durable:       consumerName,
 			AckPolicy:     jetstream.AckExplicitPolicy,
-			AckWait:       internal.NatsDefaultAckWait,
+			AckWait:       internal.NatsConsumerAckWait,
 			MaxAckPending: maxAckPending,
+			MaxDeliver:    internal.NatsConsumerMaxDeliver,
 		},
 		inputStreamName,
 	)

--- a/glassflow-api/internal/batch/nats/nats_batch_reader.go
+++ b/glassflow-api/internal/batch/nats/nats_batch_reader.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/nats-io/nats.go/jetstream"
 
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal"
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/batch"
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/models"
 )
@@ -83,7 +84,7 @@ func (r *BatchReader) Nak(_ context.Context, messages []models.Message) error {
 			return fmt.Errorf("missing NATS original message")
 		}
 
-		if err := msg.JetstreamMsgOriginal.Nak(); err != nil {
+		if err := msg.JetstreamMsgOriginal.NakWithDelay(internal.NatsConsumerNakDelay); err != nil {
 			return fmt.Errorf("nak message: %w", err)
 		}
 	}

--- a/glassflow-api/internal/batch/nats/nats_batch_reader_test.go
+++ b/glassflow-api/internal/batch/nats/nats_batch_reader_test.go
@@ -162,7 +162,7 @@ func TestBatchReader_Nak(t *testing.T) {
 	err = reader.Nak(ctx, messages)
 	require.NoError(t, err)
 
-	// Verify messages are available for redelivery with retry
+	// Verify messages are available for redelivery after NakDelay elapses
 	err = retry.Do(
 		func() error {
 			messages, err = reader.ReadBatchNoWait(ctx, models.WithBatchSize(10))
@@ -174,8 +174,8 @@ func TestBatchReader_Nak(t *testing.T) {
 			}
 			return nil
 		},
-		retry.Delay(5*time.Millisecond),
-		retry.Attempts(10),
+		retry.Delay(500*time.Millisecond),
+		retry.Attempts(20), // up to 10s — covers NatsConsumerNakDelay (5s) with headroom
 		retry.LastErrorOnly(true),
 	)
 	require.NoError(t, err, "messages should be available for redelivery after nak")

--- a/glassflow-api/internal/constants.go
+++ b/glassflow-api/internal/constants.go
@@ -153,6 +153,9 @@ const (
 	// must be set via NakWithDelay at the call site (separate work item).
 	NatsConsumerMaxDeliver = 10
 	NatsConsumerAckWait    = 30 * time.Second
+	// NatsConsumerNakDelay is the fixed delay passed to NakWithDelay on every explicit NACK.
+	// Keeps redeliveries from hammering downstream immediately while staying simple.
+	NatsConsumerNakDelay = 5 * time.Second
 
 	// Postgres client constants
 	PostgresConnectionRetries = 12

--- a/glassflow-api/internal/constants.go
+++ b/glassflow-api/internal/constants.go
@@ -146,6 +146,14 @@ const (
 	NatsDefaultFetchMaxWait = 1 * time.Second
 	NatsDefaultAckWait      = 60 * time.Second
 
+	// Pipeline consumer retry config — applied to sink, join, and dedup consumers.
+	// MaxDeliver caps total delivery attempts; AckWait is the per-attempt timeout before
+	// NATS considers the message un-acked and redelivers it.
+	// Note: AckWait only governs ack-timeout redeliveries. Explicit NACK redelivery delay
+	// must be set via NakWithDelay at the call site (separate work item).
+	NatsConsumerMaxDeliver = 10
+	NatsConsumerAckWait    = 30 * time.Second
+
 	// Postgres client constants
 	PostgresConnectionRetries = 12
 	PostgresInitialRetryDelay = 1 * time.Second

--- a/glassflow-api/internal/service/join_runner.go
+++ b/glassflow-api/internal/service/join_runner.go
@@ -100,8 +100,9 @@ func (j *JoinRunner) Start(ctx context.Context) error {
 			Name:          models.GetNATSJoinLeftConsumerName(j.cfg.ID),
 			Durable:       models.GetNATSJoinLeftConsumerName(j.cfg.ID),
 			AckPolicy:     jetstream.AckExplicitPolicy,
-			AckWait:       internal.NatsDefaultAckWait,
+			AckWait:       internal.NatsConsumerAckWait,
 			MaxAckPending: -1,
+			MaxDeliver:    internal.NatsConsumerMaxDeliver,
 		},
 		leftInputStreamName,
 	)
@@ -117,8 +118,9 @@ func (j *JoinRunner) Start(ctx context.Context) error {
 			Name:          models.GetNATSJoinRightConsumerName(j.cfg.ID),
 			Durable:       models.GetNATSJoinRightConsumerName(j.cfg.ID),
 			AckPolicy:     jetstream.AckExplicitPolicy,
-			AckWait:       internal.NatsDefaultAckWait,
+			AckWait:       internal.NatsConsumerAckWait,
 			MaxAckPending: -1,
+			MaxDeliver:    internal.NatsConsumerMaxDeliver,
 		},
 		rightInputStreamName,
 	)

--- a/glassflow-api/internal/service/sink_runner.go
+++ b/glassflow-api/internal/service/sink_runner.go
@@ -101,8 +101,9 @@ func (s *SinkRunner) Start(ctx context.Context) error {
 			Name:          consumerName,
 			Durable:       consumerName,
 			AckPolicy:     jetstream.AckExplicitPolicy,
-			AckWait:       internal.NatsDefaultAckWait,
+			AckWait:       internal.NatsConsumerAckWait,
 			MaxAckPending: maxAckPending,
+			MaxDeliver:    internal.NatsConsumerMaxDeliver,
 		},
 		inputStreamName,
 	)

--- a/glassflow-api/tests/dedup_test.go
+++ b/glassflow-api/tests/dedup_test.go
@@ -108,7 +108,10 @@ func TestDeduplication_FailureDoesNotAckMessages(t *testing.T) {
 	// Assert
 	require.Error(t, err)
 
-	// Verify messages still in input stream (not acked)
+	// Verify messages still in input stream (not acked).
+	// NakWithDelay(NatsConsumerNakDelay) means messages are not immediately available —
+	// wait for the delay to elapse before reading.
+	time.Sleep(internal.NatsConsumerNakDelay + 500*time.Millisecond)
 	consumer, err := js.Consumer(ctx, "test-input", "test-consumer")
 	require.NoError(t, err)
 	reader := batchNats.NewBatchReader(consumer)


### PR DESCRIPTION
## Summary

Closes ETL-1032.

Sets `MaxDeliver=10`, `AckWait=30s`, and `NakWithDelay(5s)` on every pipeline JetStream consumer (sink, join left/right, dedup).

Previously:
- `MaxDeliver` was unset → unlimited redeliveries
- `AckWait` was 60s
- `Nak()` was called without a delay → immediate redelivery, hammering downstream on errors

**Note on ticket scope:** The ticket pointed to `glassflow-etl-k8s-operator`. The operator does not create pipeline consumers — it only manages streams. Consumer creation lives in `clickhouse-etl` components at pod startup.

## Changes

- `internal/constants.go` — add `NatsConsumerMaxDeliver=10`, `NatsConsumerAckWait=30s`, `NatsConsumerNakDelay=5s`
- `internal/service/sink_runner.go` — apply MaxDeliver + AckWait to sink consumer
- `internal/service/join_runner.go` — apply to both join consumers
- `cmd/glassflow/dedup_component.go` — apply to dedup consumer
- `internal/batch/nats/nats_batch_reader.go` — `Nak()` → `NakWithDelay(5s)`
- `internal/batch/nats/nats_batch_reader_test.go` — update retry window to account for NAK delay

DLQ consumer unchanged (unbounded retries intentional).

## Why not BackOff on the consumer config?

`BackOff []time.Duration` on `ConsumerConfig` only applies to ack-timeout redeliveries, not explicit `Nak()` calls. Since components NACK explicitly, that field would be dead config. `NakWithDelay` is the correct mechanism for NACK-driven backoff.

## MaxAckPending

- Sink + Dedup: `batchSize * 4` (default 200k) — no change needed
- Join: `-1` (unlimited) — no change needed