### PR TITLE
refactor: simplify K8s GetStreamNames — compute stream names directly

### DIFF
--- a/glassflow-api/internal/orchestrator/k8s.go
+++ b/glassflow-api/internal/orchestrator/k8s.go
@@ -503,57 +503,32 @@ func (k *K8sOrchestrator) EditPipeline(ctx context.Context, pipelineID string, n
 	return nil
 }
 
-// buildPipelineSpec creates a complete PipelineSpec from a PipelineConfig
-// buildOperatorSpec converts a PipelineConfig into an operator.PipelineSpec
-// with spec.Resolved populated (the API-computed graph allocation). This is
-// the single place that knows how to translate API-side config into CRD
-// shape; both CR-write paths (via buildPipelineSpec) and read paths (via
-// GetStreamNames) call it.
-// GetStreamNames returns the JetStream stream names for the pipeline as the
-// operator deployed them — read from spec.Resolved via the same path that
-// produced the CR. Closes T13 S-10: usage_stats_collector now sees the
-// real names instead of the broken topic-sanitized helpers.
+// GetStreamNames returns the JetStream stream names for a K8s-deployed pipeline.
+// Stream names are deterministic from (pipelineID, topicIndex, join.Enabled) so
+// we compute them directly instead of building a full operator spec.
 func (k *K8sOrchestrator) GetStreamNames(_ context.Context, cfg models.PipelineConfig) (models.PipelineStreamNames, error) {
-	spec, err := k.buildOperatorSpec(&cfg)
-	if err != nil {
-		return models.PipelineStreamNames{}, fmt.Errorf("build operator spec: %w", err)
-	}
-	if spec.Resolved == nil {
-		return models.PipelineStreamNames{}, fmt.Errorf("resolved spec is nil for pipeline %s", cfg.ID)
-	}
-
 	names := models.PipelineStreamNames{
 		DLQStream: models.GetDLQStreamName(cfg.ID),
 	}
 
 	if !cfg.SourceType.IsOTLP() {
+		hasJoin := cfg.Join.Enabled
 		for i, topic := range cfg.Ingestor.KafkaTopics {
-			ingestorNode := spec.Resolved.FindNode(pipelinegraph.IngestorNodeID(spec, i))
-			if ingestorNode != nil && ingestorNode.Output != nil && len(ingestorNode.Output.Streams) > 0 {
-				names.IngestorStreams = append(names.IngestorStreams, ingestorNode.Output.Streams[0].Name)
-			} else {
-				names.IngestorStreams = append(names.IngestorStreams, "")
-			}
+			nodeID := pipelinegraph.IngestorNodeIDForIndex(i, hasJoin)
+			names.IngestorStreams = append(names.IngestorStreams, pipelinegraph.StreamName(cfg.ID, nodeID))
 
 			if topic.Deduplication.Enabled {
-				dedupNode := spec.Resolved.FindNode(pipelinegraph.DedupNodeID(spec, i))
-				dedupName := ""
-				if dedupNode != nil && dedupNode.Output != nil && len(dedupNode.Output.Streams) > 0 {
-					dedupName = dedupNode.Output.Streams[0].Name
-				}
+				dNodeID := pipelinegraph.DedupNodeIDForIndex(i, hasJoin)
 				names.DedupStreams = append(names.DedupStreams, models.DedupStreamName{
 					TopicIndex: i,
-					StreamName: dedupName,
+					StreamName: pipelinegraph.StreamName(cfg.ID, dNodeID),
 				})
 			}
 		}
 	}
 
 	if cfg.Join.Enabled {
-		joinNode := spec.Resolved.FindNode(pipelinegraph.JoinNodeID())
-		if joinNode != nil && joinNode.Output != nil && len(joinNode.Output.Streams) > 0 {
-			names.JoinStream = joinNode.Output.Streams[0].Name
-		}
+		names.JoinStream = pipelinegraph.StreamName(cfg.ID, pipelinegraph.JoinNodeID())
 	}
 
 	return names, nil

--- a/glassflow-api/internal/pipelinegraph/builder.go
+++ b/glassflow-api/internal/pipelinegraph/builder.go
@@ -20,7 +20,13 @@ const (
 
 // IngestorNodeID returns the graph node ID for the ingestor serving streamIndex.
 func IngestorNodeID(spec etlv1alpha1.PipelineSpec, streamIndex int) string {
-	if spec.Join.Enabled {
+	return IngestorNodeIDForIndex(streamIndex, spec.Join.Enabled)
+}
+
+// IngestorNodeIDForIndex returns the ingestor node ID for a topic index without
+// requiring a full PipelineSpec.
+func IngestorNodeIDForIndex(streamIndex int, hasJoin bool) string {
+	if hasJoin {
 		return ingestorNodeID + "_" + joinSide(streamIndex).String()
 	}
 	return ingestorNodeID
@@ -28,10 +34,25 @@ func IngestorNodeID(spec etlv1alpha1.PipelineSpec, streamIndex int) string {
 
 // DedupNodeID returns the graph node ID for the dedup serving streamIndex.
 func DedupNodeID(spec etlv1alpha1.PipelineSpec, streamIndex int) string {
-	if spec.Join.Enabled {
+	return DedupNodeIDForIndex(streamIndex, spec.Join.Enabled)
+}
+
+// DedupNodeIDForIndex returns the dedup node ID for a topic index without
+// requiring a full PipelineSpec.
+func DedupNodeIDForIndex(streamIndex int, hasJoin bool) string {
+	if hasJoin {
 		return dedupNodeID + "_" + joinSide(streamIndex).String()
 	}
 	return dedupNodeID
+}
+
+// StreamName returns the NATS JetStream stream name for a pipeline node —
+// the same deterministic formula the graph resolver uses, without requiring
+// a full PipelineSpec or graph resolution.
+func StreamName(pipelineID, nodeID string) string {
+	hash := generatePipelineHash(pipelineID)
+	prefix := truncateName(fmt.Sprintf("%s-%s-%s-%s", namePrefix, hash, sanitizeName(nodeID), nodeOutSuffix))
+	return prefix + "_0"
 }
 
 // JoinNodeID returns the graph node ID for the join component.


### PR DESCRIPTION
## Context

This is a follow-up simplification to #731 (ETL-1062/ETL-1066).

PR #731 fixes the usage stats collector returning zeros in K8s by routing stream name resolution through `Orchestrator.GetStreamNames`. The K8s implementation works, but the approach is more complex than it needs to be.

## The problem with the current approach

`K8sOrchestrator.GetStreamNames` currently:
1. Calls `buildOperatorSpec(cfg)` — converts `PipelineConfig` → `operator.PipelineSpec`
2. Calls `pipelinegraph.Resolve(spec)` — builds a full `Graph`, allocates all node bindings
3. Navigates `spec.Resolved` to find stream names from each node's output

This is overkill. K8s stream names follow a completely deterministic formula:

```
gfm-{sha256(pipelineID)[:8]}-{sanitize(nodeID)}-out_0
```

Where `nodeID` depends only on `(streamIndex, cfg.Join.Enabled)` — no spec build or graph resolution needed.

## The simplification

Add three helpers to `pipelinegraph/builder.go` that expose the naming formula directly without requiring a `PipelineSpec`:

- `StreamName(pipelineID, nodeID string) string` — the deterministic name formula
- `IngestorNodeIDForIndex(streamIndex int, hasJoin bool) string` — ingestor node ID without a spec (`IngestorNodeID` now delegates to this)
- `DedupNodeIDForIndex(streamIndex int, hasJoin bool) string` — same for dedup

`K8sOrchestrator.GetStreamNames` becomes as simple as the local-mode version in `docker.go`:

```go
func (k *K8sOrchestrator) GetStreamNames(_ context.Context, cfg models.PipelineConfig) (models.PipelineStreamNames, error) {
    names := models.PipelineStreamNames{DLQStream: models.GetDLQStreamName(cfg.ID)}
    if !cfg.SourceType.IsOTLP() {
        hasJoin := cfg.Join.Enabled
        for i, topic := range cfg.Ingestor.KafkaTopics {
            names.IngestorStreams = append(names.IngestorStreams,
                pipelinegraph.StreamName(cfg.ID, pipelinegraph.IngestorNodeIDForIndex(i, hasJoin)))
            if topic.Deduplication.Enabled {
                names.DedupStreams = append(names.DedupStreams, models.DedupStreamName{
                    TopicIndex: i,
                    StreamName: pipelinegraph.StreamName(cfg.ID, pipelinegraph.DedupNodeIDForIndex(i, hasJoin)),
                })
            }
        }
    }
    if cfg.Join.Enabled {
        names.JoinStream = pipelinegraph.StreamName(cfg.ID, pipelinegraph.JoinNodeID())
    }
    return names, nil
}
```

`buildOperatorSpec` is unchanged — it is still used for CR creation.