### PR TITLE
docs(usage-guide/python-sdk): refresh for SDK 4.0.0 (ETL-1139)

### DIFF
--- a/docs/app/usage-guide/python-sdk/page.mdx
+++ b/docs/app/usage-guide/python-sdk/page.mdx
@@ -12,10 +12,10 @@ The GlassFlow Python SDK provides a programmatic way to create and manage data p
 Install the GlassFlow Python SDK using pip:
 
 ```bash
-pip install glassflow>=3.6.0
+pip install glassflow>=4.0.0
 ```
 
-> **Pipeline version notice**: The default pipeline version is now `v3`. If you have existing `v2` configurations, see [Migrating from V2 to V3](#migrating-from-v2-to-v3) below. Pipeline version `v2` is deprecated and will be removed in a future release.
+> **Pipeline version notice**: The default and only supported pipeline version is `v3`. Pipeline version `v2` has been **removed** in `glassflow` 4.0.0. If you have existing `v2` configurations, use the `migrate_pipeline_v2_to_v3()` helper — see [Migrating from V2 to V3](#migrating-from-v2-to-v3) below.
 
 ## Basic Usage
 
@@ -162,6 +162,14 @@ or update the full pipeline config:
 pipeline.update(config_patch=<new pipeline config>)
 ```
 
+### Rename a Pipeline
+
+Rename a pipeline without stopping it — the new name is reflected in the UI and API immediately.
+
+```python
+pipeline.rename("My renamed pipeline")
+```
+
 ## Dead-Letter Queue (DLQ)
 
 ### Get DLQ State
@@ -171,21 +179,22 @@ dlq_state = pipeline.dlq.state()
 print(dlq_state)
 ```
 
-
-### Purge DLQ
-
-```python
-pipeline.dlq.purge()
-```
-
 Output:
 ```json
 {
-    "last_consumed_at": "2025-09-05T10:32:38.113427621Z",
-    "last_received_at": "2025-09-05T10:23:26.530466989Z",
+    "last_consumed_at": "2026-05-20T10:32:38.113427621Z",
+    "last_received_at": "2026-05-20T10:23:26.530466989Z",
     "total_messages": 2,
     "unconsumed_messages": 1
 }
+```
+
+### Purge DLQ
+
+Removes all messages from the DLQ. Returns `None`.
+
+```python
+pipeline.dlq.purge()
 ```
 
 ### Read Messages from DLQ
@@ -336,7 +345,20 @@ The following resource fields are **immutable** — they must be set at creation
 
 ## Migrating from V2 to V3
 
-Pipeline version `v2` is deprecated. See the [Pipeline Configuration Reference](/configuration/pipeline-config-reference#v2-reference-deprecated) for the full V2 → V3 migration table.
+Pipeline version `v2` has been **removed** in `glassflow` 4.0.0. Existing v2 configurations must be migrated to v3 before they can be deployed.
+
+The SDK ships a `migrate_pipeline_v2_to_v3()` helper that does the migration server-side and returns a validated v3 configuration. It calls the GlassFlow API's `POST /api/v1/pipeline/migrate-preview` endpoint — no pipeline is created and no state is touched, so it's safe to call repeatedly.
+
+```python
+from glassflow.etl import Client
+
+client = Client(host="http://localhost:30180")
+
+v3_config = client.migrate_pipeline_v2_to_v3(v2_config)
+pipeline = client.create_pipeline(v3_config)
+```
+
+If you prefer to migrate manually, see the [Pipeline Configuration Reference](/configuration/pipeline-config-reference#v2-reference-deprecated) for the full migration table.
 
 Key structural changes:
 


### PR DESCRIPTION
## Summary

Closes [ETL-1139](https://linear.app/glassflow/issue/ETL-1139). The Python SDK usage guide was pinned to `>=3.6.0` with deprecation-era V2 language; the published SDK is now `4.0.0` on PyPI with V2 fully removed. Plus a couple of content gaps and a presentation bug.

## Changes

- **Install constraint**: `pip install glassflow>=4.0.0`
- **V2 status**: dropped "deprecated and will be removed in a future release" wording — V2 was actually removed in 4.0.0. The version-notice block now points at the migration helper.
- **Migration helper documented**: added `client.migrate_pipeline_v2_to_v3()` example in the "Migrating from V2 to V3" section. The helper calls the server-side `POST /api/v1/pipeline/migrate-preview` endpoint, is safe to call repeatedly, and returns a validated v3 config.
- **`pipeline.rename(name)`**: added a small section. The method exists in the SDK but wasn't documented.
- **DLQ presentation bug**: the example JSON output was rendered under `### Purge DLQ` (which returns `None`); moved it under `### Get DLQ State` where it actually applies. Refreshed the example timestamps to 2026-05 since I was touching that block anyway.

## Test plan

- [x] Render the docs locally, click through `/usage-guide/python-sdk` end-to-end
- [x] Confirm the install constraint, V2 notice, rename section, and DLQ ordering all read correctly
- [x] No broken anchor links from neighbouring pages (the `#migrating-from-v2-to-v3` anchor still resolves; the new `### Rename a Pipeline` section appears between Update and DLQ)