### PR TITLE
test(e2e): parallelize e2e test suites ETL-1135

### DIFF
--- a/glassflow-api/Makefile
+++ b/glassflow-api/Makefile
@@ -48,4 +48,4 @@ run-short-test:
 
 .PHONY: run-e2e-test
 run-e2e-test:
-	TESTCONTAINERS_RYUK_DISABLED=true go test -v ./tests
+	TESTCONTAINERS_RYUK_DISABLED=true go test -v -parallel 7 -timeout 10m ./tests

--- a/glassflow-api/internal/transformer/versioned/versioned_transformation_test.go
+++ b/glassflow-api/internal/transformer/versioned/versioned_transformation_test.go
@@ -21,7 +21,7 @@ import (
 
 func setupPostgres(t *testing.T) (*postgres.PostgresStorage, *pgxpool.Pool, *testutils.PostgresContainer, context.Context) {
 	ctx := context.Background()
-	container, err := testutils.StartPostgresContainer(ctx)
+	container, err := testutils.StartPostgresContainer(ctx, "versioned-transformer")
 	require.NoError(t, err)
 
 	storage, err := postgres.NewPostgres(ctx, container.GetDSN(), nil, nil, internal.RoleDeduplicator)
@@ -54,7 +54,7 @@ func cleanupPostgres(
 }
 
 func setupNATS(t *testing.T, ctx context.Context) (*client.NATSClient, *componentsignals.ComponentSignalPublisher, *testutils.NATSContainer) {
-	natsContainer, err := testutils.StartNATSContainer(ctx)
+	natsContainer, err := testutils.StartNATSContainer(ctx, "versioned-transformer")
 	require.NoError(t, err)
 
 	natsClient, err := client.NewNATSClient(ctx, natsContainer.GetURI())

--- a/glassflow-api/tests/main_test.go
+++ b/glassflow-api/tests/main_test.go
@@ -162,14 +162,34 @@ func TestBackpressureFeatures(t *testing.T) {
 	testBackpressureFeatures(t)
 }
 
-// TestFeatures runs all feature tests but in separate contexts
+// TestFeatures runs all feature tests in parallel, each in its own container namespace.
 func TestFeatures(t *testing.T) {
-	// Run tests in subtests to isolate them
-	t.Run("SinkFeatures", testSinkFeatures)
-	t.Run("JoinComponentFeatures", testJoinFeatures)
-	t.Run("PipelineFeatures", testPipelineFeatures)
-	t.Run("IngestorFeatures", testIngetorFeatures)
-	t.Run("PlatformFeatures", testPlatformFeatures)
-	t.Run("APIFeatures", testAPIFeatures)
-	t.Run("BackpressureFeatures", testBackpressureFeatures)
+	t.Run("SinkFeatures", func(t *testing.T) {
+		t.Parallel()
+		testSinkFeatures(t)
+	})
+	t.Run("JoinComponentFeatures", func(t *testing.T) {
+		t.Parallel()
+		testJoinFeatures(t)
+	})
+	t.Run("PipelineFeatures", func(t *testing.T) {
+		t.Parallel()
+		testPipelineFeatures(t)
+	})
+	t.Run("IngestorFeatures", func(t *testing.T) {
+		t.Parallel()
+		testIngetorFeatures(t)
+	})
+	t.Run("PlatformFeatures", func(t *testing.T) {
+		t.Parallel()
+		testPlatformFeatures(t)
+	})
+	t.Run("APIFeatures", func(t *testing.T) {
+		t.Parallel()
+		testAPIFeatures(t)
+	})
+	t.Run("BackpressureFeatures", func(t *testing.T) {
+		t.Parallel()
+		testBackpressureFeatures(t)
+	})
 }

--- a/glassflow-api/tests/steps/api_steps.go
+++ b/glassflow-api/tests/steps/api_steps.go
@@ -19,6 +19,7 @@ type APISteps struct {
 func NewAPISteps() *APISteps {
 	return &APISteps{
 		BaseTestSuite: BaseTestSuite{
+			suiteName:      "api",
 			kafkaContainer: nil,
 		},
 		log: testutils.NewTestLogger(),

--- a/glassflow-api/tests/steps/backpressure_steps.go
+++ b/glassflow-api/tests/steps/backpressure_steps.go
@@ -30,7 +30,12 @@ type BackpressureTestSuite struct {
 
 func NewBackpressureTestSuite() *BackpressureTestSuite {
 	return &BackpressureTestSuite{
-		IngestorTestSuite: *NewIngestorTestSuite(),
+		IngestorTestSuite: IngestorTestSuite{ //nolint:exhaustruct // optional config
+			BaseTestSuite: BaseTestSuite{ //nolint:exhaustruct // optional config
+				suiteName: "backpressure",
+			},
+			logger: testutils.NewTestLogger(),
+		},
 	}
 }
 

--- a/glassflow-api/tests/steps/base_steps.go
+++ b/glassflow-api/tests/steps/base_steps.go
@@ -25,6 +25,8 @@ import (
 
 // BaseTestSuite provides common functionality for test suites
 type BaseTestSuite struct {
+	suiteName string
+
 	natsContainer     *testutils.NATSContainer
 	chContainer       *testutils.ClickHouseContainer
 	kafkaContainer    *testutils.KafkaContainer
@@ -42,7 +44,7 @@ type BaseTestSuite struct {
 
 func (b *BaseTestSuite) setupNATS() error {
 	if b.natsContainer == nil {
-		natsContainer, err := testutils.StartNATSContainer(context.Background())
+		natsContainer, err := testutils.StartNATSContainer(context.Background(), b.suiteName)
 		if err != nil {
 			return fmt.Errorf("start nats container: %w", err)
 		}
@@ -85,7 +87,7 @@ func (b *BaseTestSuite) cleanupNATS() error {
 }
 
 func (b *BaseTestSuite) setupCH() error {
-	chContainer, err := testutils.StartClickHouseContainer(context.Background())
+	chContainer, err := testutils.StartClickHouseContainer(context.Background(), b.suiteName)
 	if err != nil {
 		return fmt.Errorf("start clickhouse container: %w", err)
 	}
@@ -107,7 +109,7 @@ func (b *BaseTestSuite) cleanupCH() error {
 }
 
 func (b *BaseTestSuite) setupPostgres() error {
-	pgContainer, err := testutils.StartPostgresContainer(context.Background())
+	pgContainer, err := testutils.StartPostgresContainer(context.Background(), b.suiteName)
 	if err != nil {
 		return fmt.Errorf("start postgres container: %w", err)
 	}
@@ -129,7 +131,7 @@ func (b *BaseTestSuite) cleanupPostgres() error {
 }
 
 func (b *BaseTestSuite) setupKafka() error {
-	kContainer, err := testutils.StartKafkaContainer(context.Background())
+	kContainer, err := testutils.StartKafkaContainer(context.Background(), b.suiteName)
 	if err != nil {
 		return fmt.Errorf("start kafka container: %w", err)
 	}

--- a/glassflow-api/tests/steps/ingestor_steps.go
+++ b/glassflow-api/tests/steps/ingestor_steps.go
@@ -63,6 +63,7 @@ type IngestorTestSuite struct {
 func NewIngestorTestSuite() *IngestorTestSuite {
 	return &IngestorTestSuite{
 		BaseTestSuite: BaseTestSuite{ //nolint:exhaustruct // optional config
+			suiteName:         "ingestor",
 			wg:                sync.WaitGroup{},
 			kafkaContainer:    nil,
 			natsContainer:     nil,

--- a/glassflow-api/tests/steps/join_steps.go
+++ b/glassflow-api/tests/steps/join_steps.go
@@ -46,7 +46,8 @@ type JoinTestSuite struct {
 
 func NewJoinTestSuite() *JoinTestSuite {
 	return &JoinTestSuite{
-		logger: testutils.NewTestLogger(),
+		BaseTestSuite: BaseTestSuite{suiteName: "join"}, //nolint:exhaustruct // optional config
+		logger:        testutils.NewTestLogger(),
 	}
 }
 

--- a/glassflow-api/tests/steps/pipeline_steps.go
+++ b/glassflow-api/tests/steps/pipeline_steps.go
@@ -44,6 +44,7 @@ type PipelineSteps struct {
 func NewPipelineSteps() *PipelineSteps {
 	return &PipelineSteps{ //nolint:exhaustruct // only necessary fields
 		BaseTestSuite: BaseTestSuite{ //nolint:exhaustruct // only necessary fields
+			suiteName:      "pipeline",
 			kafkaContainer: nil,
 		},
 		kTopics: make([]string, 0),

--- a/glassflow-api/tests/steps/platform_steps.go
+++ b/glassflow-api/tests/steps/platform_steps.go
@@ -30,6 +30,7 @@ type PlatformSteps struct {
 func NewPlatformSteps() *PlatformSteps {
 	return &PlatformSteps{
 		BaseTestSuite: BaseTestSuite{
+			suiteName:      "platform",
 			kafkaContainer: nil,
 		},
 		log: testutils.NewTestLogger(),

--- a/glassflow-api/tests/steps/sink_steps.go
+++ b/glassflow-api/tests/steps/sink_steps.go
@@ -45,7 +45,8 @@ type SinkTestSuite struct {
 func NewSinkTestSuite() *SinkTestSuite {
 	return &SinkTestSuite{ //nolint:exhaustruct // optional config
 		BaseTestSuite: BaseTestSuite{ //nolint:exhaustruct // optional config
-			wg: sync.WaitGroup{},
+			suiteName: "sink",
+			wg:        sync.WaitGroup{},
 		},
 	}
 }

--- a/glassflow-api/tests/testutils/containers.go
+++ b/glassflow-api/tests/testutils/containers.go
@@ -64,9 +64,9 @@ type NATSContainer struct {
 	uri       string
 }
 
-func StartNATSContainer(ctx context.Context) (*NATSContainer, error) {
+func StartNATSContainer(ctx context.Context, name string) (*NATSContainer, error) {
 	req := testcontainers.ContainerRequest{ //nolint:exhaustruct // optional config
-		Name:         "testcontainers-nats",
+		Name:         "testcontainers-nats-" + name,
 		Image:        NATSContainerImage,
 		ExposedPorts: []string{NATSPort},
 		Cmd:          []string{"-js"},
@@ -134,7 +134,7 @@ type ClickHouseContainer struct {
 }
 
 // StartClickHouseContainer starts a ClickHouse container
-func StartClickHouseContainer(ctx context.Context) (*ClickHouseContainer, error) {
+func StartClickHouseContainer(ctx context.Context, name string) (*ClickHouseContainer, error) {
 	container, err := chContainer.Run(
 		ctx,
 		ClickHouseContainerImage,
@@ -142,7 +142,7 @@ func StartClickHouseContainer(ctx context.Context) (*ClickHouseContainer, error)
 			wait.ForHTTP("/").
 				WithPort("8123/tcp").
 				WithStartupTimeout(60*time.Second)),
-		testcontainers.WithReuseByName("testcontainers-clickhouse"),
+		testcontainers.WithReuseByName("testcontainers-clickhouse-"+name),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start ClickHouse container %w", err)
@@ -209,11 +209,11 @@ type KafkaContainer struct {
 	uri       string
 }
 
-func StartKafkaContainer(ctx context.Context) (*KafkaContainer, error) {
+func StartKafkaContainer(ctx context.Context, name string) (*KafkaContainer, error) {
 	clusterID := "test-cluster"
 
 	req := testcontainers.ContainerRequest{ //nolint:exhaustruct // necessary fields only
-		Name:         "testcontainers-kafka",
+		Name:         "testcontainers-kafka-" + name,
 		Image:        KafkaContainerImage,
 		ExposedPorts: []string{string(KafkaPort)},
 		Env: map[string]string{
@@ -329,9 +329,9 @@ type PostgresContainer struct {
 }
 
 // StartPostgresContainer starts a Postgres container
-func StartPostgresContainer(ctx context.Context) (*PostgresContainer, error) {
+func StartPostgresContainer(ctx context.Context, name string) (*PostgresContainer, error) {
 	req := testcontainers.ContainerRequest{ //nolint:exhaustruct // optional config
-		Name:         "testcontainers-postgres",
+		Name:         "testcontainers-postgres-" + name,
 		Image:        PostgresContainerImage,
 		ExposedPorts: []string{PostgresPort},
 		Env: map[string]string{


### PR DESCRIPTION
# e2e test runtime 3 min 30 sec (can be faster with bigger runner, takes 80 sec on local)

## Summary

- Running 7 test suites sequentially was leaving ~5–6 min of wall-clock time on the table; each suite is fully independent so there's no correctness reason for the sequential order.
- Scopes Docker container names per suite so suites can run concurrently without name collisions (`testcontainers-nats-sink`, `testcontainers-nats-ingestor`, etc.).

## Changes

- `testutils/containers.go` — `Start*Container` functions accept a `name string` suffix; container names become `testcontainers-<type>-<suite>`.
- `steps/base_steps.go` — adds `suiteName` field to `BaseTestSuite`; passed through to all container start calls.
- Each suite constructor sets its own `suiteName` (`"sink"`, `"join"`, `"pipeline"`, `"ingestor"`, `"platform"`, `"api"`, `"backpressure"`).
- `tests/main_test.go` — `TestFeatures` wraps each `t.Run` with `t.Parallel()`.
- `Makefile` — adds `-parallel 7 -timeout 10m` to `run-e2e-test`.
- `GLASSFLOW_REUSE_TESTCONTAINERS` behaviour unchanged; reuse now happens per-suite name.

## Test plan

- [ ] `make run-e2e-test` completes with all suites passing (~80s on local vs ~6–7 min sequential)
- [ ] Single-suite run still works: `TESTCONTAINERS_RYUK_DISABLED=true go test -v -run 'TestFeatures/SinkFeatures' ./tests`

## Rollback

Revert PR — no migrations, no data writes.