### PR TITLE
fix(otlp-receiver): unwedge publish path and add NATS healthz probe (ETL-1128)

### DIFF
--- a/glassflow-api/cmd/glassflow/oltp_receiver.go
+++ b/glassflow-api/cmd/glassflow/oltp_receiver.go
@@ -19,7 +19,7 @@ func mainOLTPReceiver(
 ) error {
 	fetcher := configFetcher.New(cfg.OTLPConfigFetcherBaseURL)
 	otlpDataProcessor := otlp_processor.NewProcessor(fetcher, nc, cfg.OTLPMaxConcurrentRequests, cfg.OTLPNatsChunkSize)
-	r, err := oltp_receiver.New(log, otlpDataProcessor)
+	r, err := oltp_receiver.New(log, nc, otlpDataProcessor)
 	if err != nil {
 		return err
 	}

--- a/glassflow-api/internal/batch/nats/nats_batch_writer.go
+++ b/glassflow-api/internal/batch/nats/nats_batch_writer.go
@@ -62,7 +62,7 @@ func (w *BatchWriter) WriteBatch(ctx context.Context, messages []models.Message)
 	return failedMessages
 }
 
-func (w *BatchWriter) writeChunk(_ context.Context, messages []models.Message) []models.FailedMessage {
+func (w *BatchWriter) writeChunk(ctx context.Context, messages []models.Message) []models.FailedMessage {
 	futures := make([]jetstream.PubAckFuture, 0, len(messages))
 	var failedMessages []models.FailedMessage
 
@@ -88,7 +88,15 @@ func (w *BatchWriter) writeChunk(_ context.Context, messages []models.Message) [
 		return failedMessages
 	}
 
-	<-w.js.PublishAsyncComplete()
+	// Honor ctx so a wedged JetStream connection (e.g. cluster member restart
+	// mid-flight) cannot deadlock the caller forever. Without this, the gRPC
+	// handler goroutine that hits PublishAsyncComplete will block until the
+	// process is restarted, even though the client has already timed out.
+	select {
+	case <-w.js.PublishAsyncComplete():
+	case <-ctx.Done():
+		return appendUnresolvedAsFailed(failedMessages, futures, ctx.Err())
+	}
 
 	for _, future := range futures {
 		select {
@@ -106,6 +114,36 @@ func (w *BatchWriter) writeChunk(_ context.Context, messages []models.Message) [
 	}
 
 	return failedMessages
+}
+
+// appendUnresolvedAsFailed marks every future that has not yet resolved with the
+// given error so the caller's DLQ/retry path can handle them. Futures that did
+// resolve successfully before the deadline are dropped silently — the messages
+// they cover are already durable in JetStream.
+func appendUnresolvedAsFailed(failed []models.FailedMessage, futures []jetstream.PubAckFuture, cause error) []models.FailedMessage {
+	for _, future := range futures {
+		select {
+		case <-future.Ok():
+			continue
+		case err := <-future.Err():
+			failed = append(failed, models.FailedMessage{
+				Message: models.Message{
+					Type:            models.MessageTypeNatsMsg,
+					NatsMsgOriginal: future.Msg(),
+				},
+				Error: err,
+			})
+		default:
+			failed = append(failed, models.FailedMessage{
+				Message: models.Message{
+					Type:            models.MessageTypeNatsMsg,
+					NatsMsgOriginal: future.Msg(),
+				},
+				Error: cause,
+			})
+		}
+	}
+	return failed
 }
 
 // Close closes the batch writer

--- a/glassflow-api/internal/constants.go
+++ b/glassflow-api/internal/constants.go
@@ -146,6 +146,14 @@ const (
 	NatsDefaultFetchMaxWait = 1 * time.Second
 	NatsDefaultAckWait      = 60 * time.Second
 
+	// OTLP receiver NATS health probe: a background goroutine calls
+	// js.AccountInfo every OTLPReceiverNATSHealthInterval to verify NATS is
+	// responsive. /healthz returns 503 if no sample has succeeded within
+	// OTLPReceiverNATSHealthStaleAfter, so kubelet restarts wedged pods.
+	OTLPReceiverNATSHealthInterval   = 5 * time.Second
+	OTLPReceiverNATSHealthTimeout    = 2 * time.Second
+	OTLPReceiverNATSHealthStaleAfter = 15 * time.Second
+
 	// Pipeline consumer retry config — applied to sink, join, and dedup consumers.
 	// MaxDeliver caps total delivery attempts; AckWait is the per-attempt timeout before
 	// NATS considers the message un-acked and redelivers it.

--- a/glassflow-api/internal/otlp-receiver/server/http/http.go
+++ b/glassflow-api/internal/otlp-receiver/server/http/http.go
@@ -23,10 +23,17 @@ type OTLPDataProcessor interface {
 	ProcessMetrics(ctx context.Context, pipelineID string, exportMetricsRequest *colmetricspb.ExportMetricsServiceRequest) error
 }
 
+// NATSHealthProbe reports whether NATS has acknowledged a recent JetStream
+// request. Used by /healthz so kubelet sees a wedged NATS connection.
+type NATSHealthProbe interface {
+	Healthy() (ok bool, lastGood time.Time)
+}
+
 type handler struct {
 	ready             *atomic.Bool
 	log               *slog.Logger
 	otlpDataProcessor OTLPDataProcessor
+	natsHealth        NATSHealthProbe
 }
 
 type healthResponse struct {
@@ -43,6 +50,7 @@ func NewHTTPServer(
 	ready *atomic.Bool,
 	log *slog.Logger,
 	otlpDataProcessor OTLPDataProcessor,
+	natsHealth NATSHealthProbe,
 ) *server.Server {
 	r := mux.NewRouter()
 
@@ -58,6 +66,7 @@ func NewHTTPServer(
 		ready:             ready,
 		log:               log,
 		otlpDataProcessor: otlpDataProcessor,
+		natsHealth:        natsHealth,
 	}
 	registerHumaHandler("/healthz", h.healthz, healthzOperation(), humaAPI)
 	registerHumaHandler("/readyz", h.readyz, readyzOperation(), humaAPI)
@@ -106,6 +115,19 @@ func readyzOperation() huma.Operation {
 }
 
 func (h handler) healthz(_ context.Context, _ *struct{}) (*healthResponse, error) {
+	if h.natsHealth != nil {
+		if ok, lastGood := h.natsHealth.Healthy(); !ok {
+			h.log.Warn("healthz: NATS unhealthy",
+				slog.Time("last_good", lastGood))
+			return &healthResponse{
+				Status: nethttp.StatusServiceUnavailable,
+				Body: healthStatus{
+					Status: "nats unhealthy",
+				},
+			}, nil
+		}
+	}
+
 	return &healthResponse{
 		Status: nethttp.StatusOK,
 		Body: healthStatus{

--- a/glassflow-api/internal/otlp-receiver/server/natshealth/probe.go
+++ b/glassflow-api/internal/otlp-receiver/server/natshealth/probe.go
@@ -1,0 +1,95 @@
+// Package natshealth runs a background goroutine that periodically issues a
+// JetStream AccountInfo request to verify NATS is responsive end-to-end. The
+// result feeds the OTLP receiver's /healthz so a wedged JetStream connection
+// (e.g. cluster member restart mid-flight) is visible to kubelet and turns
+// into a pod restart instead of a silent 26-hour ingest outage.
+//
+// AccountInfo exercises the JetStream API surface but not the async-publish
+// ack-tracking path that the production traffic uses. It catches most NATS
+// failures (broker down, network partition, JetStream meta-leader failover)
+// but is not a guarantee that publishes are actually succeeding. A synthetic
+// publish probe would be strictly more accurate at the cost of writing into
+// the data plane on every tick; AccountInfo is the cheaper first step.
+package natshealth
+
+import (
+	"context"
+	"log/slog"
+	"sync/atomic"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// Probe samples JetStream health on a fixed interval and tracks the timestamp
+// of the most recent successful sample. Healthy() reports whether the most
+// recent success is within the configured staleness window.
+type Probe struct {
+	js         jetstream.JetStream
+	interval   time.Duration
+	timeout    time.Duration
+	staleAfter time.Duration
+	log        *slog.Logger
+
+	lastGoodNanos atomic.Int64 // unix nano of last successful AccountInfo; 0 == never
+}
+
+func NewProbe(
+	js jetstream.JetStream,
+	interval time.Duration,
+	timeout time.Duration,
+	staleAfter time.Duration,
+	log *slog.Logger,
+) *Probe {
+	return &Probe{
+		js:         js,
+		interval:   interval,
+		timeout:    timeout,
+		staleAfter: staleAfter,
+		log:        log,
+	}
+}
+
+// Start runs the probe loop until ctx cancels. The first sample is taken
+// immediately so Healthy() has a fresh result before the first tick fires.
+func (p *Probe) Start(ctx context.Context) {
+	go func() {
+		p.tick(ctx)
+
+		t := time.NewTicker(p.interval)
+		defer t.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				p.tick(ctx)
+			}
+		}
+	}()
+}
+
+func (p *Probe) tick(ctx context.Context) {
+	probeCtx, cancel := context.WithTimeout(ctx, p.timeout)
+	defer cancel()
+
+	if _, err := p.js.AccountInfo(probeCtx); err != nil {
+		p.log.WarnContext(ctx, "NATS health probe failed", slog.Any("error", err))
+		return
+	}
+
+	p.lastGoodNanos.Store(time.Now().UnixNano())
+}
+
+// Healthy reports whether NATS acknowledged a JetStream request within
+// staleAfter. lastGood is the timestamp of the most recent success, or the
+// zero value if no sample has ever succeeded.
+func (p *Probe) Healthy() (ok bool, lastGood time.Time) {
+	ts := p.lastGoodNanos.Load()
+	if ts == 0 {
+		return false, time.Time{}
+	}
+	lastGood = time.Unix(0, ts)
+	return time.Since(lastGood) <= p.staleAfter, lastGood
+}

--- a/glassflow-api/internal/otlp-receiver/server/natshealth/probe_test.go
+++ b/glassflow-api/internal/otlp-receiver/server/natshealth/probe_test.go
@@ -1,0 +1,129 @@
+package natshealth_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats-server/v2/server"
+	natsTest "github.com/nats-io/nats-server/v2/test"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/otlp-receiver/server/natshealth"
+)
+
+func setupNATS(t *testing.T) (*server.Server, *nats.Conn, jetstream.JetStream) {
+	t.Helper()
+
+	natsServer := natsTest.RunServer(&server.Options{
+		Host:      "127.0.0.1",
+		Port:      -1,
+		NoLog:     true,
+		NoSigs:    true,
+		JetStream: true,
+	})
+
+	nc, err := nats.Connect(natsServer.ClientURL())
+	require.NoError(t, err)
+
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	return natsServer, nc, js
+}
+
+func waitFor(t *testing.T, deadline time.Duration, cond func() bool) bool {
+	t.Helper()
+	end := time.Now().Add(deadline)
+	for time.Now().Before(end) {
+		if cond() {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return cond()
+}
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestProbe_HealthyFalseBeforeFirstSuccess(t *testing.T) {
+	natsServer, nc, js := setupNATS(t)
+	defer natsServer.Shutdown()
+	defer nc.Close()
+
+	p := natshealth.NewProbe(js, time.Second, time.Second, time.Second, discardLogger())
+
+	ok, lastGood := p.Healthy()
+	require.False(t, ok, "probe should be unhealthy before any sample succeeds")
+	require.True(t, lastGood.IsZero(), "lastGood should be zero before any sample")
+}
+
+func TestProbe_HealthyAfterFirstTick(t *testing.T) {
+	natsServer, nc, js := setupNATS(t)
+	defer natsServer.Shutdown()
+	defer nc.Close()
+
+	p := natshealth.NewProbe(js, 50*time.Millisecond, 500*time.Millisecond, time.Second, discardLogger())
+	p.Start(t.Context())
+
+	require.True(t, waitFor(t, 2*time.Second, func() bool {
+		ok, _ := p.Healthy()
+		return ok
+	}), "probe should report healthy after first successful tick")
+}
+
+func TestProbe_GoesUnhealthyWhenNATSShutsDown(t *testing.T) {
+	natsServer, nc, js := setupNATS(t)
+	defer nc.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	p := natshealth.NewProbe(js, 50*time.Millisecond, 200*time.Millisecond, 300*time.Millisecond, discardLogger())
+	p.Start(ctx)
+
+	require.True(t, waitFor(t, 2*time.Second, func() bool {
+		ok, _ := p.Healthy()
+		return ok
+	}), "probe should be healthy against running server")
+
+	natsServer.Shutdown()
+	natsServer.WaitForShutdown()
+
+	require.True(t, waitFor(t, 2*time.Second, func() bool {
+		ok, _ := p.Healthy()
+		return !ok
+	}), "probe should go unhealthy after server shutdown + stale window")
+}
+
+func TestProbe_ExitsOnCtxCancel(t *testing.T) {
+	natsServer, nc, js := setupNATS(t)
+	defer natsServer.Shutdown()
+	defer nc.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	p := natshealth.NewProbe(js, 50*time.Millisecond, 500*time.Millisecond, time.Second, discardLogger())
+	p.Start(ctx)
+
+	require.True(t, waitFor(t, 2*time.Second, func() bool {
+		ok, _ := p.Healthy()
+		return ok
+	}), "probe should be healthy before cancel")
+
+	cancel()
+
+	// After cancel, the goroutine should stop ticking. We can't observe the
+	// goroutine directly, but we can verify the lastGood timestamp stops
+	// advancing across multiple intervals.
+	_, snapshot := p.Healthy()
+	time.Sleep(300 * time.Millisecond)
+	_, after := p.Healthy()
+	require.Equal(t, snapshot, after, "lastGood should not advance after ctx cancel")
+}

--- a/glassflow-api/internal/otlp-receiver/server/receiver.go
+++ b/glassflow-api/internal/otlp-receiver/server/receiver.go
@@ -12,8 +12,11 @@ import (
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal"
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/client"
 	grpcQ "github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/otlp-receiver/server/grpc"
 	httpQ "github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/otlp-receiver/server/http"
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/otlp-receiver/server/natshealth"
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/otlp-receiver/server/processor"
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/server"
 )
@@ -31,10 +34,12 @@ type Receiver struct {
 	grpcLis    net.Listener
 	log        *slog.Logger
 	done       chan struct{}
+	natsProbe  *natshealth.Probe
 }
 
 func New(
 	log *slog.Logger,
+	nc *client.NATSClient,
 	otlpDataProcessor *processor.Processor,
 ) (*Receiver, error) {
 	grpcServer, grpcHealth, grpcLis, err := grpcQ.NewGRPCServer(grpcAddr, log, otlpDataProcessor)
@@ -42,21 +47,32 @@ func New(
 		return nil, err
 	}
 
+	probe := natshealth.NewProbe(
+		nc.JetStream(),
+		internal.OTLPReceiverNATSHealthInterval,
+		internal.OTLPReceiverNATSHealthTimeout,
+		internal.OTLPReceiverNATSHealthStaleAfter,
+		log,
+	)
+
 	r := &Receiver{
 		log:        log,
 		grpcServer: grpcServer,
 		grpcHealth: grpcHealth,
 		grpcLis:    grpcLis,
 		done:       make(chan struct{}),
+		natsProbe:  probe,
 	}
 
-	r.httpServer = httpQ.NewHTTPServer(httpAddr, &r.ready, log, otlpDataProcessor)
+	r.httpServer = httpQ.NewHTTPServer(httpAddr, &r.ready, log, otlpDataProcessor, probe)
 
 	return r, nil
 }
 
 func (r *Receiver) Start(ctx context.Context) error {
 	defer close(r.done)
+
+	r.natsProbe.Start(ctx)
 
 	grpcErrCh := make(chan error, 1)
 	go func() {


### PR DESCRIPTION
  ## Summary

  Fixes the OTLP receiver's silent-wedge failure mode where a NATS cluster restart could stall ingest for 26h while the pod still
  reported `Ready 1/1`. Two changes:

  - **`writeChunk` honors `ctx.Done()`** while waiting on `PublishAsyncComplete`, so the gRPC handler goroutine returns at the client
  deadline instead of leaking forever.
  - **Background NATS health probe** issues `js.AccountInfo` every 5s; `/healthz` returns 503 if no sample has succeeded in 15s, so
  kubelet restarts wedged pods.