### PR TITLE
fix(processor): emit dlq_records_written_total for dedup/join/transform/filter DLQ writes

### DIFF
--- a/glassflow-api/internal/processor/component.go
+++ b/glassflow-api/internal/processor/component.go
@@ -11,6 +11,7 @@ import (
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal"
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/batch"
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/models"
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/pkg/observability"
 )
 
 type ProcessorBatch struct {
@@ -183,6 +184,8 @@ func (c *Component) writeFailedBatch(ctx context.Context, failedMessages []model
 	if len(failedDlqMessages) > 0 {
 		return fmt.Errorf("failed to write to DLQ: %w", failedDlqMessages[0].Error)
 	}
+
+	observability.RecordDLQWrite(ctx, c.role, observability.DLQReasonUnrecoverable, int64(len(messages)))
 
 	return nil
 }

--- a/glassflow-api/internal/processor/component_test.go
+++ b/glassflow-api/internal/processor/component_test.go
@@ -1,0 +1,59 @@
+package processor
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/models"
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/pkg/observability"
+)
+
+func TestComponent_WriteFailedBatch_RecordsDLQMetric(t *testing.T) {
+	reader := observability.InitMetricsForTesting()
+
+	dlq := &stubWriter{calls: [][]models.FailedMessage{nil}}
+	c := &Component{
+		dlqWriter: dlq,
+		log:       slog.Default(),
+		role:      "dedup",
+		shutdown:  shutdown{doneCh: make(chan struct{})},
+	}
+
+	failed := []models.FailedMessage{
+		{Message: makeMsg(`{"id":1}`), Error: errors.New("processing error")},
+		{Message: makeMsg(`{"id":2}`), Error: errors.New("another error")},
+	}
+
+	err := c.writeFailedBatch(context.Background(), failed)
+	require.NoError(t, err)
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	found := false
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != observability.GfMetricPrefix+"_dlq_records_written_total" {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			if !ok {
+				continue
+			}
+			for _, dp := range sum.DataPoints {
+				comp, _ := dp.Attributes.Value("component")
+				reason, _ := dp.Attributes.Value("reason")
+				if comp.AsString() == "dedup" && reason.AsString() == observability.DLQReasonUnrecoverable {
+					require.Equal(t, int64(2), dp.Value)
+					found = true
+				}
+			}
+		}
+	}
+	require.True(t, found, "dlq_records_written_total metric not recorded for component=dedup")
+}

--- a/glassflow-api/internal/processor/streaming_component.go
+++ b/glassflow-api/internal/processor/streaming_component.go
@@ -11,6 +11,7 @@ import (
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/batch"
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/models"
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/stream"
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/pkg/observability"
 )
 
 // streamingState encapsulates all streaming-specific state
@@ -246,6 +247,8 @@ func (sc *StreamingComponent) writeFailedBatch(ctx context.Context, failedMessag
 	if len(failedDlqMessages) > 0 {
 		return fmt.Errorf("failed to write to DLQ: %w", failedDlqMessages[0].Error)
 	}
+
+	observability.RecordDLQWrite(ctx, sc.role, observability.DLQReasonUnrecoverable, int64(len(messages)))
 
 	return nil
 }

--- a/glassflow-api/internal/processor/streaming_component_test.go
+++ b/glassflow-api/internal/processor/streaming_component_test.go
@@ -9,9 +9,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/models"
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/stream"
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/pkg/observability"
 )
 
 // stubWriter is a BatchWriter whose WriteBatch behaviour is controlled per call.
@@ -129,4 +131,45 @@ func TestWriteWithBackpressure_ContextCancelledDuringRetry(t *testing.T) {
 	err := sc.writeWithBackpressure(ctx, []models.Message{msg}, []models.Message{msg})
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, context.DeadlineExceeded))
+}
+
+func TestStreamingComponent_WriteFailedBatch_RecordsDLQMetric(t *testing.T) {
+	reader := observability.InitMetricsForTesting()
+
+	dlq := &stubWriter{calls: [][]models.FailedMessage{nil}}
+	sc := newTestComponent(nil, dlq)
+	sc.role = "join"
+
+	failed := []models.FailedMessage{
+		{Message: makeMsg(`{"id":1}`), Error: errors.New("processing error")},
+		{Message: makeMsg(`{"id":2}`), Error: errors.New("another error")},
+	}
+
+	err := sc.writeFailedBatch(context.Background(), failed)
+	require.NoError(t, err)
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	found := false
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != observability.GfMetricPrefix+"_dlq_records_written_total" {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			if !ok {
+				continue
+			}
+			for _, dp := range sum.DataPoints {
+				comp, _ := dp.Attributes.Value("component")
+				reason, _ := dp.Attributes.Value("reason")
+				if comp.AsString() == "join" && reason.AsString() == observability.DLQReasonUnrecoverable {
+					require.Equal(t, int64(2), dp.Value)
+					found = true
+				}
+			}
+		}
+	}
+	require.True(t, found, "dlq_records_written_total metric not recorded for component=join")
 }


### PR DESCRIPTION
## Summary

- `Component.writeFailedBatch` and `StreamingComponent.writeFailedBatch` were publishing records to the DLQ NATS stream but never calling `RecordDLQWrite`, leaving `glassflow_gfm_dlq_records_written_total` at zero for all dedup/join/transform/filter paths. Fixes ETL-1143.
- The ingestor and sink paths already emitted this metric correctly; this closes the gap for the four processor-based components.

## Changes

- Added `observability.RecordDLQWrite(ctx, role, DLQReasonUnrecoverable, count)` after each successful `WriteBatch` in both `Component.writeFailedBatch` and `StreamingComponent.writeFailedBatch`.
- Added `component_test.go` with a test asserting the counter is recorded with correct `component` and `reason` attributes when `Component.writeFailedBatch` runs.
- Extended `streaming_component_test.go` with the same assertion for `StreamingComponent.writeFailedBatch`.

## Test plan

- [ ] `go test ./internal/processor/... -race` passes
- [ ] After deploy to staging: run a backpressure scenario that produces DLQ writes and confirm `sum(glassflow_gfm_dlq_records_written_total{component=~"dedup|join|transform|filter"})` is non-zero and matches the NATS DLQ stream depth

## Rollback

Revert PR — no migrations or data writes.