### PR TITLE
docs(CLAUDE): always branch from main before starting a ticket

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,18 @@ Both must pass. `make pre-push-check` runs the full suite including lint.
 - Frontend changes reviewed by: Vladimir (sole frontend dev)
 - No `Co-Authored-By: Claude` or AI attribution in commits/PRs
 
+### Starting work on a new ticket
+
+**Always branch from `main`.** Before creating a branch, run:
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b username/ETL-XYZ-short-description
+```
+
+Never start a ticket branch from another feature branch. If the current working directory is on a non-main branch when a ticket is requested, check out main and pull before creating the new branch. Skipping this causes the PR to include unrelated commits from the prior branch.
+
 ## Configuration
 
 Components are configured via environment variables (envconfig pattern). PostgreSQL stores persistent pipeline config. NATS KV is used for runtime metadata (legacy).


### PR DESCRIPTION
## Summary

- Adds an explicit "Starting work on a new ticket" section to `CLAUDE.md` with the exact commands to run before branching.
- Prevents the recurring mistake of branching off a non-main branch and accidentally including unrelated commits in a PR diff.

## Rollback

Revert PR.