### PR TITLE
feat(observability): add reason label to dlq_records_written_total (ETL-1124)

### DIFF
--- a/glassflow-api/cmd/glassflow/dedup_component.go
+++ b/glassflow-api/cmd/glassflow/dedup_component.go
@@ -194,7 +194,7 @@ func NewDedupComponent(
 	}
 
 	statelessTransformerProcessor := processor.ChainProcessors(
-		processor.ChainMiddlewares(processor.DLQMiddleware(dlqWriter, role)),
+		processor.ChainMiddlewares(processor.DLQMiddleware(dlqWriter, role, observability.DLQReasonDedupOverflow)),
 		statelessTransformerProcessorBase,
 	)
 
@@ -203,7 +203,7 @@ func NewDedupComponent(
 		return nil, err
 	}
 	filterProcessor := processor.ChainProcessors(
-		processor.ChainMiddlewares(processor.DLQMiddleware(dlqWriter, role)),
+		processor.ChainMiddlewares(processor.DLQMiddleware(dlqWriter, role, observability.DLQReasonDedupOverflow)),
 		filterProcessorBase,
 	)
 

--- a/glassflow-api/internal/ingestor/processor.go
+++ b/glassflow-api/internal/ingestor/processor.go
@@ -108,7 +108,7 @@ func NewKafkaMsgProcessor(
 	}, nil
 }
 
-func (k *KafkaMsgProcessor) pushMsgToDLQ(ctx context.Context, orgMsg []byte, err error) error {
+func (k *KafkaMsgProcessor) pushMsgToDLQ(ctx context.Context, orgMsg []byte, err error, reason string) error {
 	k.log.Error("Pushing message to DLQ", slog.Any("error", err), slog.String("topic", k.topic.Name))
 
 	data, err := models.NewDLQMessage(internal.RoleIngestor, err.Error(), orgMsg).ToJSON()
@@ -123,7 +123,7 @@ func (k *KafkaMsgProcessor) pushMsgToDLQ(ctx context.Context, orgMsg []byte, err
 		return fmt.Errorf("failed to publish to DLQ: %w", err)
 	}
 
-	observability.RecordDLQWrite(ctx, internal.RoleIngestor, 1)
+	observability.RecordDLQWrite(ctx, internal.RoleIngestor, reason, 1)
 
 	return nil
 }
@@ -209,7 +209,7 @@ func (k *KafkaMsgProcessor) prepareMesssage(ctx context.Context, msg *kgo.Record
 			validationErr = err
 		}
 
-		if dlqErr := k.pushMsgToDLQ(ctx, msg.Value, validationErr); dlqErr != nil {
+		if dlqErr := k.pushMsgToDLQ(ctx, msg.Value, validationErr, observability.DLQReasonParseError); dlqErr != nil {
 			return nil, fmt.Errorf("failed to push to DLQ: %w", dlqErr)
 		}
 		return nil, nil
@@ -221,7 +221,7 @@ func (k *KafkaMsgProcessor) prepareMesssage(ctx context.Context, msg *kgo.Record
 	}
 	subject, dedupKeyStr, err := k.getSubjectAndDedupKey(ctx, version, msgData)
 	if err != nil {
-		if dlqErr := k.pushMsgToDLQ(ctx, msg.Value, fmt.Errorf("%w: %w", models.ErrDeduplicateData, err)); dlqErr != nil {
+		if dlqErr := k.pushMsgToDLQ(ctx, msg.Value, fmt.Errorf("%w: %w", models.ErrDeduplicateData, err), observability.DLQReasonParseError); dlqErr != nil {
 			return nil, fmt.Errorf("failed to push to DLQ: %w", dlqErr)
 		}
 		return nil, nil
@@ -315,7 +315,7 @@ func (k *KafkaMsgProcessor) processBatchSync(ctx context.Context, batch []*kgo.R
 				slog.String("topic", msg.Topic),
 				slog.Int("partition", int(msg.Partition)))
 
-			if dlqErr := k.pushMsgToDLQ(ctx, msg.Value, err); dlqErr != nil {
+			if dlqErr := k.pushMsgToDLQ(ctx, msg.Value, err, observability.DLQReasonUnrecoverable); dlqErr != nil {
 				k.log.Error("Failed to push failed message to DLQ",
 					slog.Any("error", dlqErr),
 					slog.String("topic", msg.Topic),
@@ -605,7 +605,7 @@ func (k *KafkaMsgProcessor) drainToDLQ(ctx context.Context, s *asyncBatchState, 
 		if s.completed[idx] {
 			continue
 		}
-		err := k.pushMsgToDLQ(ctx, s.batch[idx].Value, fmt.Errorf("ingestor cleanup: %w", cause))
+		err := k.pushMsgToDLQ(ctx, s.batch[idx].Value, fmt.Errorf("ingestor cleanup: %w", cause), observability.DLQReasonUnrecoverable)
 		if err != nil {
 			return err
 		}

--- a/glassflow-api/internal/processor/dlq_processor.go
+++ b/glassflow-api/internal/processor/dlq_processor.go
@@ -8,13 +8,15 @@ import (
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/pkg/observability"
 )
 
-// DLQMiddleware returns a middleware that wraps a processor and writes failed messages to DLQ
-func DLQMiddleware(dlqWriter batch.BatchWriter, role string) func(Processor) Processor {
+// DLQMiddleware returns a middleware that wraps a processor and writes failed messages to DLQ.
+// reason must be one of the observability.DLQReason* constants.
+func DLQMiddleware(dlqWriter batch.BatchWriter, role, reason string) func(Processor) Processor {
 	return func(next Processor) Processor {
 		return &dlqMiddleware{
 			next:      next,
 			dlqWriter: dlqWriter,
 			role:      role,
+			reason:    reason,
 		}
 	}
 }
@@ -23,6 +25,7 @@ type dlqMiddleware struct {
 	next      Processor
 	dlqWriter batch.BatchWriter
 	role      string
+	reason    string
 }
 
 func (d *dlqMiddleware) Close(ctx context.Context) error {
@@ -57,7 +60,7 @@ func (d *dlqMiddleware) ProcessBatch(ctx context.Context, batch ProcessorBatch) 
 			return result
 		}
 
-		observability.RecordDLQWrite(ctx, d.role, int64(len(result.FailedMessages)))
+		observability.RecordDLQWrite(ctx, d.role, d.reason, int64(len(result.FailedMessages)))
 
 		result.FailedMessages = nil
 	}

--- a/glassflow-api/internal/sink/clickhouse.go
+++ b/glassflow-api/internal/sink/clickhouse.go
@@ -391,8 +391,9 @@ func (ch *ClickHouseSink) flushFailedBatch(
 	messages []jetstream.Msg,
 	batchErr error,
 ) error {
+	reason := observability.DLQReasonSinkRejection + "_" + sinkerrors.ErrorName(batchErr)
 	for _, msg := range messages {
-		err := ch.pushMsgToDLQ(ctx, msg.Data(), batchErr, observability.DLQReasonSinkRejection)
+		err := ch.pushMsgToDLQ(ctx, msg.Data(), batchErr, reason)
 		if err != nil {
 			return fmt.Errorf("push message to DLQ: %w", err)
 		}
@@ -640,7 +641,7 @@ func (ch *ClickHouseSink) createCHBatches(
 					ch.log.Warn("Failed to append message to batch, pushing to DLQ",
 						slog.Any("error", err))
 
-					dlqErr := ch.pushMsgToDLQ(ctx, procMsg.msg.Data(), err, observability.DLQReasonSinkRejection)
+					dlqErr := ch.pushMsgToDLQ(ctx, procMsg.msg.Data(), err, observability.DLQReasonSinkRejection+"_"+sinkerrors.ErrorName(err))
 					if dlqErr != nil {
 						return nil, fmt.Errorf("failed to push bad message to DLQ: %w", dlqErr)
 					}

--- a/glassflow-api/internal/sink/clickhouse.go
+++ b/glassflow-api/internal/sink/clickhouse.go
@@ -392,7 +392,7 @@ func (ch *ClickHouseSink) flushFailedBatch(
 	batchErr error,
 ) error {
 	for _, msg := range messages {
-		err := ch.pushMsgToDLQ(ctx, msg.Data(), batchErr)
+		err := ch.pushMsgToDLQ(ctx, msg.Data(), batchErr, observability.DLQReasonSinkRejection)
 		if err != nil {
 			return fmt.Errorf("push message to DLQ: %w", err)
 		}
@@ -609,7 +609,7 @@ func (ch *ClickHouseSink) createCHBatches(
 		for _, procMsg := range result.processed {
 			// If there was an error during processing, push to DLQ and skip
 			if procMsg.err != nil {
-				dlqErr := ch.pushMsgToDLQ(ctx, procMsg.msg.Data(), procMsg.err)
+				dlqErr := ch.pushMsgToDLQ(ctx, procMsg.msg.Data(), procMsg.err, observability.DLQReasonSchemaMismatch)
 				if dlqErr != nil {
 					return nil, fmt.Errorf("failed to push bad message to DLQ: %w", dlqErr)
 				}
@@ -640,7 +640,7 @@ func (ch *ClickHouseSink) createCHBatches(
 					ch.log.Warn("Failed to append message to batch, pushing to DLQ",
 						slog.Any("error", err))
 
-					dlqErr := ch.pushMsgToDLQ(ctx, procMsg.msg.Data(), err)
+					dlqErr := ch.pushMsgToDLQ(ctx, procMsg.msg.Data(), err, observability.DLQReasonSinkRejection)
 					if dlqErr != nil {
 						return nil, fmt.Errorf("failed to push bad message to DLQ: %w", dlqErr)
 					}
@@ -735,7 +735,7 @@ func (ch *ClickHouseSink) Stop(noWait bool) {
 	})
 }
 
-func (ch *ClickHouseSink) pushMsgToDLQ(ctx context.Context, orgMsg []byte, err error) error {
+func (ch *ClickHouseSink) pushMsgToDLQ(ctx context.Context, orgMsg []byte, err error, reason string) error {
 	data, err := models.NewDLQMessage(internal.RoleSink, err.Error(), orgMsg).ToJSON()
 	if err != nil {
 		return fmt.Errorf("convert DLQ message to JSON: %w", err)
@@ -746,8 +746,7 @@ func (ch *ClickHouseSink) pushMsgToDLQ(ctx context.Context, orgMsg []byte, err e
 		return fmt.Errorf("publish to DLQ: %w", err)
 	}
 
-	// Record DLQ write metric
-	observability.RecordDLQWrite(ctx, "sink", 1)
+	observability.RecordDLQWrite(ctx, "sink", reason, 1)
 
 	return nil
 }

--- a/glassflow-api/pkg/observability/meter.go
+++ b/glassflow-api/pkg/observability/meter.go
@@ -254,13 +254,24 @@ func RecordKafkaRead(ctx context.Context, component string, count int64) {
 	))
 }
 
-func RecordDLQWrite(ctx context.Context, component string, count int64) {
+// DLQ reason constants — keep cardinality bounded, never pass free-form strings.
+const (
+	DLQReasonParseError     = "parse_error"
+	DLQReasonSchemaMismatch = "schema_mismatch"
+	DLQReasonSinkRejection  = "sink_rejection"
+	DLQReasonRetryExhausted = "retry_exhausted"
+	DLQReasonDedupOverflow  = "dedup_overflow"
+	DLQReasonUnrecoverable  = "unrecoverable"
+)
+
+func RecordDLQWrite(ctx context.Context, component, reason string, count int64) {
 	if DLQRecordsWritten == nil {
 		return
 	}
 	DLQRecordsWritten.Add(ctx, count, metric.WithAttributes(
 		attribute.String("component", component),
 		attribute.String("pipeline_id", pipelineID),
+		attribute.String("reason", reason),
 	))
 }
 

--- a/glassflow-api/tests/dedup_test.go
+++ b/glassflow-api/tests/dedup_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/processor"
 	subjectrouter "github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/subject/router"
 	jsonTransformer "github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/transformer/json"
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/pkg/observability"
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/tests/steps"
 )
 
@@ -207,7 +208,7 @@ func createComponent(
 		require.NoError(t, err)
 		statelessTransformerProcessorBase := processor.NewStatelessTransformerProcessor(transformer)
 		statelessTransformerProcessor = processor.ChainProcessors(
-			processor.ChainMiddlewares(processor.DLQMiddleware(dlqWriter, role)),
+			processor.ChainMiddlewares(processor.DLQMiddleware(dlqWriter, role, observability.DLQReasonDedupOverflow)),
 			statelessTransformerProcessorBase,
 		)
 	} else {
@@ -221,7 +222,7 @@ func createComponent(
 		require.NoError(t, err)
 		filterProcessorBase := processor.NewFilterProcessor(filterJson)
 		filterProcessor = processor.ChainProcessors(
-			processor.ChainMiddlewares(processor.DLQMiddleware(dlqWriter, role)),
+			processor.ChainMiddlewares(processor.DLQMiddleware(dlqWriter, role, observability.DLQReasonDedupOverflow)),
 			filterProcessorBase,
 		)
 	} else {

--- a/glassflow-api/tests/streaming_component_test.go
+++ b/glassflow-api/tests/streaming_component_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/processor"
 	subjectrouter "github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/subject/router"
 	jsonTransformer "github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/transformer/json"
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/pkg/observability"
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/tests/steps"
 )
 
@@ -82,7 +83,7 @@ func createStreamingComponent(
 		require.NoError(t, err)
 		statelessTransformerProcessorBase := processor.NewStatelessTransformerProcessor(transformer)
 		statelessTransformerProcessor = processor.ChainProcessors(
-			processor.ChainMiddlewares(processor.DLQMiddleware(dlqWriter, role)),
+			processor.ChainMiddlewares(processor.DLQMiddleware(dlqWriter, role, observability.DLQReasonDedupOverflow)),
 			statelessTransformerProcessorBase,
 		)
 	} else {
@@ -96,7 +97,7 @@ func createStreamingComponent(
 		require.NoError(t, err)
 		filterProcessorBase := processor.NewFilterProcessor(filterJson)
 		filterProcessor = processor.ChainProcessors(
-			processor.ChainMiddlewares(processor.DLQMiddleware(dlqWriter, role)),
+			processor.ChainMiddlewares(processor.DLQMiddleware(dlqWriter, role, observability.DLQReasonDedupOverflow)),
 			filterProcessorBase,
 		)
 	} else {


### PR DESCRIPTION
## Summary

- DLQ traffic was opaque — operators could see *that* records were going to DLQ but not *why*. Triage required reading pod logs.
- Adds a bounded `reason` label to `gfm_dlq_records_written_total`, enabling a *DLQ by Reason* breakdown panel per pipeline (ETL-888 follow-up).
- Linear: https://linear.app/glassflow/issue/ETL-1124

## Changes

- `pkg/observability/meter.go`: `RecordDLQWrite` gains a `reason string` param; six `DLQReason*` constants define the allowed enum values.
- `internal/processor/dlq_processor.go`: `DLQMiddleware` gains a `reason` param threaded through to `RecordDLQWrite`.
- `internal/ingestor/processor.go`: `pushMsgToDLQ` gains a `reason` param; call sites labelled `parse_error` (schema validation, dedup-key extraction) or `unrecoverable` (NATS publish failure, ingestor cleanup).
- `internal/sink/clickhouse.go`: `pushMsgToDLQ` gains a `reason` param; `schema_mismatch` for mapping failures, `sink_rejection` for CH batch-append and flush failures.
- `cmd/glassflow/dedup_component.go`, tests: updated to pass `dedup_overflow`.

## Test plan

- [ ] `go test ./internal/sink/... ./internal/ingestor/... ./internal/processor/... -race` passes
- [ ] Deploy to staging, trigger a schema-invalid message, confirm `gfm_dlq_records_written_total{reason="parse_error"}` appears in Prometheus

## Rollback

Revert PR — metrics-only label addition, no migrations or data writes.