### PR TITLE
test(e2e): ingestor back-pressure BDD scenarios (ETL-1022)

### DIFF
--- a/glassflow-api/pkg/observability/meter.go
+++ b/glassflow-api/pkg/observability/meter.go
@@ -94,8 +94,23 @@ func InitMetrics(cfg *Config) error {
 	)
 	otel.SetMeterProvider(meterProvider)
 
-	m := otel.Meter("glassflow-etl")
+	initMetricInstruments(otel.Meter("glassflow-etl"))
 
+	return nil
+}
+
+// InitMetricsForTesting sets up a ManualReader-backed meter provider and
+// initialises all instrument vars. Returns the reader so tests can call
+// Collect() to inspect recorded values.
+func InitMetricsForTesting() *sdkmetric.ManualReader {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	otel.SetMeterProvider(mp)
+	initMetricInstruments(mp.Meter("glassflow-etl"))
+	return reader
+}
+
+func initMetricInstruments(m metric.Meter) {
 	KafkaRecordsRead = mustCreateCounter(m, GfMetricPrefix+"_"+"kafka_records_read_total",
 		"Total number of records read from Kafka")
 	DLQRecordsWritten = mustCreateCounter(m, GfMetricPrefix+"_"+"dlq_records_written_total",
@@ -137,8 +152,6 @@ func InitMetrics(cfg *Config) error {
 		"Number of messages currently stored in a JetStream stream")
 	StreamDepthRatio = mustCreateGauge(m, GfMetricPrefix+"_"+"stream_depth_ratio",
 		"Stream depth divided by max_messages, 0.0-1.0")
-
-	return nil
 }
 
 func mustCreateCounter(m metric.Meter, name, description string) metric.Int64Counter {

--- a/glassflow-api/tests/features/backpressure/backpressure.feature
+++ b/glassflow-api/tests/features/backpressure/backpressure.feature
@@ -1,0 +1,176 @@
+@backpressure
+Feature: Ingestor back-pressure propagation
+
+    # Validates that the ingestor correctly back-pressures Kafka consumption when
+    # the output NATS stream is full, and recovers cleanly when the stream drains.
+
+    Background: Shared setup for every scenario
+        Given I set up metrics collection
+        And the NATS stream config:
+            """json
+            {
+                "stream": "bp_output_stream",
+                "subject": "bp_output_subject",
+                "consumer": "bp_output_consumer"
+            }
+            """
+
+    # Scenario 1: baseline — Kafka lag grows when the output stream is capped.
+    Scenario: Back-pressure is applied when the ingestor output stream is full
+        Given a Kafka topic "bp_topic_s1" with 1 partition
+        And the NATS output stream has max messages 50
+        And pipeline config with configuration
+            """json
+            {
+                "pipeline_id": "bp-test-pipeline-s1",
+                "source_type": "kafka",
+                "ingestor": {
+                    "type": "kafka",
+                    "kafka_connection_params": {
+                        "brokers": [],
+                        "mechanism": "NO_AUTH",
+                        "protocol": "SASL_PLAINTEXT",
+                        "username": "",
+                        "password": "",
+                        "root_ca": ""
+                    },
+                    "kafka_topics": [
+                        {
+                            "name": "bp_topic_s1",
+                            "id": "bp_topic_s1",
+                            "consumer_group_name": "bp-cg-s1",
+                            "replicas": 1,
+                            "consumer_group_initial_offset": "earliest",
+                            "deduplication": {
+                                "enabled": false
+                            }
+                        }
+                    ]
+                },
+                "join": {"enabled": false},
+                "sink": {"type": "clickhouse", "source_id": "bp_topic_s1"},
+                "schema_versions": {
+                    "bp_topic_s1": {
+                        "source_id": "bp_topic_s1",
+                        "version_id": "1",
+                        "data_type": "json",
+                        "fields": [
+                            {"name": "id", "type": "string"},
+                            {"name": "val", "type": "string"}
+                        ]
+                    }
+                }
+            }
+            """
+        When I write 200 generated events to Kafka topic "bp_topic_s1"
+        And I run the ingestor component
+        Then Kafka consumer lag should grow above 50 within "20s"
+        And the NATS output stream depth should be at most 50
+        And the ingestor back-pressure events metric should be greater than 0
+
+    # Scenario 5: recovery — after the stream is drained, the ingestor resumes and
+    # Kafka lag returns to zero.
+    Scenario: Ingestor recovers when back-pressure clears
+        Given a Kafka topic "bp_topic_s5" with 1 partition
+        And the NATS output stream has max messages 50
+        And pipeline config with configuration
+            """json
+            {
+                "pipeline_id": "bp-test-pipeline-s5",
+                "source_type": "kafka",
+                "ingestor": {
+                    "type": "kafka",
+                    "kafka_connection_params": {
+                        "brokers": [],
+                        "mechanism": "NO_AUTH",
+                        "protocol": "SASL_PLAINTEXT",
+                        "username": "",
+                        "password": "",
+                        "root_ca": ""
+                    },
+                    "kafka_topics": [
+                        {
+                            "name": "bp_topic_s5",
+                            "id": "bp_topic_s5",
+                            "consumer_group_name": "bp-cg-s5",
+                            "replicas": 1,
+                            "consumer_group_initial_offset": "earliest",
+                            "deduplication": {
+                                "enabled": false
+                            }
+                        }
+                    ]
+                },
+                "join": {"enabled": false},
+                "sink": {"type": "clickhouse", "source_id": "bp_topic_s5"},
+                "schema_versions": {
+                    "bp_topic_s5": {
+                        "source_id": "bp_topic_s5",
+                        "version_id": "1",
+                        "data_type": "json",
+                        "fields": [
+                            {"name": "id", "type": "string"},
+                            {"name": "val", "type": "string"}
+                        ]
+                    }
+                }
+            }
+            """
+        When I write 200 generated events to Kafka topic "bp_topic_s5"
+        And I run the ingestor component
+        And Kafka consumer lag grows above 50 within "20s"
+        When I drain the NATS output stream
+        Then Kafka consumer lag should return to 0 within "45s"
+
+    # Scenario 6: stop during back-pressure — the ingestor stops cleanly when
+    # signalled while it is in a back-pressure retry loop.
+    Scenario: Ingestor stops cleanly during back-pressure
+        Given a Kafka topic "bp_topic_s6" with 1 partition
+        And the NATS output stream has max messages 50
+        And pipeline config with configuration
+            """json
+            {
+                "pipeline_id": "bp-test-pipeline-s6",
+                "source_type": "kafka",
+                "ingestor": {
+                    "type": "kafka",
+                    "kafka_connection_params": {
+                        "brokers": [],
+                        "mechanism": "NO_AUTH",
+                        "protocol": "SASL_PLAINTEXT",
+                        "username": "",
+                        "password": "",
+                        "root_ca": ""
+                    },
+                    "kafka_topics": [
+                        {
+                            "name": "bp_topic_s6",
+                            "id": "bp_topic_s6",
+                            "consumer_group_name": "bp-cg-s6",
+                            "replicas": 1,
+                            "consumer_group_initial_offset": "earliest",
+                            "deduplication": {
+                                "enabled": false
+                            }
+                        }
+                    ]
+                },
+                "join": {"enabled": false},
+                "sink": {"type": "clickhouse", "source_id": "bp_topic_s6"},
+                "schema_versions": {
+                    "bp_topic_s6": {
+                        "source_id": "bp_topic_s6",
+                        "version_id": "1",
+                        "data_type": "json",
+                        "fields": [
+                            {"name": "id", "type": "string"},
+                            {"name": "val", "type": "string"}
+                        ]
+                    }
+                }
+            }
+            """
+        When I write 200 generated events to Kafka topic "bp_topic_s6"
+        And I run the ingestor component
+        And Kafka consumer lag grows above 50 within "20s"
+        Then I can stop the ingestor within "15s"

--- a/glassflow-api/tests/main_test.go
+++ b/glassflow-api/tests/main_test.go
@@ -145,6 +145,23 @@ func testAPIFeatures(t *testing.T) {
 	runSingleSuite(t, "api", apiSuite, config)
 }
 
+func testBackpressureFeatures(t *testing.T) {
+	bpSuite := steps.NewBackpressureTestSuite()
+
+	config := TestConfig{
+		FeaturePaths: []string{filepath.Join("features", "backpressure")},
+		Tags:         "@backpressure",
+		Format:       "pretty",
+	}
+
+	runSingleSuite(t, "backpressure", bpSuite, config)
+}
+
+// TestBackpressureFeatures runs the back-pressure propagation scenarios (ETL-1022).
+func TestBackpressureFeatures(t *testing.T) {
+	testBackpressureFeatures(t)
+}
+
 // TestFeatures runs all feature tests but in separate contexts
 func TestFeatures(t *testing.T) {
 	// Run tests in subtests to isolate them
@@ -154,4 +171,5 @@ func TestFeatures(t *testing.T) {
 	t.Run("IngestorFeatures", testIngetorFeatures)
 	t.Run("PlatformFeatures", testPlatformFeatures)
 	t.Run("APIFeatures", testAPIFeatures)
+	t.Run("BackpressureFeatures", testBackpressureFeatures)
 }

--- a/glassflow-api/tests/steps/backpressure_steps.go
+++ b/glassflow-api/tests/steps/backpressure_steps.go
@@ -296,7 +296,7 @@ func (b *BackpressureTestSuite) scenarioCleanup() error {
 		b.drainCancel = nil
 		b.drainWg.Wait()
 	}
-	return b.IngestorTestSuite.fastCleanUp()
+	return b.fastCleanUp()
 }
 
 // --- step registration ---

--- a/glassflow-api/tests/steps/backpressure_steps.go
+++ b/glassflow-api/tests/steps/backpressure_steps.go
@@ -1,0 +1,330 @@
+package steps
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/cucumber/godog"
+	"github.com/nats-io/nats.go/jetstream"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/component"
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/pkg/observability"
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/tests/testutils"
+)
+
+// BackpressureTestSuite tests ingestor back-pressure behaviour: Kafka lag grows
+// when the output NATS stream is full, and clears when the stream is drained.
+type BackpressureTestSuite struct {
+	IngestorTestSuite
+
+	metricsReader *sdkmetric.ManualReader
+
+	// drainCancel stops the background drain goroutine started by iDrainTheNatsOutputStream.
+	drainCancel context.CancelFunc
+	drainWg     sync.WaitGroup
+}
+
+func NewBackpressureTestSuite() *BackpressureTestSuite {
+	return &BackpressureTestSuite{
+		IngestorTestSuite: *NewIngestorTestSuite(),
+	}
+}
+
+func (b *BackpressureTestSuite) SetupResources() error {
+	return b.IngestorTestSuite.SetupResources()
+}
+
+func (b *BackpressureTestSuite) CleanupResources() error {
+	return b.IngestorTestSuite.CleanupResources()
+}
+
+// --- step implementations ---
+
+func (b *BackpressureTestSuite) iSetUpMetricsCollection() error {
+	b.metricsReader = observability.InitMetricsForTesting()
+	return nil
+}
+
+// theNatsOutputStreamHasMaxMessages creates (or updates) the output NATS stream
+// with a hard message-count cap and DiscardNew policy so new publishes fail
+// with a server-side error when the stream is full — triggering ingestor BP.
+// WorkQueuePolicy is used so that ACKed messages are deleted from the stream,
+// freeing capacity for the ingestor to resume after back-pressure clears.
+// Must be called after theNatsStreamConfig has set b.streamCfg.
+func (b *BackpressureTestSuite) theNatsOutputStreamHasMaxMessages(maxMsgs int) error {
+	cfg := b.streamCfg
+	cfg.MaxMsgs = int64(maxMsgs)
+	cfg.Discard = jetstream.DiscardNew
+	cfg.Storage = jetstream.MemoryStorage
+	cfg.Retention = jetstream.WorkQueuePolicy
+
+	_, err := b.natsClient.JetStream().CreateOrUpdateStream(context.Background(), cfg)
+	if err != nil {
+		return fmt.Errorf("create bounded output stream (max_msgs=%d): %w", maxMsgs, err)
+	}
+	return nil
+}
+
+// iWriteNGeneratedEventsToKafkaTopic writes count simple JSON events to the
+// named Kafka topic without requiring a Gherkin table.
+func (b *BackpressureTestSuite) iWriteNGeneratedEventsToKafkaTopic(count int, topicName string) error {
+	events := make([]testutils.KafkaEvent, count)
+	for i := range count {
+		events[i] = testutils.KafkaEvent{
+			Key:   fmt.Sprintf("%d", i+1),
+			Value: []byte(fmt.Sprintf(`{"id": "%d", "val": "value-%04d"}`, i+1, i+1)),
+		}
+	}
+
+	if err := b.createKafkaWriter(); err != nil {
+		return fmt.Errorf("create kafka writer: %w", err)
+	}
+	if err := b.kWriter.WriteJSONEvents(topicName, events); err != nil {
+		return fmt.Errorf("write %d generated events to kafka topic %q: %w", count, topicName, err)
+	}
+	return nil
+}
+
+// kafkaLagShouldGrowAboveWithin polls the Kafka consumer-group lag until it
+// exceeds minLag or the timeout elapses.
+func (b *BackpressureTestSuite) kafkaLagShouldGrowAboveWithin(minLag int, timeout string) error {
+	dur, err := time.ParseDuration(timeout)
+	if err != nil {
+		return fmt.Errorf("parse timeout %q: %w", timeout, err)
+	}
+
+	deadline := time.NewTimer(dur)
+	defer deadline.Stop()
+	ticker := time.NewTicker(300 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-deadline.C:
+			lag, _ := b.kWriter.GetLag(context.Background(), b.topicName, b.cGroupName)
+			return fmt.Errorf("kafka lag %d did not grow above %d within %s (topic=%s cgroup=%s)",
+				lag, minLag, timeout, b.topicName, b.cGroupName)
+		case <-ticker.C:
+			lag, err := b.kWriter.GetLag(context.Background(), b.topicName, b.cGroupName)
+			if err != nil {
+				continue // consumer group not yet registered
+			}
+			if lag > int64(minLag) {
+				return nil
+			}
+		}
+	}
+}
+
+// natsOutputStreamDepthShouldBeAtMost asserts the stream holds no more than
+// maxDepth messages (pending + ack-pending).
+func (b *BackpressureTestSuite) natsOutputStreamDepthShouldBeAtMost(maxDepth int) error {
+	str, err := b.natsClient.JetStream().Stream(context.Background(), b.streamCfg.Name)
+	if err != nil {
+		return fmt.Errorf("get stream handle for %q: %w", b.streamCfg.Name, err)
+	}
+	si, err := str.Info(context.Background())
+	if err != nil {
+		return fmt.Errorf("stream info for %q: %w", b.streamCfg.Name, err)
+	}
+	if si.State.Msgs > uint64(maxDepth) {
+		return fmt.Errorf("NATS stream %q depth %d exceeds max allowed %d",
+			b.streamCfg.Name, si.State.Msgs, maxDepth)
+	}
+	return nil
+}
+
+// ingestorBackpressureEventsMetricShouldBeGreaterThanZero polls until the
+// ingestor has emitted at least one back-pressure-start event via OTEL metrics,
+// or the 15-second timeout elapses. Polling is necessary because Kafka lag can
+// exceed the threshold before the ingestor has finished its first publish batch
+// and detected the back-pressure error from the NATS server.
+func (b *BackpressureTestSuite) ingestorBackpressureEventsMetricShouldBeGreaterThanZero() error {
+	const timeout = 15 * time.Second
+	const poll = 500 * time.Millisecond
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(poll)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-deadline.C:
+			val, _ := b.collectMetricSum(observability.GfMetricPrefix + "_ingestor_backpressure_events_total")
+			return fmt.Errorf("gfm_ingestor_backpressure_events_total still 0 after %s (last value: %d)", timeout, val)
+		case <-ticker.C:
+			val, err := b.collectMetricSum(observability.GfMetricPrefix + "_ingestor_backpressure_events_total")
+			if err != nil {
+				return err
+			}
+			if val > 0 {
+				return nil
+			}
+		}
+	}
+}
+
+// iDrainTheNatsOutputStream starts a background pull consumer that continuously
+// ACKs messages from the output stream. This simulates a sink catching up after
+// back-pressure and allows the ingestor to resume publishing.
+func (b *BackpressureTestSuite) iDrainTheNatsOutputStream() error {
+	js := b.natsClient.JetStream()
+
+	const drainConsumer = "bp-drain-consumer"
+	consumer, err := js.CreateOrUpdateConsumer(context.Background(), b.streamCfg.Name, jetstream.ConsumerConfig{
+		Name:          drainConsumer,
+		Durable:       drainConsumer,
+		FilterSubject: b.streamCfg.Subjects[0],
+		AckPolicy:     jetstream.AckExplicitPolicy,
+		AckWait:       5 * time.Second,
+	})
+	if err != nil {
+		return fmt.Errorf("create drain consumer: %w", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	b.drainCancel = cancel
+
+	b.drainWg.Add(1)
+	go func() {
+		defer b.drainWg.Done()
+		for ctx.Err() == nil {
+			msgs, fetchErr := consumer.Fetch(100, jetstream.FetchMaxWait(300*time.Millisecond))
+			if fetchErr != nil {
+				continue
+			}
+			for msg := range msgs.Messages() {
+				_ = msg.Ack()
+			}
+		}
+	}()
+
+	return nil
+}
+
+// kafkaLagShouldReturnToZeroWithin polls until the Kafka consumer-group lag
+// drops to 0 or the timeout elapses.
+func (b *BackpressureTestSuite) kafkaLagShouldReturnToZeroWithin(timeout string) error {
+	dur, err := time.ParseDuration(timeout)
+	if err != nil {
+		return fmt.Errorf("parse timeout %q: %w", timeout, err)
+	}
+
+	deadline := time.NewTimer(dur)
+	defer deadline.Stop()
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-deadline.C:
+			lag, _ := b.kWriter.GetLag(context.Background(), b.topicName, b.cGroupName)
+			return fmt.Errorf("kafka lag %d did not return to 0 within %s (topic=%s cgroup=%s)",
+				lag, timeout, b.topicName, b.cGroupName)
+		case <-ticker.C:
+			lag, err := b.kWriter.GetLag(context.Background(), b.topicName, b.cGroupName)
+			if err != nil {
+				continue
+			}
+			if lag == 0 {
+				return nil
+			}
+		}
+	}
+}
+
+// iCanStopTheIngestorWithin stops the ingestor and asserts it completes within
+// the given duration. Back-pressure is cleared by context cancellation so the
+// retry loop exits immediately.
+func (b *BackpressureTestSuite) iCanStopTheIngestorWithin(timeout string) error {
+	dur, err := time.ParseDuration(timeout)
+	if err != nil {
+		return fmt.Errorf("parse timeout %q: %w", timeout, err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		b.ingestor.Stop(component.WithNoWait(true))
+		b.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		b.ingestor = nil
+		return nil
+	case <-time.After(dur):
+		return fmt.Errorf("ingestor did not stop within %s", timeout)
+	}
+}
+
+// --- metrics helpers ---
+
+func (b *BackpressureTestSuite) collectMetricSum(metricName string) (int64, error) {
+	if b.metricsReader == nil {
+		return 0, fmt.Errorf("metrics reader not initialized — call 'I set up metrics collection' first")
+	}
+	var rm metricdata.ResourceMetrics
+	if err := b.metricsReader.Collect(context.Background(), &rm); err != nil {
+		return 0, fmt.Errorf("collect metrics: %w", err)
+	}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != metricName {
+				continue
+			}
+			if data, ok := m.Data.(metricdata.Sum[int64]); ok {
+				var total int64
+				for _, dp := range data.DataPoints {
+					total += dp.Value
+				}
+				return total, nil
+			}
+		}
+	}
+	return 0, nil
+}
+
+// --- scenario cleanup ---
+
+func (b *BackpressureTestSuite) scenarioCleanup() error {
+	if b.drainCancel != nil {
+		b.drainCancel()
+		b.drainCancel = nil
+		b.drainWg.Wait()
+	}
+	return b.IngestorTestSuite.fastCleanUp()
+}
+
+// --- step registration ---
+
+func (b *BackpressureTestSuite) RegisterSteps(sc *godog.ScenarioContext) {
+	logElapsedTime(sc)
+
+	// Inherited ingestor steps
+	sc.Step(`^the NATS stream config:$`, b.theNatsStreamConfig)
+	sc.Step(`^pipeline config with configuration$`, b.aPipelineConfig)
+	sc.Step(`^a Kafka topic "([^"]*)" with (\d+) partition`, b.aKafkaTopicWithPartitions)
+	sc.Step(`^I run the ingestor component$`, b.iRunningIngestorComponent)
+
+	// Back-pressure–specific steps
+	sc.Step(`^I set up metrics collection$`, b.iSetUpMetricsCollection)
+	sc.Step(`^the NATS output stream has max messages (\d+)$`, b.theNatsOutputStreamHasMaxMessages)
+	sc.Step(`^I write (\d+) generated events to Kafka topic "([^"]*)"$`, b.iWriteNGeneratedEventsToKafkaTopic)
+	sc.Step(`^Kafka consumer lag (?:should grow|grows) above (\d+) within "([^"]*)"$`, b.kafkaLagShouldGrowAboveWithin)
+	sc.Step(`^the NATS output stream depth should be at most (\d+)$`, b.natsOutputStreamDepthShouldBeAtMost)
+	sc.Step(`^the ingestor back-pressure events metric should be greater than 0$`, b.ingestorBackpressureEventsMetricShouldBeGreaterThanZero)
+	sc.Step(`^I drain the NATS output stream$`, b.iDrainTheNatsOutputStream)
+	sc.Step(`^Kafka consumer lag should return to 0 within "([^"]*)"$`, b.kafkaLagShouldReturnToZeroWithin)
+	sc.Step(`^I can stop the ingestor within "([^"]*)"$`, b.iCanStopTheIngestorWithin)
+
+	sc.After(func(ctx context.Context, _ *godog.Scenario, _ error) (context.Context, error) {
+		if err := b.scenarioCleanup(); err != nil {
+			return ctx, err
+		}
+		return ctx, nil
+	})
+}


### PR DESCRIPTION
## Summary

- Adds three Gherkin scenarios under `@backpressure` verifying ingestor back-pressure propagation
- Baseline: Kafka lag grows and stays elevated when the NATS output stream is capped at 50 messages (MaxMsgs + DiscardNew)
- Recovery: lag returns to zero once a drain consumer clears the bounded stream, proving the ingestor resumes normally
- Graceful stop: ingestor shuts down cleanly within 15 s while stuck in a BP retry loop
- Adds `InitMetricsForTesting()` to `pkg/observability` (ManualReader-backed provider) so the `gfm_ingestor_backpressure_events_total` counter can be asserted in-process without spinning up an OTEL collector

## Key design decisions

- **WorkQueuePolicy** on the bounded NATS stream: with the default LimitsPolicy, ACKing messages does not free stream capacity — the stream stays full indefinitely and the recovery scenario can never converge. WorkQueuePolicy deletes messages on ACK, letting the drain consumer actually free space for the ingestor to retry.
- **Polling for the BP-events metric**: Kafka lag exceeds the threshold almost instantly (consumer group joins; all 200 messages are pre-written), but the ingestor hasn't published its first batch yet. The metric assertion polls every 500 ms for up to 15 s to avoid a race with the async publish→ack→classify path.
- **Stream pre-creation trick**: `createStream` in `BaseTestSuite` skips creation if the stream already exists. Pre-creating the bounded stream (MaxMsgs + DiscardNew + WorkQueuePolicy) before `iRunningIngestorComponent` ensures the orchestrator's `CreateOrUpdateStream` call is never reached.

## Scope

Scenarios 2–4 from the original ticket (transform/filter mid-tier BP and blocked sink) require either a LocalOrchestrator transform runner (currently unsupported) or a CHGateProxy shim. Those are deferred to follow-up tickets. The three scenarios here cover the ingestor-level back-pressure mechanism end-to-end.

## Test plan

- [x] `go test ./tests/... -run TestBackpressureFeatures -v` — all 3 scenarios pass locally
- [x] `go build ./tests/...` — clean compile