### PR TITLE
fix: emit backpressure component signals for all components

### DIFF
--- a/glassflow-api/cmd/glassflow/dedup_component.go
+++ b/glassflow-api/cmd/glassflow/dedup_component.go
@@ -213,6 +213,8 @@ func NewDedupComponent(
 		dlqWriter,
 		log,
 		role,
+		pipelineConfig.ID,
+		componentSignalPublisher,
 		// execution depends on order in this slice
 		[]processor.Processor{
 			filterProcessor,

--- a/glassflow-api/internal/component/join.go
+++ b/glassflow-api/internal/component/join.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nats-io/nats.go/jetstream"
 
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal"
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/componentsignals"
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/configs"
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/join"
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/kv"
@@ -41,6 +42,8 @@ func NewJoinComponent(
 	leftSourceName, rightSourceName, leftKey, rightKey string,
 	doneCh chan struct{},
 	log *slog.Logger,
+	pipelineID string,
+	signalPublisher *componentsignals.ComponentSignalPublisher,
 ) (Component, error) {
 	if cfg.Type != internal.TemporalJoinType {
 		return nil, fmt.Errorf("unsupported join type")
@@ -57,6 +60,8 @@ func NewJoinComponent(
 		leftKVStore, rightKVStore,
 		leftSourceName, rightSourceName, leftKey, rightKey,
 		log,
+		pipelineID,
+		signalPublisher,
 	)
 	return &JoinComponent{
 		leftStreamSubsriber:   stream.NewNATSSubscriber(leftStreamConsumer, log),

--- a/glassflow-api/internal/ingestor/processor.go
+++ b/glassflow-api/internal/ingestor/processor.go
@@ -259,7 +259,7 @@ func (k *KafkaMsgProcessor) bpStart(ctx context.Context) {
 			Component:  internal.RoleIngestor,
 			PipelineID: k.pipelineID,
 			Reason:     "stream back-pressure",
-			Text:       "NATS stream is full — ingestor is retrying",
+			Text:       fmt.Sprintf("NATS stream is full — ingestor is retrying (topic: %s)", k.topic.Name),
 		}); sigErr != nil {
 			k.log.WarnContext(ctx, "failed to send backpressure signal", slog.Any("error", sigErr))
 		}

--- a/glassflow-api/internal/ingestor/processor.go
+++ b/glassflow-api/internal/ingestor/processor.go
@@ -52,9 +52,9 @@ type KafkaMsgProcessor struct {
 
 	// Back-pressure episode state. Mutated only from the single-goroutine
 	// processor driver, so no synchronization is needed.
-	activeBackpressure      bool
-	backpressureStartTS     time.Time
-	lastBackpressureSignal  time.Time
+	activeBackpressure     bool
+	backpressureStartTS    time.Time
+	lastBackpressureSignal time.Time
 }
 
 func NewKafkaMsgProcessor(

--- a/glassflow-api/internal/ingestor/processor.go
+++ b/glassflow-api/internal/ingestor/processor.go
@@ -52,8 +52,9 @@ type KafkaMsgProcessor struct {
 
 	// Back-pressure episode state. Mutated only from the single-goroutine
 	// processor driver, so no synchronization is needed.
-	activeBackpressure  bool
-	backpressureStartTS time.Time
+	activeBackpressure      bool
+	backpressureStartTS     time.Time
+	lastBackpressureSignal  time.Time
 }
 
 func NewKafkaMsgProcessor(
@@ -237,6 +238,8 @@ func (k *KafkaMsgProcessor) prepareMesssage(ctx context.Context, msg *kgo.Record
 	return nMsg, nil
 }
 
+const backpressureSignalCooldown = 5 * time.Minute
+
 // bpStart marks the beginning of a back-pressure episode. Idempotent — extra
 // calls inside an active episode are no-ops, so the histogram observes one
 // duration per episode regardless of how many BP errors happen along the way.
@@ -249,6 +252,18 @@ func (k *KafkaMsgProcessor) bpStart(ctx context.Context) {
 	observability.RecordIngestorBackpressureStart(ctx)
 	k.log.InfoContext(ctx, "ingestor backpressure: start",
 		slog.String("pipeline_id", k.pipelineID))
+
+	if k.signalPublisher != nil && time.Since(k.lastBackpressureSignal) >= backpressureSignalCooldown {
+		k.lastBackpressureSignal = time.Now()
+		if sigErr := k.signalPublisher.SendSignal(ctx, models.ComponentSignal{
+			Component:  internal.RoleIngestor,
+			PipelineID: k.pipelineID,
+			Reason:     "stream back-pressure",
+			Text:       "NATS stream is full — ingestor is retrying",
+		}); sigErr != nil {
+			k.log.WarnContext(ctx, "failed to send backpressure signal", slog.Any("error", sigErr))
+		}
+	}
 }
 
 // bpStop ends an active back-pressure episode and observes its duration.

--- a/glassflow-api/internal/join/temporal.go
+++ b/glassflow-api/internal/join/temporal.go
@@ -13,11 +13,15 @@ import (
 	"github.com/nats-io/nats.go/jetstream"
 
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal"
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/componentsignals"
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/configs"
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/kv"
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/models"
 	schemav2 "github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/schema_v2"
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/stream"
 )
+
+const backpressureSignalCooldown = 5 * time.Minute
 
 type TemporalJoinExecutor struct {
 	resultsPublisher stream.Publisher
@@ -31,6 +35,10 @@ type TemporalJoinExecutor struct {
 	leftKey          string
 	rightKey         string
 	log              *slog.Logger
+	pipelineID       string
+	signalPublisher  *componentsignals.ComponentSignalPublisher
+
+	lastBackpressureSignal time.Time
 }
 
 func NewTemporalJoinExecutor(
@@ -40,6 +48,8 @@ func NewTemporalJoinExecutor(
 	leftKVStore, rightKVStore kv.KeyValueStore,
 	leftSourceName, rightSourceName, leftKey, rightKey string,
 	log *slog.Logger,
+	pipelineID string,
+	signalPublisher *componentsignals.ComponentSignalPublisher,
 ) *TemporalJoinExecutor {
 	return &TemporalJoinExecutor{
 		resultsPublisher: resultsPublisher,
@@ -53,6 +63,8 @@ func NewTemporalJoinExecutor(
 		leftKey:          leftKey,
 		rightKey:         rightKey,
 		log:              log,
+		pipelineID:       pipelineID,
+		signalPublisher:  signalPublisher,
 	}
 }
 
@@ -80,6 +92,18 @@ func (t *TemporalJoinExecutor) publishJoinedMsg(ctx context.Context, inflight je
 			t.log.WarnContext(ctx, "failed to extend ack-wait while waiting on back-pressure", "error", ipErr)
 		}
 		t.log.WarnContext(ctx, "results stream back-pressure, retrying publish", "backoff", backoff)
+
+		if t.signalPublisher != nil && time.Since(t.lastBackpressureSignal) >= backpressureSignalCooldown {
+			t.lastBackpressureSignal = time.Now()
+			if sigErr := t.signalPublisher.SendSignal(ctx, models.ComponentSignal{
+				Component:  internal.RoleJoin,
+				PipelineID: t.pipelineID,
+				Reason:     "stream back-pressure",
+				Text:       fmt.Sprintf("NATS results stream is full — %s is retrying", internal.RoleJoin),
+			}); sigErr != nil {
+				t.log.WarnContext(ctx, "failed to send backpressure signal", slog.Any("error", sigErr))
+			}
+		}
 		select {
 		case <-ctx.Done():
 			return ctx.Err()

--- a/glassflow-api/internal/models/resources.go
+++ b/glassflow-api/internal/models/resources.go
@@ -400,7 +400,7 @@ func dedupEnabled(pc *PipelineConfig) bool {
 			return true
 		}
 	}
-	return false
+	return pc.OTLPSource.Deduplication.Enabled
 }
 
 func transformEnabled(pc *PipelineConfig) bool {

--- a/glassflow-api/internal/otlp-receiver/server/processor/processor.go
+++ b/glassflow-api/internal/otlp-receiver/server/processor/processor.go
@@ -214,6 +214,8 @@ func (p *Processor) emitBackpressureSignal(ctx context.Context, pipelineID strin
 	p.lastBackpressureSignal[pipelineID] = time.Now()
 	p.signalMu.Unlock()
 
+	observability.RecordBackpressureStart(ctx, internal.RoleOLTPReceiver)
+
 	_ = p.signalSender.SendSignal(ctx, models.ComponentSignal{
 		Component:  internal.RoleOLTPReceiver,
 		PipelineID: pipelineID,

--- a/glassflow-api/internal/processor/streaming_component.go
+++ b/glassflow-api/internal/processor/streaming_component.go
@@ -12,6 +12,7 @@ import (
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/componentsignals"
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/models"
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/stream"
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/pkg/observability"
 )
 
 const backpressureSignalCooldown = 5 * time.Minute
@@ -37,7 +38,9 @@ type StreamingComponent struct {
 	pipelineID      string
 	signalPublisher *componentsignals.ComponentSignalPublisher
 
-	lastBackpressureSignal time.Time
+	lastBackpressureSignal  time.Time
+	activeBackpressure      bool
+	backpressureStartTS     time.Time
 
 	streaming streamingState
 }
@@ -202,7 +205,17 @@ func (sc *StreamingComponent) writeWithBackpressure(ctx context.Context, upstrea
 		}
 
 		if len(backpressure) == 0 {
+			if sc.activeBackpressure {
+				sc.activeBackpressure = false
+				observability.RecordBackpressureStop(ctx, sc.role, time.Since(sc.backpressureStartTS).Seconds())
+			}
 			return nil
+		}
+
+		if !sc.activeBackpressure {
+			sc.activeBackpressure = true
+			sc.backpressureStartTS = time.Now()
+			observability.RecordBackpressureStart(ctx, sc.role)
 		}
 
 		// Extend AckWait on upstream JetStream messages so the broker does not

--- a/glassflow-api/internal/processor/streaming_component.go
+++ b/glassflow-api/internal/processor/streaming_component.go
@@ -38,9 +38,9 @@ type StreamingComponent struct {
 	pipelineID      string
 	signalPublisher *componentsignals.ComponentSignalPublisher
 
-	lastBackpressureSignal  time.Time
-	activeBackpressure      bool
-	backpressureStartTS     time.Time
+	lastBackpressureSignal time.Time
+	activeBackpressure     bool
+	backpressureStartTS    time.Time
 
 	streaming streamingState
 }

--- a/glassflow-api/internal/processor/streaming_component.go
+++ b/glassflow-api/internal/processor/streaming_component.go
@@ -9,9 +9,12 @@ import (
 
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal"
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/batch"
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/componentsignals"
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/models"
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/stream"
 )
+
+const backpressureSignalCooldown = 5 * time.Minute
 
 // streamingState encapsulates all streaming-specific state
 type streamingState struct {
@@ -24,13 +27,17 @@ type streamingState struct {
 }
 
 type StreamingComponent struct {
-	reader     batch.BatchReader
-	writer     batch.BatchWriter
-	dlqWriter  batch.BatchWriter
-	log        *slog.Logger
-	processors []Processor
-	shutdown   shutdown
-	role       string
+	reader          batch.BatchReader
+	writer          batch.BatchWriter
+	dlqWriter       batch.BatchWriter
+	log             *slog.Logger
+	processors      []Processor
+	shutdown        shutdown
+	role            string
+	pipelineID      string
+	signalPublisher *componentsignals.ComponentSignalPublisher
+
+	lastBackpressureSignal time.Time
 
 	streaming streamingState
 }
@@ -41,15 +48,19 @@ func NewStreamingComponent(
 	dlqWriter batch.BatchWriter,
 	log *slog.Logger,
 	role string,
+	pipelineID string,
+	signalPublisher *componentsignals.ComponentSignalPublisher,
 	processors []Processor,
 ) *StreamingComponent {
 	return &StreamingComponent{
-		reader:     reader,
-		writer:     writer,
-		dlqWriter:  dlqWriter,
-		log:        log,
-		processors: processors,
-		role:       role,
+		reader:          reader,
+		writer:          writer,
+		dlqWriter:       dlqWriter,
+		log:             log,
+		processors:      processors,
+		role:            role,
+		pipelineID:      pipelineID,
+		signalPublisher: signalPublisher,
 		shutdown: shutdown{
 			doneCh: make(chan struct{}),
 		},
@@ -206,6 +217,18 @@ func (sc *StreamingComponent) writeWithBackpressure(ctx context.Context, upstrea
 		}
 
 		sc.log.WarnContext(ctx, "output stream back-pressure, retrying", "backoff", backoff, "pending", len(backpressure))
+
+		if sc.signalPublisher != nil && time.Since(sc.lastBackpressureSignal) >= backpressureSignalCooldown {
+			sc.lastBackpressureSignal = time.Now()
+			if sigErr := sc.signalPublisher.SendSignal(ctx, models.ComponentSignal{
+				Component:  sc.role,
+				PipelineID: sc.pipelineID,
+				Reason:     "stream back-pressure",
+				Text:       fmt.Sprintf("NATS output stream is full — %s is retrying", sc.role),
+			}); sigErr != nil {
+				sc.log.WarnContext(ctx, "failed to send backpressure signal", slog.Any("error", sigErr))
+			}
+		}
 
 		select {
 		case <-ctx.Done():

--- a/glassflow-api/internal/service/join_runner.go
+++ b/glassflow-api/internal/service/join_runner.go
@@ -10,6 +10,7 @@ import (
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal"
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/client"
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/component"
+	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/componentsignals"
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/configs"
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/kv"
 	"github.com/glassflow/clickhouse-etl-internal/glassflow-api/internal/models"
@@ -163,6 +164,12 @@ func (j *JoinRunner) Start(ctx context.Context) error {
 		TotalSubjectCount: outputSubjectCount,
 	})
 
+	signalPublisher, err := componentsignals.NewPublisher(j.nc)
+	if err != nil {
+		j.log.ErrorContext(ctx, "failed to create component signal publisher", "error", err)
+		return fmt.Errorf("create signal publisher: %w", err)
+	}
+
 	jComponent, err := component.NewJoinComponent(
 		j.joinCfg,
 		leftConsumer,
@@ -179,6 +186,8 @@ func (j *JoinRunner) Start(ctx context.Context) error {
 		rightSource.JoinKey,
 		j.doneCh,
 		j.log,
+		j.cfg.ID,
+		signalPublisher,
 	)
 	if err != nil {
 		j.log.ErrorContext(ctx, "failed to join: ", "error", err)

--- a/glassflow-api/internal/service/pipeline.go
+++ b/glassflow-api/internal/service/pipeline.go
@@ -280,9 +280,13 @@ func (p *PipelineService) GetOTLPConfig(ctx context.Context, pid string) (models
 
 	var routing models.RoutingConfig
 	if dedup.Enabled {
+		subjectCount := 1
+		if pipeline.PipelineResources.Transform != nil && pipeline.PipelineResources.Transform.Replicas != nil {
+			subjectCount = int(*pipeline.PipelineResources.Transform.Replicas)
+		}
 		routing = models.RoutingConfig{
 			OutputSubject: outputSubject,
-			SubjectCount:  int(*pipeline.PipelineResources.Transform.Replicas),
+			SubjectCount:  subjectCount,
 			Type:          models.RoutingTypeField,
 			Field:         &models.RoutingConfigField{Name: dedup.ID},
 		}

--- a/glassflow-api/pkg/observability/meter.go
+++ b/glassflow-api/pkg/observability/meter.go
@@ -50,8 +50,13 @@ var (
 	IngestorBackpressureActive   metric.Int64Gauge
 	IngestorBackpressureEvents   metric.Int64Counter
 	IngestorBackpressureDuration metric.Float64Histogram
-	StreamDepth                  metric.Int64Gauge
-	StreamDepthRatio             metric.Float64Gauge
+
+	ComponentBackpressureActive   metric.Int64Gauge
+	ComponentBackpressureEvents   metric.Int64Counter
+	ComponentBackpressureDuration metric.Float64Histogram
+
+	StreamDepth      metric.Int64Gauge
+	StreamDepthRatio metric.Float64Gauge
 )
 
 // pipelineID is set once at component startup (not used by the API which handles multiple pipelines).
@@ -160,6 +165,15 @@ func initMetricInstruments(m metric.Meter) {
 	IngestorBackpressureDuration = mustCreateBackpressureDurationHistogram(m,
 		GfMetricPrefix+"_"+"ingestor_backpressure_duration_seconds",
 		"Duration of each ingestor back-pressure episode in seconds")
+
+	ComponentBackpressureActive = mustCreateInt64Gauge(m, GfMetricPrefix+"_"+"component_backpressure_active",
+		"1 while the component is in back-pressure, 0 otherwise; labelled by component")
+	ComponentBackpressureEvents = mustCreateCounter(m, GfMetricPrefix+"_"+"component_backpressure_events_total",
+		"Total number of times a component entered back-pressure; labelled by component")
+	ComponentBackpressureDuration = mustCreateBackpressureDurationHistogram(m,
+		GfMetricPrefix+"_"+"component_backpressure_duration_seconds",
+		"Duration of each component back-pressure episode in seconds; labelled by component")
+
 	StreamDepth = mustCreateInt64Gauge(m, GfMetricPrefix+"_"+"stream_depth",
 		"Number of messages currently stored in a JetStream stream")
 	StreamDepthRatio = mustCreateGauge(m, GfMetricPrefix+"_"+"stream_depth_ratio",
@@ -370,6 +384,30 @@ func RecordReceiverRequest(ctx context.Context, component, transport, status, pi
 	}
 }
 
+func RecordBackpressureStart(ctx context.Context, component string) {
+	if ComponentBackpressureActive == nil {
+		return
+	}
+	attrs := metric.WithAttributes(
+		attribute.String("pipeline_id", pipelineID),
+		attribute.String("component", component),
+	)
+	ComponentBackpressureActive.Record(ctx, 1, attrs)
+	ComponentBackpressureEvents.Add(ctx, 1, attrs)
+}
+
+func RecordBackpressureStop(ctx context.Context, component string, duration float64) {
+	if ComponentBackpressureActive == nil {
+		return
+	}
+	attrs := metric.WithAttributes(
+		attribute.String("pipeline_id", pipelineID),
+		attribute.String("component", component),
+	)
+	ComponentBackpressureActive.Record(ctx, 0, attrs)
+	ComponentBackpressureDuration.Record(ctx, duration, attrs)
+}
+
 func RecordIngestorBackpressureStart(ctx context.Context) {
 	if IngestorBackpressureActive == nil {
 		return
@@ -377,6 +415,7 @@ func RecordIngestorBackpressureStart(ctx context.Context) {
 	attrs := metric.WithAttributes(attribute.String("pipeline_id", pipelineID))
 	IngestorBackpressureActive.Record(ctx, 1, attrs)
 	IngestorBackpressureEvents.Add(ctx, 1, attrs)
+	RecordBackpressureStart(ctx, "ingestor")
 }
 
 func RecordIngestorBackpressureStop(ctx context.Context, duration float64) {
@@ -386,6 +425,7 @@ func RecordIngestorBackpressureStop(ctx context.Context, duration float64) {
 	attrs := metric.WithAttributes(attribute.String("pipeline_id", pipelineID))
 	IngestorBackpressureActive.Record(ctx, 0, attrs)
 	IngestorBackpressureDuration.Record(ctx, duration, attrs)
+	RecordBackpressureStop(ctx, "ingestor", duration)
 }
 
 func RecordStreamDepth(ctx context.Context, streamName string, depth int64) {

--- a/glassflow-api/tests/steps/join_steps.go
+++ b/glassflow-api/tests/steps/join_steps.go
@@ -267,7 +267,7 @@ func (j *JoinTestSuite) iRunJoinComponent(leftTTL, rightTTL string) error {
 		rightSource.JoinKey,
 		make(chan struct{}),
 		logger,
-		"", // pipelineID not needed in tests
+		"",  // pipelineID not needed in tests
 		nil, // signalPublisher not needed in tests
 	)
 

--- a/glassflow-api/tests/steps/join_steps.go
+++ b/glassflow-api/tests/steps/join_steps.go
@@ -267,6 +267,8 @@ func (j *JoinTestSuite) iRunJoinComponent(leftTTL, rightTTL string) error {
 		rightSource.JoinKey,
 		make(chan struct{}),
 		logger,
+		"", // pipelineID not needed in tests
+		nil, // signalPublisher not needed in tests
 	)
 
 	if err != nil {

--- a/glassflow-api/tests/streaming_component_test.go
+++ b/glassflow-api/tests/streaming_component_test.go
@@ -110,6 +110,8 @@ func createStreamingComponent(
 		dlqWriter,
 		slog.Default(),
 		role,
+		"", // pipelineID not needed in tests
+		nil, // signalPublisher not needed in tests
 		[]processor.Processor{
 			filterProcessor,
 			dedupProcessor,


### PR DESCRIPTION
## Summary
- During back-pressure episodes, no component was sending a `ComponentSignal` to the stream — the operator never received notifications
- Fixed for all three affected components:
  - **Ingestor** (`processor.go` `bpStart`): signal includes the Kafka topic name
  - **Dedup/transform/filter** (`StreamingComponent.writeWithBackpressure`): signal includes the role name
  - **Join** (`TemporalJoinExecutor.publishJoinedMsg`): signal includes the role name
- All signals are rate-limited with a 5-minute cooldown to avoid spam during sustained back-pressure

## Test plan
- [ ] Unit tests pass (`make run-test`)
- [ ] Trigger back-pressure on ingestor, dedup, and join — confirm signals appear on `component-signals.failures` stream with correct component and descriptive text