### PR TITLE
ci: retry ghcr push on transient connection errors (ETL-1137)

### DIFF
--- a/.github/workflows/build_image.yaml
+++ b/.github/workflows/build_image.yaml
@@ -84,17 +84,30 @@ jobs:
             echo "dockerfile=glassflow-api/docker/${{ matrix.component.name }}/Dockerfile" >> $GITHUB_OUTPUT
           fi
       - name: Build & push Docker image
-        uses: docker/build-push-action@v6
         id: build-arch-image
-        with:
-          platforms: ${{ matrix.platform.os }}/${{ matrix.platform.arch }}
-          context: .
-          file: ${{ steps.set-dockerfile.outputs.dockerfile }}
-          push: ${{ inputs.push }}
-          provenance: false
-          outputs: push-by-digest=true,type=image
-          tags: |
-            ghcr.io/glassflow/${{ matrix.component.image_name }}
+        run: |
+          METADATA_FILE=$(mktemp)
+          OUTPUT="push-by-digest=true,type=image"
+          if [ "${{ inputs.push }}" = "true" ]; then
+            OUTPUT="${OUTPUT},push=true"
+          fi
+          for attempt in 1 2 3; do
+            if docker buildx build \
+              --platform "${{ matrix.platform.os }}/${{ matrix.platform.arch }}" \
+              --file "${{ steps.set-dockerfile.outputs.dockerfile }}" \
+              --provenance=false \
+              --output "$OUTPUT" \
+              --tag "ghcr.io/glassflow/${{ matrix.component.image_name }}" \
+              --metadata-file "$METADATA_FILE" \
+              .; then
+              break
+            fi
+            [ $attempt -eq 3 ] && exit 1
+            echo "Attempt $attempt failed, retrying in 15s..."
+            sleep 15
+          done
+          DIGEST=$(jq -r '."containerimage.digest"' "$METADATA_FILE")
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
       - name: Generate output
         id: gen-output
         run: echo "${COMPONENT}-${ARCH}=$DIGEST" >> "$GITHUB_OUTPUT"
@@ -167,7 +180,12 @@ jobs:
             docker manifest create "$REPOSITORY:$TAG" \
               --amend "$REPOSITORY@$AMD64_DIGEST" \
               --amend "$REPOSITORY@$ARM64_DIGEST"
-            docker manifest push "$REPOSITORY:$TAG"
+            for attempt in 1 2 3; do
+              docker manifest push "$REPOSITORY:$TAG" && break
+              [ $attempt -eq 3 ] && exit 1
+              echo "Attempt $attempt failed, retrying in 15s..."
+              sleep 15
+            done
           done
         env:
           AMD64_DIGEST: ${{ matrix.component.amd64_digest }}


### PR DESCRIPTION
## Ex - In the CI run Push to UI fails due to conn issue to ghcr but backend images push succeeds - https://github.com/glassflow/clickhouse-etl/actions/runs/26103397725

## This CI run had to be retried multiple times to connect GHCR successfully - https://github.com/glassflow/clickhouse-etl/actions/runs/26098627280

## Summary

- Replaces `docker/build-push-action@v6` with a shell script in `build-docker-image` that retries `docker buildx build` up to 3 times (15s delay), capturing the digest via `--metadata-file`
- Adds a retry loop (3 attempts, 15s delay) around `docker manifest push` in `push-docker-manifest`
- Frontend jobs are untouched

Fixes intermittent ghcr.io connection errors that require a manual job re-run to resolve.

Linear: https://linear.app/glassflow/issue/ETL-1137