### PR TITLE
ci: run tests and binary build in parallel (ETL-1105)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,11 +9,10 @@ jobs:
   build-binary:
     uses: ./.github/workflows/build_binary.yaml
   test:
-    needs:
-      - build-binary
     uses: ./.github/workflows/test.yaml
   build:
     needs:
+      - build-binary
       - test
     uses: ./.github/workflows/build_image.yaml
     with:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -20,8 +20,6 @@ jobs:
   build-binary:
     uses: ./.github/workflows/build_binary.yaml
   test:
-    needs:
-      - build-binary
     if: >-
       !contains(github.event.pull_request.labels.*.name || '', 'build-only')
     uses: ./.github/workflows/test.yaml


### PR DESCRIPTION
## Summary

**- CI runtime reduced from [9min](https://github.com/glassflow/clickhouse-etl/actions/runs/25728536324)  to [6m](https://github.com/glassflow/clickhouse-etl/actions/runs/25746998361)**
- `test` had a spurious `needs: [build-binary]` in both workflows — test jobs never use the artifact (e2e runs the API in-process via `httptest`, unit/lint only need source). This was blocking tests from starting for ~94s with no benefit.
- Removes the dependency so `test` and `build-binary` run in parallel. `build` (docker images) still waits for both, since `build-docker-image` is the only job that actually downloads the artifact.
- Saves ~94s from the critical path on every PR and main merge (measured from actual CI run timings).

## Changes

- `pull_request.yaml`: remove `needs: [build-binary]` from `test`
- `main.yaml`: remove `needs: [build-binary]` from `test`; add `build-binary` to `needs` of `build` (was implicit before, now explicit)

## Test plan

- [ ] CI run on this PR shows `test` and `build-binary` starting simultaneously
- [ ] `build` job still waits for both before starting

## Rollback

Revert PR.