### PR TITLE
ETL-1151: Data Plane message format: payload and originals

### DIFF
--- a/glassflow-api/internal/dataplane/message/errors.go
+++ b/glassflow-api/internal/dataplane/message/errors.go
@@ -1,0 +1,31 @@
+package message
+
+import "errors"
+
+// Typed errors returned by Parse, Pack, and DataPlaneMsg.Originals when a
+// wire buffer or pack request fails the v1 framing contract. Exported so
+// callers (component DLQ paths, tests, future debug tooling) can branch on
+// the specific failure mode.
+var (
+	// ErrReservedFlags reports that one or more reserved flag bits (bits 1..7
+	// in v1) were set on the inbound frame. Producers MUST keep these zero.
+	ErrReservedFlags = errors.New("dataplane/message: reserved flag bits set")
+
+	// ErrShortBuffer reports that the wire buffer is shorter than the minimum
+	// frame header (flags + payload_len + original_len = 9 bytes) or shorter
+	// than the bytes declared by a length prefix.
+	ErrShortBuffer = errors.New("dataplane/message: buffer truncated")
+
+	// ErrLenOverflow reports that a declared length prefix would read past the
+	// end of the surrounding buffer.
+	ErrLenOverflow = errors.New("dataplane/message: length prefix overflows buffer")
+
+	// ErrBadCount reports that the originals count is 0. A frame must carry
+	// at least one original payload — both at pack time (caller passed zero
+	// originals) and at parse time (multi-source slot declared count == 0).
+	ErrBadCount = errors.New("dataplane/message: originals count must be >= 1")
+
+	// ErrTooManyOriginals reports that the originals count exceeds 255. The
+	// count is a single byte and thus must be <= 255.
+	ErrTooManyOriginals = errors.New("dataplane/message: originals count must be <= 255")
+)

--- a/glassflow-api/internal/dataplane/message/message.go
+++ b/glassflow-api/internal/dataplane/message/message.go
@@ -1,0 +1,308 @@
+// Package message implements the GlassFlow data-plane wire format.
+//
+// Every NATS data-plane message body (between source stage and sink) is a
+// fixed framing of two length-prefixed slots: a "payload" slot carrying the
+// in-flight bytes that each processor reads/mutates, followed by an
+// immutable "original" slot carrying the raw source payload(s). DLQ writers
+// always read from the original slot so re-processing replays source bytes,
+// not the post-transform body.
+//
+// Payload-before-original keeps the hot in-flight bytes adjacent to the
+// header — a small cache-locality win on small frames, and a natural fit
+// for future tooling that reads only the payload (e.g. very-large records
+// where the original is shipped out-of-band).
+//
+// Message layout:
+//
+//	offset    size  field
+//	------    ----  -------------------------------------------------
+//	0         1     flags         (bit 0: multi_source; 1..7 reserved=0)
+//	1         4     payload_len   (big-endian u32)
+//	5         M     payload
+//	5+M       4     original_len  (big-endian u32)
+//	9+M       N     original_slot
+//
+// When flags has bit 0 unset (single_source), original_slot is the raw source
+// bytes verbatim. When bit 0 is set (multi_source), original_slot is itself a
+// count-prefixed encoding of one or more sources:
+//
+//	offset  size  field
+//	------  ----  -------------------------------------------------
+//	0       1     count                 (uint8, >= 1)
+//	1       4     source_0_len          (big-endian u32)
+//	5       …     source_0_bytes
+//	…       4     source_{k-1}_len
+//	…       …     source_{k-1}_bytes
+//
+// Two flows produce a wire frame:
+//   - Source / join stages: NewDataPlaneMsg(payload, originals…) → Pack.
+//   - Mid-stages: Parse(buf) → SetPayload(new) → Pack.
+//
+// Pass-through components forward the inbound bytes verbatim and never touch
+// either slot.
+package message
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+const (
+	// FlagMultiSource (bit 0) signals the multi-source encoding inside the
+	// original slot. Set automatically by Pack when len(originals) > 1. A
+	// single-source frame has flags == 0.
+	FlagMultiSource byte = 1 << 0
+
+	// flagsReservedMask covers bits 1..7. v1 producers MUST keep these zero
+	// and v1 readers MUST reject any non-zero reserved bit. The mask doubles
+	// as a sanity check that catches accidental raw-byte publishes: common
+	// payload preludes (JSON '{' = 0x7B, JSON '[' = 0x5B, Avro/protobuf
+	// headers) all carry non-zero reserved bits.
+	//
+	// Future format extensions (e.g. compression) will claim bits from this
+	// mask one at a time; until then, set bits here are a producer bug.
+	flagsReservedMask byte = 0xFE
+
+	// headerSize is the size of the fixed frame prelude: flags + payload_len
+	// + original_len. The payload and original bytes sit between/after.
+	headerSize = 1 + 4 + 4
+
+	// maxOriginalsCount is the upper bound on the multi-source count byte.
+	maxOriginalsCount = 255
+)
+
+// DataPlaneMsg is a parsed (or to-be-packed) data-plane wire frame.
+//
+// Memory & lifetime contract:
+//
+//   - After Parse, Payload() and Originals() return sub-slices into the
+//     buffer that was parsed — no copies. NATS reuses message buffers
+//     between fetches, so those slices are only valid until the message is
+//     ack'd (or, more conservatively, until the next batch fetch).
+//   - After NewDataPlaneMsg, Originals() aliases the caller's argument
+//     slice — the constructor does not copy. Lifetime is the caller's.
+//
+// In both cases the returned bytes are READ-ONLY. Mutating Payload() /
+// Originals() return values has undefined effects on the frame, the source
+// NATS buffer, and any other holder of the slice.
+//
+// The type is small (1 byte + three slice headers); pass it by value on the
+// hot path. Use SetPayload to swap the payload slot before Pack().
+//
+// Exactly one of origSlot / originals is populated on a valid msg:
+//   - Parse populates origSlot with the encoded slot bytes from the buffer.
+//   - NewDataPlaneMsg populates originals with the raw per-source bytes;
+//     Pack inline-encodes them into the output buffer.
+//
+// The zero value packs to a valid empty single-source frame.
+type DataPlaneMsg struct {
+	flags     byte
+	payload   []byte
+	origSlot  []byte
+	originals [][]byte
+}
+
+// Parse reads a wire frame from b. The returned DataPlaneMsg holds sub-slices
+// into b; no copies. Returns a typed error on any framing violation; never
+// panics.
+func Parse(b []byte) (DataPlaneMsg, error) {
+	var zero DataPlaneMsg
+	if len(b) < headerSize {
+		return zero, fmt.Errorf("%w: need at least %d bytes, have %d", ErrShortBuffer, headerSize, len(b))
+	}
+
+	flags := b[0]
+	if flags&flagsReservedMask != 0 {
+		return zero, fmt.Errorf("%w: flags=0x%02x", ErrReservedFlags, flags)
+	}
+
+	payloadLen := binary.BigEndian.Uint32(b[1:5])
+	payloadEnd := uint64(5) + uint64(payloadLen)
+	origLenEnd := payloadEnd + 4
+	if origLenEnd > uint64(len(b)) {
+		return zero, fmt.Errorf("%w: payload_len=%d exceeds buffer (len=%d)", ErrLenOverflow, payloadLen, len(b))
+	}
+
+	payload := b[5:payloadEnd]
+
+	origLen := binary.BigEndian.Uint32(b[payloadEnd:origLenEnd])
+	origEnd := origLenEnd + uint64(origLen)
+	if origEnd > uint64(len(b)) {
+		return zero, fmt.Errorf("%w: original_len=%d exceeds buffer (len=%d)", ErrLenOverflow, origLen, len(b))
+	}
+
+	return DataPlaneMsg{
+		flags:    flags,
+		payload:  payload,
+		origSlot: b[origLenEnd:origEnd],
+	}, nil
+}
+
+// NewDataPlaneMsg constructs a frame in memory from a payload and one or
+// more originals. The frame is not encoded until Pack is called.
+//
+// The wire format is chosen by source count:
+//   - 1 original  → single-source frame (flags=0, no inner count prefix)
+//   - 2..255      → multi-source frame (flags=FlagMultiSource, count-prefixed)
+//
+// Returns ErrBadCount when len(originals) == 0 and ErrTooManyOriginals when
+// it exceeds 255 (the wire format's single-byte count limit). Source stages
+// (ingestor, OTLP receiver) call this with one original; the join component
+// calls it with two.
+//
+// The returned value holds a reference to the originals slice; do not mutate
+// the elements between construction and Pack.
+func NewDataPlaneMsg(payload []byte, originals ...[]byte) (DataPlaneMsg, error) {
+	switch {
+	case len(originals) == 0:
+		return DataPlaneMsg{}, fmt.Errorf("%w: NewDataPlaneMsg requires at least one original", ErrBadCount)
+	case len(originals) > maxOriginalsCount:
+		return DataPlaneMsg{}, fmt.Errorf("%w: got %d originals", ErrTooManyOriginals, len(originals))
+	}
+
+	flags := byte(0)
+	if len(originals) > 1 {
+		flags = FlagMultiSource
+	}
+	return DataPlaneMsg{
+		flags:     flags,
+		payload:   payload,
+		originals: originals,
+	}, nil
+}
+
+// Payload returns the data-slot bytes. For parsed frames this is a sub-slice
+// into the NATS buffer; for constructed frames it aliases the caller's
+// argument. In both cases the bytes are READ-ONLY — see the DataPlaneMsg
+// memory & lifetime contract. To replace the payload, use SetPayload.
+func (m DataPlaneMsg) Payload() []byte { return m.payload }
+
+// SetPayload replaces the data slot. Used by mutating processors between
+// Parse and Pack. The original slot and flags are preserved.
+func (m *DataPlaneMsg) SetPayload(p []byte) { m.payload = p }
+
+// Originals returns the source payloads carried in the original slot. For
+// single-source frames a one-element slice; for multi-source the decoded
+// per-source bytes.
+//
+// The returned [][]byte and its element bytes are READ-ONLY — see the
+// DataPlaneMsg memory & lifetime contract. For constructed frames the slice
+// aliases the constructor's argument directly (zero allocation); for parsed
+// frames the elements are sub-slices into the NATS buffer.
+//
+// Contract: a valid frame always yields at least one element. An empty/nil
+// single-source original yields one entry with empty bytes — DLQ writers
+// should iterate and emit one envelope per element regardless of length.
+func (m DataPlaneMsg) Originals() ([][]byte, error) {
+	// Constructed frame: originals already in slice form, no decode needed.
+	if len(m.originals) > 0 {
+		return m.originals, nil
+	}
+	if m.flags&FlagMultiSource == 0 {
+		return [][]byte{m.origSlot}, nil
+	}
+
+	if len(m.origSlot) < 1 {
+		return nil, fmt.Errorf("%w: multi-source slot needs count byte", ErrShortBuffer)
+	}
+
+	count := m.origSlot[0]
+	if count == 0 {
+		return nil, fmt.Errorf("%w: count=0", ErrBadCount)
+	}
+
+	srcs := make([][]byte, 0, count)
+	pos := uint64(1)
+	bound := uint64(len(m.origSlot))
+
+	for i := range int(count) {
+		if pos+4 > bound {
+			return nil, fmt.Errorf("%w: multi-source[%d] length prefix truncated", ErrShortBuffer, i)
+		}
+		srcLen := binary.BigEndian.Uint32(m.origSlot[pos : pos+4])
+		pos += 4
+		end := pos + uint64(srcLen)
+		if end > bound {
+			return nil, fmt.Errorf("%w: multi-source[%d] len=%d exceeds slot (len=%d)", ErrLenOverflow, i, srcLen, len(m.origSlot))
+		}
+		srcs = append(srcs, m.origSlot[pos:end])
+		pos = end
+	}
+
+	return srcs, nil
+}
+
+// Flags returns the raw flags byte. Bit 0 (FlagMultiSource) distinguishes
+// single-source (0) from multi-source (1); bits 1..7 are reserved for future
+// extensions (e.g. compression). Exported so callers like the sink can fast-
+// branch on shape without going through Originals().
+func (m DataPlaneMsg) Flags() byte { return m.flags }
+
+// Pack encodes the message into a wire frame.
+//
+// For messages produced by Parse, the original slot is already encoded and
+// is copied through byte-identical. For messages produced by NewDataPlaneMsg,
+// the originals are encoded inline into the output buffer — single allocation
+// regardless of source count.
+//
+// The payload slot reflects any SetPayload changes since construction/parse.
+// The zero-value DataPlaneMsg packs to a valid empty single-source frame.
+func (m DataPlaneMsg) Pack() []byte {
+	// Path 1: constructed frame — originals carry the raw per-source bytes.
+	if len(m.originals) > 0 {
+		if len(m.originals) == 1 {
+			return writeFrame(0, m.payload, m.originals[0])
+		}
+		return writeFrameMulti(0, m.payload, m.originals)
+	}
+	// Path 2: parsed frame (or zero value) — origSlot already encoded.
+	return writeFrame(m.flags, m.payload, m.origSlot)
+}
+
+// writeFrame writes a wire frame whose original slot is already encoded.
+// Used for parsed frames (any flags) and constructed single-source frames
+// (where the raw original IS the slot, no inner framing). Callers must
+// pass a v1-legal flags byte (reserved bits zero).
+func writeFrame(flags byte, payload, slot []byte) []byte {
+	out := make([]byte, headerSize+len(payload)+len(slot))
+	out[0] = flags
+	binary.BigEndian.PutUint32(out[1:5], uint32(len(payload))) //nolint:gosec // bounded by NATS message size
+	copy(out[5:], payload)
+	origLenOff := 5 + len(payload)
+	binary.BigEndian.PutUint32(out[origLenOff:origLenOff+4], uint32(len(slot))) //nolint:gosec // bounded by NATS message size
+	copy(out[origLenOff+4:], slot)
+	return out
+}
+
+// writeFrameMulti writes a multi-source wire frame in a single allocation.
+// The count-prefixed slot is materialized directly into the output buffer
+// rather than into a temporary. FlagMultiSource is set automatically;
+// callers may pass additional flag bits in flags (v1 defines none).
+// Callers must pass a v1-legal flags byte (reserved bits zero).
+func writeFrameMulti(flags byte, payload []byte, originals [][]byte) []byte {
+	flags |= FlagMultiSource
+
+	slotLen := 1 // count byte
+	for _, s := range originals {
+		slotLen += 4 + len(s)
+	}
+
+	out := make([]byte, headerSize+len(payload)+slotLen)
+	out[0] = flags
+	binary.BigEndian.PutUint32(out[1:5], uint32(len(payload))) //nolint:gosec // bounded by NATS message size
+	copy(out[5:], payload)
+
+	origLenOff := 5 + len(payload)
+	binary.BigEndian.PutUint32(out[origLenOff:origLenOff+4], uint32(slotLen)) //nolint:gosec // bounded by NATS message size
+
+	pos := origLenOff + 4
+	out[pos] = byte(len(originals))
+	pos++
+	for _, s := range originals {
+		binary.BigEndian.PutUint32(out[pos:pos+4], uint32(len(s))) //nolint:gosec // bounded by NATS message size
+		pos += 4
+		copy(out[pos:], s)
+		pos += len(s)
+	}
+	return out
+}

--- a/glassflow-api/internal/dataplane/message/message_test.go
+++ b/glassflow-api/internal/dataplane/message/message_test.go
@@ -1,0 +1,466 @@
+package message
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// packForTest is a tiny helper to keep test setup terse: it runs the
+// NewDataPlaneMsg → Pack flow and fails the test on error.
+func packForTest(t *testing.T, payload []byte, originals ...[]byte) []byte {
+	t.Helper()
+	m, err := NewDataPlaneMsg(payload, originals...)
+	require.NoError(t, err)
+	return m.Pack()
+}
+
+func TestRoundTripSingleSource(t *testing.T) {
+	orig := []byte(`{"id":1,"v":"src"}`)
+	data := []byte(`{"id":1,"v":"transformed"}`)
+
+	buf := packForTest(t, data, orig)
+	m, err := Parse(buf)
+	require.NoError(t, err)
+	require.Equal(t, byte(0), m.Flags(), "1-original New must write a single-source frame")
+	require.True(t, bytes.Equal(data, m.Payload()))
+
+	srcs, err := m.Originals()
+	require.NoError(t, err)
+	require.Len(t, srcs, 1)
+	require.True(t, bytes.Equal(orig, srcs[0]))
+}
+
+func TestRoundTripMultiSource(t *testing.T) {
+	left := []byte(`{"side":"left"}`)
+	right := []byte(`{"side":"right"}`)
+	data := []byte(`{"joined":true}`)
+
+	buf := packForTest(t, data, left, right)
+	m, err := Parse(buf)
+	require.NoError(t, err)
+	require.Equal(t, FlagMultiSource, m.Flags()&FlagMultiSource, "2-original New must set multi-source flag")
+	require.True(t, bytes.Equal(data, m.Payload()))
+
+	srcs, err := m.Originals()
+	require.NoError(t, err)
+	require.Len(t, srcs, 2)
+	require.True(t, bytes.Equal(left, srcs[0]))
+	require.True(t, bytes.Equal(right, srcs[1]))
+}
+
+func TestRepackInvariant(t *testing.T) {
+	tests := []struct {
+		name      string
+		originals [][]byte
+	}{
+		{
+			name:      "single source",
+			originals: [][]byte{[]byte("orig-bytes")},
+		},
+		{
+			name:      "multi source",
+			originals: [][]byte{[]byte("L"), []byte("R")},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			inbound := packForTest(t, []byte("inner"), tc.originals...)
+
+			m, err := Parse(inbound)
+			require.NoError(t, err)
+			origBefore := append([]byte(nil), m.origSlot...) // snapshot before mutation
+			flagsBefore := m.Flags()
+
+			newData := []byte("new-mutated-payload")
+			m.SetPayload(newData)
+
+			out := m.Pack()
+
+			m2, err := Parse(out)
+			require.NoError(t, err)
+			require.Equal(t, flagsBefore, m2.Flags())
+			require.True(t, bytes.Equal(origBefore, m2.origSlot), "origSlot must be byte-identical after Pack")
+			require.True(t, bytes.Equal(newData, m2.Payload()))
+		})
+	}
+}
+
+func TestEmptyPayloads(t *testing.T) {
+	// NewDataPlaneMsg with len(originals)==1 has no validation in v1; nil / []
+	// round-trip cleanly so the package itself doesn't trip on edge cases that
+	// callers (source stages) may screen for separately.
+	tests := []struct {
+		name string
+		orig []byte
+		data []byte
+	}{
+		{"both nil", nil, nil},
+		{"both empty", []byte{}, []byte{}},
+		{"empty data, real orig", []byte("source"), nil},
+		{"empty orig, real data", nil, []byte("data")},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := packForTest(t, tc.data, tc.orig)
+			m, err := Parse(buf)
+			require.NoError(t, err)
+			require.Equal(t, byte(0), m.Flags())
+			require.Equal(t, len(tc.data), len(m.Payload()))
+
+			srcs, err := m.Originals()
+			require.NoError(t, err)
+			require.Len(t, srcs, 1)
+			require.Equal(t, len(tc.orig), len(srcs[0]))
+		})
+	}
+}
+
+func TestLargePayloads(t *testing.T) {
+	// NATS body cap is 8 MB; 4 MB + 4 MB exercises the u32 length math
+	// without hitting the cap.
+	orig := bytes.Repeat([]byte("A"), 4<<20)
+	data := bytes.Repeat([]byte("B"), 4<<20)
+
+	buf := packForTest(t, data, orig)
+	m, err := Parse(buf)
+	require.NoError(t, err)
+	require.Equal(t, byte(0), m.Flags())
+	require.True(t, bytes.Equal(data, m.Payload()))
+
+	srcs, err := m.Originals()
+	require.NoError(t, err)
+	require.True(t, bytes.Equal(orig, srcs[0]))
+}
+
+func TestNewDataPlaneMsg_ZeroOriginals(t *testing.T) {
+	_, err := NewDataPlaneMsg([]byte("data"))
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrBadCount), "got %v", err)
+}
+
+func TestNewDataPlaneMsg_TooManyOriginals(t *testing.T) {
+	// 256 originals overflows the single-byte count field.
+	originals := make([][]byte, 256)
+	for i := range originals {
+		originals[i] = []byte{byte(i)}
+	}
+	_, err := NewDataPlaneMsg([]byte("data"), originals...)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrTooManyOriginals), "got %v", err)
+}
+
+func TestNewDataPlaneMsg_MaxOriginals(t *testing.T) {
+	// Exactly 255 must succeed and round-trip.
+	originals := make([][]byte, 255)
+	for i := range originals {
+		originals[i] = []byte{byte(i)}
+	}
+	m, err := NewDataPlaneMsg([]byte("data"), originals...)
+	require.NoError(t, err)
+	buf := m.Pack()
+
+	m2, err := Parse(buf)
+	require.NoError(t, err)
+	srcs, err := m2.Originals()
+	require.NoError(t, err)
+	require.Len(t, srcs, 255)
+}
+
+func TestMalformedInputs(t *testing.T) {
+	tests := []struct {
+		name    string
+		build   func() []byte
+		wantErr error
+	}{
+		{
+			name: "buffer shorter than header",
+			build: func() []byte {
+				return make([]byte, 8) // header is 9 bytes
+			},
+			wantErr: ErrShortBuffer,
+		},
+		{
+			name: "payload_len exceeds buffer",
+			build: func() []byte {
+				b := make([]byte, headerSize)
+				binary.BigEndian.PutUint32(b[1:5], 9999)
+				return b
+			},
+			wantErr: ErrLenOverflow,
+		},
+		{
+			name: "original_len exceeds buffer",
+			build: func() []byte {
+				// payload_len=0, then bogus original_len
+				b := make([]byte, headerSize)
+				binary.BigEndian.PutUint32(b[1:5], 0)
+				binary.BigEndian.PutUint32(b[5:9], 9999)
+				return b
+			},
+			wantErr: ErrLenOverflow,
+		},
+		{
+			name: "u32 overflow on payload_len",
+			build: func() []byte {
+				b := make([]byte, headerSize)
+				binary.BigEndian.PutUint32(b[1:5], ^uint32(0))
+				return b
+			},
+			wantErr: ErrLenOverflow,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Parse(tc.build())
+			require.Error(t, err)
+			require.True(t, errors.Is(err, tc.wantErr), "got %v, want errors.Is(%v)", err, tc.wantErr)
+		})
+	}
+}
+
+func TestReservedFlagsBitByBit(t *testing.T) {
+	// Cover each reserved bit 1..7 individually. v1 must reject all of them.
+	for bit := 1; bit <= 7; bit++ {
+		t.Run(fmt.Sprintf("bit_%d", bit), func(t *testing.T) {
+			b := make([]byte, headerSize)
+			b[0] = byte(1 << bit)
+			_, err := Parse(b)
+			require.Error(t, err)
+			require.True(t, errors.Is(err, ErrReservedFlags))
+		})
+	}
+}
+
+func TestProducerBugDetection(t *testing.T) {
+	// Common raw payloads accidentally published without wrapping. All should
+	// trip ErrReservedFlags or another framing error — never silently parse.
+	tests := []struct {
+		name string
+		body []byte
+	}{
+		{"json object", []byte(`{"id":1}`)},
+		{"json array", []byte(`[1,2,3]`)},
+		{"avro header", []byte{'O', 'b', 'j', 1}},
+		{"protobuf varint prelude", []byte{0x0A, 0x05, 'h', 'e', 'l', 'l', 'o'}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Pad to header size so we exercise the flags-check before the
+			// length-check trips.
+			body := tc.body
+			if len(body) < headerSize {
+				body = append(body, make([]byte, headerSize-len(body))...)
+			}
+			_, err := Parse(body)
+			require.Error(t, err, "raw payload %q should not parse as a v1 wire frame", tc.body)
+			require.True(t, errors.Is(err, ErrReservedFlags), "got %v", err)
+		})
+	}
+}
+
+func TestMultiSourceBadCount(t *testing.T) {
+	t.Run("count=0", func(t *testing.T) {
+		// Multi-source flag set, origSlot is a single zero byte (count=0).
+		m := DataPlaneMsg{flags: FlagMultiSource, origSlot: []byte{0x00}}
+		_, err := m.Originals()
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrBadCount))
+	})
+
+	t.Run("count exceeds slot", func(t *testing.T) {
+		// count=2, but only one source bytes truncated
+		m := DataPlaneMsg{
+			flags:    FlagMultiSource,
+			origSlot: []byte{0x02, 0x00, 0x00, 0x00, 0x01, 'a'},
+		}
+		_, err := m.Originals()
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrShortBuffer))
+	})
+
+	t.Run("source len exceeds slot", func(t *testing.T) {
+		// count=1, source_0_len=999, only 1 byte of payload
+		m := DataPlaneMsg{
+			flags:    FlagMultiSource,
+			origSlot: []byte{0x01, 0x00, 0x00, 0x03, 0xE7, 'a'},
+		}
+		_, err := m.Originals()
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrLenOverflow))
+	})
+
+	t.Run("multi-source empty slot", func(t *testing.T) {
+		m := DataPlaneMsg{flags: FlagMultiSource, origSlot: nil}
+		_, err := m.Originals()
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrShortBuffer))
+	})
+}
+
+func TestParseThenOriginals_MalformedMultiSource(t *testing.T) {
+	// Frame parses cleanly but the multi-source slot declares count=0. The
+	// realistic on-wire shape of a bad-count failure, complementing the
+	// direct-construction cases above.
+	payload := []byte("payload")
+	slot := []byte{0x00} // count=0
+	buf := writeFrame(FlagMultiSource, payload, slot)
+
+	m, err := Parse(buf)
+	require.NoError(t, err, "Parse should accept the frame shape")
+
+	_, err = m.Originals()
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrBadCount))
+}
+
+func TestFlagShapeMismatch(t *testing.T) {
+	// Build a single-source frame and forcibly re-interpret as multi-source.
+	// Originals must surface a framing error rather than silently treating
+	// the raw bytes as a count-prefixed slot.
+	orig := []byte("plain source bytes — no count prefix")
+	buf := packForTest(t, []byte("data"), orig)
+	m, err := Parse(buf)
+	require.NoError(t, err)
+
+	// Strip the constructed-frame originals so the discriminator falls
+	// through to the parsed-frame origSlot path.
+	m.originals = nil
+	m.flags |= FlagMultiSource
+	_, err = m.Originals()
+	require.Error(t, err)
+}
+
+func TestParseNoAllocOnHotPath(t *testing.T) {
+	buf := packForTest(t, []byte("data"), []byte("orig"))
+	allocs := testing.AllocsPerRun(100, func() {
+		_, _ = Parse(buf)
+	})
+	require.Equal(t, 0.0, allocs, "Parse must not allocate on the hot path")
+}
+
+func TestOriginalsSingleSourceLowAlloc_ParsedFrame(t *testing.T) {
+	buf := packForTest(t, []byte("data"), []byte("orig"))
+	m, err := Parse(buf)
+	require.NoError(t, err)
+
+	allocs := testing.AllocsPerRun(100, func() {
+		_, _ = m.Originals()
+	})
+	require.Equal(t, 1.0, allocs, "Originals on parsed single-source should allocate exactly the result slice")
+}
+
+func TestOriginalsConstructedFrame_NoAlloc(t *testing.T) {
+	// Constructed frames already hold the originals slice; Originals returns
+	// it directly with zero allocations.
+	m, err := NewDataPlaneMsg([]byte("data"), []byte("orig"))
+	require.NoError(t, err)
+
+	allocs := testing.AllocsPerRun(100, func() {
+		_, _ = m.Originals()
+	})
+	require.Equal(t, 0.0, allocs, "Originals on constructed frame should allocate zero")
+}
+
+func TestPackSingleSourceSingleAlloc(t *testing.T) {
+	// Construct + Pack should allocate exactly the output buffer.
+	payload := []byte("payload")
+	orig := []byte("source")
+
+	allocs := testing.AllocsPerRun(100, func() {
+		m, _ := NewDataPlaneMsg(payload, orig)
+		_ = m.Pack()
+	})
+	require.Equal(t, 1.0, allocs, "single-source construct+Pack should allocate exactly the output buffer")
+}
+
+func TestPackMultiSourceSingleAlloc(t *testing.T) {
+	// Multi-source construct + Pack writes the count-prefixed slot directly
+	// into the output buffer; the only allocation should be the output buffer.
+	payload := []byte("payload")
+	left := []byte("left-src")
+	right := []byte("right-src")
+
+	allocs := testing.AllocsPerRun(100, func() {
+		m, _ := NewDataPlaneMsg(payload, left, right)
+		_ = m.Pack()
+	})
+	require.Equal(t, 1.0, allocs, "multi-source construct+Pack should allocate exactly the output buffer")
+}
+
+func TestPayloadFirstLayout(t *testing.T) {
+	// Lock the wire-format layout against accidental reversal: bytes 5..5+M
+	// must be the payload, NOT the original slot.
+	orig := []byte("ORIGINAL_BYTES")
+	data := []byte("payload-here")
+	buf := packForTest(t, data, orig)
+
+	// flags byte
+	require.Equal(t, byte(0), buf[0])
+	// payload_len at bytes 1..5
+	require.Equal(t, uint32(len(data)), binary.BigEndian.Uint32(buf[1:5]))
+	// payload bytes immediately follow
+	require.True(t, bytes.Equal(data, buf[5:5+len(data)]))
+	// original_len after payload
+	origLenOff := 5 + len(data)
+	require.Equal(t, uint32(len(orig)), binary.BigEndian.Uint32(buf[origLenOff:origLenOff+4]))
+	// original bytes at the tail
+	require.True(t, bytes.Equal(orig, buf[origLenOff+4:]))
+}
+
+func BenchmarkParse(b *testing.B) {
+	buf := mustPack(bytes.Repeat([]byte("x"), 1024), []byte("orig bytes"))
+	b.ReportAllocs()
+	for b.Loop() {
+		_, _ = Parse(buf)
+	}
+}
+
+func BenchmarkPackFromParsed(b *testing.B) {
+	inbound := mustPack(bytes.Repeat([]byte("x"), 1024), []byte("orig bytes"))
+	m, _ := Parse(inbound)
+	m.SetPayload(bytes.Repeat([]byte("y"), 1024))
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = m.Pack()
+	}
+}
+
+func BenchmarkNewAndPackSingleSource(b *testing.B) {
+	payload := bytes.Repeat([]byte("y"), 1024)
+	orig := []byte("orig bytes")
+	b.ReportAllocs()
+	for b.Loop() {
+		m, _ := NewDataPlaneMsg(payload, orig)
+		_ = m.Pack()
+	}
+}
+
+func BenchmarkNewAndPackMultiSource(b *testing.B) {
+	payload := bytes.Repeat([]byte("y"), 1024)
+	left := []byte("left bytes")
+	right := []byte("right bytes")
+	b.ReportAllocs()
+	for b.Loop() {
+		m, _ := NewDataPlaneMsg(payload, left, right)
+		_ = m.Pack()
+	}
+}
+
+// mustPack is the benchmark-side equivalent of packForTest — same flow, no
+// *testing.T (so it can be used from BenchmarkXxx setup).
+func mustPack(payload []byte, originals ...[]byte) []byte {
+	m, err := NewDataPlaneMsg(payload, originals...)
+	if err != nil {
+		panic(err)
+	}
+	return m.Pack()
+}


### PR DESCRIPTION
  ## Summary

  Introduces a v1 data-plane message format that preserves source-stage bytes from ingest through to DLQ. Every NATS data-plane body is
   now a `DataPlaneMsg` carrying two length-prefixed slots: a mutable **payload** (the in-flight bytes each component reads/writes) and
   an immutable **original** (the raw source payload — single-source for regular pipelines, multi-source for joins). DLQ writers always
   emit envelopes carrying the original bytes, so reprocessing replays what arrived at the source — not the post-transform body that
  got rejected.

  ## Why

  DLQ envelopes used to carry the in-flight (mutated) bytes, so:
  - Replaying a sink-rejected record fed the *transformed* payload through the pipeline again, breaking customer-data consistency.
  - A failed joined record had no relation to either input side; the source rows were unrecoverable.

  ## Layout

  [flags:1][payload_len:4][payload:M][original_len:4][original_slot:N]

  - `flags` bit 0 = multi_source; bits 1–7 reserved-zero in v1 (rejected on read; future v2 extension channel).
  - `original_slot` is the raw source bytes for single-source messages, or a `count`-prefixed encoding for multi-source (join today,
  N-way enrichment later).

  ## What changed

  - **New `internal/dataplane/message`** package: `DataPlaneMsg` struct with `Parse` / `NewDataPlaneMsg(payload, originals…)` /
  `SetPayload` / `Originals` / `Pack`. Zero-alloc `Parse`, single-alloc `Pack` (multi-source original slot written inline into the
  output buffer).
  - **Source stages wrap**: ingestor + OTLP receiver emit `DataPlaneMsg` on every NATS publish. Ingestor's external-schema case is
  asymmetric — payload = stripped, original = raw Kafka bytes — so DLQ replay keeps the magic-byte prefix.
  - **Mid-stages**: filter / transformer use Parse → SetPayload → Pack; dedup is a verified pass-through (keys off `Nats-Msg-Id`
  header, never touches the payload).
  - **Join emits multi-source `DataPlaneMsg`**: KV buffers store inbound data-plane messages so the matching side can recover both the
  inner payload and the original source bytes.
  - **Sink + DLQ middleware**: parse on read, emit **one DLQ envelope per source** (single = 1, join failure = 2 independent
  envelopes), with malformed-message fallback to raw bytes + a tagged error.