### PR TITLE
feat(sink): emit processor_messages_total, batch-size histograms, retries_total (ETL-1123)

### DIFF
--- a/glassflow-api/internal/sink/clickhouse.go
+++ b/glassflow-api/internal/sink/clickhouse.go
@@ -423,6 +423,7 @@ func (ch *ClickHouseSink) sendBatch(ctx context.Context, messages []jetstream.Ms
 	}
 
 	observability.RecordBytesProcessed(ctx, "sink", "in", totalBytes)
+	observability.RecordSinkBatchSize(ctx, int64(len(messages)), totalBytes)
 
 	batchesBySchema, err := ch.createCHBatches(ctx, messages)
 	if err != nil {
@@ -452,6 +453,8 @@ func (ch *ClickHouseSink) sendBatch(ctx context.Context, messages []jetstream.Ms
 					"batch_size", len(schemaData.messages))
 				ch.nakMessages(ctx, schemaData.messages)
 				observability.RecordSinkNackMessages(ctx, int64(len(schemaData.messages)))
+				observability.RecordProcessorMessages(ctx, "sink", "retry", int64(size))
+				observability.RecordSinkRetry(ctx, "retry", int64(size))
 				continue
 			}
 
@@ -460,6 +463,9 @@ func (ch *ClickHouseSink) sendBatch(ctx context.Context, messages []jetstream.Ms
 				"error", err,
 				"classification", classification.String(),
 				"batch_size", len(schemaData.messages))
+
+			observability.RecordProcessorMessages(ctx, "sink", "error", int64(size))
+			observability.RecordSinkRetry(ctx, "exhausted", int64(size))
 
 			flushErr := ch.flushFailedBatch(ctx, schemaData.messages, err)
 			if flushErr != nil {
@@ -479,6 +485,7 @@ func (ch *ClickHouseSink) sendBatch(ctx context.Context, messages []jetstream.Ms
 			"message_count", size)
 
 		observability.RecordClickHouseWrite(ctx, "sink", int64(size))
+		observability.RecordProcessorMessages(ctx, "sink", "success", int64(size))
 
 		duration := time.Since(start).Seconds()
 		if duration > 0 {

--- a/glassflow-api/pkg/observability/meter.go
+++ b/glassflow-api/pkg/observability/meter.go
@@ -43,6 +43,9 @@ var (
 
 	SinkErrorsByClassification metric.Int64Counter
 	SinkNackMessagesTotal      metric.Int64Counter
+	SinkBatchSizeRecords       metric.Int64Histogram
+	SinkBatchSizeBytes         metric.Int64Histogram
+	SinkRetriesTotal           metric.Int64Counter
 
 	IngestorBackpressureActive   metric.Int64Gauge
 	IngestorBackpressureEvents   metric.Int64Counter
@@ -140,6 +143,17 @@ func initMetricInstruments(m metric.Meter) {
 	SinkNackMessagesTotal = mustCreateCounter(m,
 		GfMetricPrefix+"_"+"sink_nack_messages_total",
 		"Messages NACKed by the sink due to retryable ClickHouse errors")
+	SinkBatchSizeRecords = mustCreateInt64Histogram(m,
+		GfMetricPrefix+"_"+"sink_batch_size_records",
+		"Distribution of records per sink batch", "1",
+		1, 10, 100, 1_000, 10_000, 100_000)
+	SinkBatchSizeBytes = mustCreateInt64Histogram(m,
+		GfMetricPrefix+"_"+"sink_batch_size_bytes",
+		"Distribution of bytes per sink batch", "By",
+		1_024, 10_240, 102_400, 1_048_576, 10_485_760, 104_857_600)
+	SinkRetriesTotal = mustCreateCounter(m,
+		GfMetricPrefix+"_"+"sink_retries_total",
+		"Sink batch retry attempts labelled by outcome (exhausted|retry)")
 
 	IngestorBackpressureActive = mustCreateInt64Gauge(m, GfMetricPrefix+"_"+"ingestor_backpressure_active",
 		"1 while the ingestor is in back-pressure, 0 otherwise")
@@ -193,6 +207,17 @@ func mustCreateBackpressureDurationHistogram(m metric.Meter, name, description s
 		panic(fmt.Sprintf("failed to create histogram %s: %v", name, err))
 	}
 	return histogram
+}
+
+func mustCreateInt64Histogram(m metric.Meter, name, description, unit string, buckets ...float64) metric.Int64Histogram {
+	h, err := m.Int64Histogram(name,
+		metric.WithDescription(description),
+		metric.WithUnit(unit),
+		metric.WithExplicitBucketBoundaries(buckets...))
+	if err != nil {
+		panic(fmt.Sprintf("failed to create histogram %s: %v", name, err))
+	}
+	return h
 }
 
 func mustCreateHistogram(m metric.Meter, name, description string) metric.Float64Histogram {
@@ -408,5 +433,25 @@ func RecordStreamDepthRatio(ctx context.Context, streamName string, ratio float6
 	StreamDepthRatio.Record(ctx, ratio, metric.WithAttributes(
 		attribute.String("pipeline_id", pipelineID),
 		attribute.String("stream", streamName),
+	))
+}
+
+func RecordSinkBatchSize(ctx context.Context, records, bytes int64) {
+	attrs := metric.WithAttributes(attribute.String("pipeline_id", pipelineID))
+	if SinkBatchSizeRecords != nil {
+		SinkBatchSizeRecords.Record(ctx, records, attrs)
+	}
+	if SinkBatchSizeBytes != nil {
+		SinkBatchSizeBytes.Record(ctx, bytes, attrs)
+	}
+}
+
+func RecordSinkRetry(ctx context.Context, outcome string, count int64) {
+	if SinkRetriesTotal == nil {
+		return
+	}
+	SinkRetriesTotal.Add(ctx, count, metric.WithAttributes(
+		attribute.String("pipeline_id", pipelineID),
+		attribute.String("outcome", outcome),
 	))
 }


### PR DESCRIPTION
## Summary

- The sink was a metrics black box — no per-status counters, no batch-size distribution, no retry visibility. Fixes the gaps that forced workarounds in the public-demo Grafana dashboard (ETL-888).
- Adds `processor_messages_total{component="sink", status=success|error|retry}` so the dashboard can show a real sink error-rate panel instead of the DLQ-rate proxy.
- Linear: https://linear.app/glassflow/issue/ETL-1123

## Changes

- `pkg/observability/meter.go`: three new instruments — `gfm_sink_batch_size_records` (Int64Histogram), `gfm_sink_batch_size_bytes` (Int64Histogram), `gfm_sink_retries_total` (Int64Counter); new `mustCreateInt64Histogram` helper; `RecordSinkBatchSize` and `RecordSinkRetry` wrapper functions.
- `internal/sink/clickhouse.go`: four new recording call sites in `sendBatch` — batch-size histograms on entry, `status=success` on ACK, `status=retry` + `outcome=retry` on NACK, `status=error` + `outcome=exhausted` before DLQ flush.

## Test plan

- [ ] `go test ./internal/sink/... ./pkg/observability/... -race` passes
- [ ] `go build ./...` passes
- [ ] Deploy to staging, run a pipeline, confirm `gfm_processor_messages_total{component="sink", status="success"}` appears in Prometheus

## Rollback

Revert PR — metrics-only change, no migrations or state writes.