### PR TITLE
fix(e2e): use ForSQL wait strategy to eliminate transient postgres readiness race in e2e tests (ETL-1103)

### DIFF
--- a/glassflow-api/tests/testutils/containers.go
+++ b/glassflow-api/tests/testutils/containers.go
@@ -339,10 +339,11 @@ func StartPostgresContainer(ctx context.Context) (*PostgresContainer, error) {
 			"POSTGRES_USER":     "testuser",
 			"POSTGRES_PASSWORD": "testpass",
 		},
-		WaitingFor: wait.ForAll(
-			wait.ForListeningPort(PostgresPort).WithStartupTimeout(30*time.Second),
-			wait.ForLog("database system is ready to accept connections").WithStartupTimeout(30*time.Second),
-		),
+		// ForSQL polls SELECT 1 until postgres accepts queries, avoiding the race
+		// where ForListeningPort+ForLog fires before postgres is fully initialized.
+		WaitingFor: wait.ForSQL(PostgresPort, "postgres", func(host string, port nat.Port) string {
+			return fmt.Sprintf("postgres://testuser:testpass@%s:%s/glassflow_test?sslmode=disable", host, port.Port())
+		}).WithStartupTimeout(30 * time.Second),
 	}
 
 	container, err := testcontainers.GenericContainer(ctx,


### PR DESCRIPTION
## Summary

- `wait.ForListeningPort + ForLog` fires as soon as postgres logs "ready to accept connections", but postgres can still briefly reset TCP connections during final initialization — `golang-migrate`'s `New()` hits this window and fails with `EOF` / `connection reset by peer` in CI.
- Replacing with `wait.ForSQL` (polls `SELECT 1` in a loop) guarantees postgres can actually execute queries before migrations run. No new dependencies — `lib/pq` is already registered as the `"postgres"` driver via the existing `golang-migrate` import.

## Test plan

- [x] CI e2e tests pass without the intermittent `failed to open database: EOF` failure on the platform scenario
- [x] `make run-e2e-test` passes locally

## Tested multiple runs

[attempt 1](https://github.com/glassflow/clickhouse-etl/actions/runs/25745103099/attempts/1)
[attempt 2](https://github.com/glassflow/clickhouse-etl/actions/runs/25745103099/attempts/2)
[attempt 3](https://github.com/glassflow/clickhouse-etl/actions/runs/25745103099)