### PR TITLE
docs(sources/cloudwatch): validated AWS CloudWatch via OTel Collector to GlassFlow pattern (ETL-1163)

### DIFF
--- a/docs/app/sources/cloudwatch/page.mdx
+++ b/docs/app/sources/cloudwatch/page.mdx
@@ -134,29 +134,6 @@ Numeric metric values land in different schema fields depending on the receiver'
 
 For full OTLP source field reference, see [OTLP Schema Reference](/sources/otlp/schema-reference). For the GlassFlow pipeline shape that writes these records to ClickHouse, see [OTLP Examples](/sources/otlp/examples).
 
-## Latency
-
-`awscloudwatchreceiver` is pull-based. Three timings stack:
-
-- **CloudWatch ingestion lag.** AWS itself takes anywhere between 1 and 10 minutes to make a published log event or metric datapoint queryable. The receiver's default `delay: 10m` on metrics accounts for this; reduce it only after confirming CloudWatch's own lag for your region and metric source is consistently lower.
-- **Logs `poll_interval`.** Default `1m`. Each poll fetches new events since the last poll.
-- **Metrics `collection_interval`.** Default `5m`, lowered to `1m` in the example above for the smallest reasonable batch size.
-
-End-to-end first-event latency is typically 2 to 12 minutes, depending on the AWS source and the receiver settings. If you need sub-minute latency, see the push alternative below.
-
-## Push alternative: Kinesis Data Firehose
-
-For sub-minute latency on metrics and logs, AWS supports two push paths that can avoid the receiver's poll lag:
-
-- **Metrics:** [CloudWatch Metric Streams](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Metric-Streams.html) to Firehose's HTTP endpoint, fronted by the [`awsfirehosereceiver`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awsfirehosereceiver) in alpha.
-- **Logs:** CloudWatch Logs subscription filter to Firehose with the same `awsfirehosereceiver` extension.
-
-This trades the simple pull config for an HTTPS endpoint, IAM for Firehose, and the Firehose record envelope. The advanced path is out of scope for this page; reach out via Slack or [get in touch](https://www.glassflow.dev/contact) with our team if you want to validate it end-to-end.
-
-<Callout type="info">
-**Migration note.** The legacy `awscloudwatchmetricsreceiver` was removed from `opentelemetry-collector-contrib` in v0.134.0 ([deprecation tracking](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/38912)). Metrics now live inside `awscloudwatchreceiver` under the `metrics:` config key. If you have a pre-v0.134.0 Collector config, the new key shape is `metrics.queries[]` (or `metrics.discovery`), not the old top-level `metrics_named[]`.
-</Callout>
-
 ## Related
 
 - [Sources overview](/sources).

--- a/docs/app/sources/cloudwatch/page.mdx
+++ b/docs/app/sources/cloudwatch/page.mdx
@@ -79,7 +79,7 @@ One OpenTelemetry Collector instance can drive both signals in parallel. Logs an
 
 ### Minimum IAM permissions
 
-The credentials used by the Collector need read-only access to the CloudWatch APIs the receiver calls. Scope `Resource` to the specific log group ARNs and metric namespaces in production; the wildcard below is suitable for validation only.
+The credentials used by the Collector require read-only access to the specific CloudWatch APIs called by the receiver. While a wildcard is fine for initial validation, you should restrict the 'Resource' scope to specific log group ARNs and metric namespaces in production.
 
 ```json
 {
@@ -138,11 +138,11 @@ For full OTLP source field reference, see [OTLP Schema Reference](/sources/otlp/
 
 `awscloudwatchreceiver` is pull-based. Three timings stack:
 
-- **CloudWatch ingestion lag.** AWS itself takes 1 to 10 minutes to make a published log event or metric datapoint queryable. The receiver's default `delay: 10m` on metrics accounts for this; reduce it only after confirming CloudWatch's own lag for your region and metric source is consistently lower.
+- **CloudWatch ingestion lag.** AWS itself takes anywhere between 1 and 10 minutes to make a published log event or metric datapoint queryable. The receiver's default `delay: 10m` on metrics accounts for this; reduce it only after confirming CloudWatch's own lag for your region and metric source is consistently lower.
 - **Logs `poll_interval`.** Default `1m`. Each poll fetches new events since the last poll.
 - **Metrics `collection_interval`.** Default `5m`, lowered to `1m` in the example above for the smallest reasonable batch size.
 
-End-to-end first-event latency is typically 2 to 12 minutes depending on the AWS source and the receiver settings. If you need sub-minute latency, see the push alternative below.
+End-to-end first-event latency is typically 2 to 12 minutes, depending on the AWS source and the receiver settings. If you need sub-minute latency, see the push alternative below.
 
 ## Push alternative: Kinesis Data Firehose
 
@@ -151,7 +151,7 @@ For sub-minute latency on metrics and logs, AWS supports two push paths that can
 - **Metrics:** [CloudWatch Metric Streams](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Metric-Streams.html) to Firehose's HTTP endpoint, fronted by the [`awsfirehosereceiver`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awsfirehosereceiver) in alpha.
 - **Logs:** CloudWatch Logs subscription filter to Firehose with the same `awsfirehosereceiver` extension.
 
-This trades the simple pull config for an HTTPS endpoint, IAM for Firehose, and the Firehose record envelope. The advanced path is out of scope for this page; reach out via Slack if you want to validate it end-to-end.
+This trades the simple pull config for an HTTPS endpoint, IAM for Firehose, and the Firehose record envelope. The advanced path is out of scope for this page; reach out via Slack or [get in touch](https://www.glassflow.dev/contact) with our team if you want to validate it end-to-end.
 
 <Callout type="info">
 **Migration note.** The legacy `awscloudwatchmetricsreceiver` was removed from `opentelemetry-collector-contrib` in v0.134.0 ([deprecation tracking](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/38912)). Metrics now live inside `awscloudwatchreceiver` under the `metrics:` config key. If you have a pre-v0.134.0 Collector config, the new key shape is `metrics.queries[]` (or `metrics.discovery`), not the old top-level `metrics_named[]`.

--- a/docs/app/sources/cloudwatch/page.mdx
+++ b/docs/app/sources/cloudwatch/page.mdx
@@ -1,21 +1,166 @@
 ---
 title: 'AWS CloudWatch'
-description: 'Ingest logs and metrics from AWS CloudWatch into ClickHouse with GlassFlow'
+description: 'Ingest logs and metrics from AWS CloudWatch into ClickHouse through an OpenTelemetry Collector relay to the GlassFlow OTLP receiver.'
 ---
 import { Callout } from 'nextra/components'
 
 # AWS CloudWatch
 
-CloudWatch is AWS's monitoring and observability service that collects logs, metrics, and events from cloud resources. It provides alerting, dashboards, and insights into system performance and health.
+[AWS CloudWatch](https://aws.amazon.com/cloudwatch/) is AWS's native monitoring service. Every managed AWS service emits its logs and metrics to CloudWatch by default, which makes it the canonical source of telemetry for AWS workloads.
 
-## Using AWS CloudWatch with GlassFlow
+## Why isn't direct CloudWatch to GlassFlow supported today?
 
-GlassFlow can ingest logs and metrics from AWS CloudWatch into ClickHouse with the same pipeline capabilities available to all GlassFlow sources — deduplication, filtering, and stateless transformations.
+CloudWatch has no first-party way to push data to a third-party OTLP endpoint with a custom HTTP header. AWS Marketplace integrations cover a fixed set of partner vendors, and the CloudWatch Logs subscription path through Kinesis Data Firehose's HTTP endpoint cannot inject per-record headers without a Lambda transform. Either route is strictly more work than running the standard OpenTelemetry Collector's pull-based receiver, so GlassFlow's recommended path is the Collector relay below.
+
+## Recommended pattern: AWS CloudWatch to OpenTelemetry Collector to GlassFlow
+
+Run an [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) with the [`awscloudwatchreceiver`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awscloudwatchreceiver) (alpha; covers both logs and metrics) and forward to the GlassFlow OTLP receiver via `otlp_http`. The Collector polls CloudWatch over standard AWS APIs using the SDK credential chain (env vars, shared credentials file, or EC2 IMDS).
+
+### OpenTelemetry Collector config
+
+```yaml
+# otel-collector.yaml
+receivers:
+  awscloudwatch/logs:
+    region: <aws-region>
+    logs:
+      poll_interval: 1m
+      groups:
+        named:
+          /your/log-group-name:
+            names: [your-log-stream]
+
+  awscloudwatch/metrics:
+    region: <aws-region>
+    metrics:
+      collection_interval: 1m
+      period: 60s
+      delay: 10m
+      queries:
+        - namespace: AWS/EC2
+          metric_name: CPUUtilization
+          dimensions:
+            InstanceId: i-0123456789abcdef0
+
+processors:
+  batch:
+    timeout: 1s
+
+exporters:
+  otlp_http/glassflow_logs:
+    endpoint: http://<glassflow-otlp-receiver>:4318
+    compression: none
+    headers:
+      x-glassflow-pipeline-id: <your-logs-pipeline-id>
+
+  otlp_http/glassflow_metrics:
+    endpoint: http://<glassflow-otlp-receiver>:4318
+    compression: none
+    headers:
+      x-glassflow-pipeline-id: <your-metrics-pipeline-id>
+
+service:
+  pipelines:
+    logs:
+      receivers: [awscloudwatch/logs]
+      processors: [batch]
+      exporters: [otlp_http/glassflow_logs]
+    metrics:
+      receivers: [awscloudwatch/metrics]
+      processors: [batch]
+      exporters: [otlp_http/glassflow_metrics]
+```
+
+<Callout type="warning">
+**Disable gzip compression** on the `otlp_http` exporter (`compression: none`). The GlassFlow OTLP receiver does not decompress gzip-encoded payloads and will return `400 Bad Request` if you leave the exporter's default `gzip` compression enabled.
+</Callout>
+
+One OpenTelemetry Collector instance can drive both signals in parallel. Logs and metrics need their own GlassFlow pipelines (`otlp.logs` source and `otlp.metrics` source respectively), so route each signal to its own exporter with the matching `x-glassflow-pipeline-id`.
+
+### Minimum IAM permissions
+
+The credentials used by the Collector need read-only access to the CloudWatch APIs the receiver calls. Scope `Resource` to the specific log group ARNs and metric namespaces in production; the wildcard below is suitable for validation only.
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:DescribeLogGroups",
+        "logs:DescribeLogStreams",
+        "logs:FilterLogEvents",
+        "logs:GetLogEvents"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "cloudwatch:ListMetrics",
+        "cloudwatch:GetMetricData"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+### What lands in ClickHouse
+
+A CloudWatch log event `{"event_id":"a1","level":"info","message":"hello"}` on log group `/your/log-group-name`, stream `your-log-stream`, in region `eu-central-1` arrives as:
+
+| Column | Value |
+|---|---|
+| `body` | `{"event_id":"a1","level":"info","message":"hello"}` |
+| `resource_attributes` | `{'aws.region': 'eu-central-1', 'cloudwatch.log.group.name': '/your/log-group-name', 'cloudwatch.log.stream': 'your-log-stream'}` |
+| `attributes` | `{'id': '<cloudwatch-event-id>'}` |
+
+A CloudWatch metric in namespace `AWS/EC2`, name `CPUUtilization`, with dimension `InstanceId=i-...` arrives as:
+
+| Column | Value |
+|---|---|
+| `metric_name` | `amazonaws.com/AWS/EC2/CPUUtilization` |
+| `resource_attributes` | `{'cloud.provider': 'aws', 'cloud.region': 'eu-central-1'}` |
+| `attributes` | `{'Namespace': 'AWS/EC2', 'MetricName': 'CPUUtilization', 'Dimensions': '{...}'}` |
+
+The receiver prepends `amazonaws.com/<Namespace>/` to the metric name per the [CloudWatch Metric Streams OpenTelemetry 1.0 format](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-metric-streams-formats-opentelemetry-100.html).
+
+Numeric metric values land in different schema fields depending on the receiver's `stats` configuration:
+
+- **No `stats` (default).** Each datapoint is an OTel Summary built from `Sum`, `SampleCount`, `Minimum`, `Maximum`. Map the GlassFlow OTLP fields `sum`, `count`, `min`, `max` in your sink to capture the full statistical picture.
+- **Explicit `stats: [Average]` (or any single stat).** Each datapoint is a Gauge with one value. Map the GlassFlow OTLP field `value_double` in your sink.
+
+For full OTLP source field reference, see [OTLP Schema Reference](/sources/otlp/schema-reference). For the GlassFlow pipeline shape that writes these records to ClickHouse, see [OTLP Examples](/sources/otlp/examples).
+
+## Latency
+
+`awscloudwatchreceiver` is pull-based. Three timings stack:
+
+- **CloudWatch ingestion lag.** AWS itself takes 1 to 10 minutes to make a published log event or metric datapoint queryable. The receiver's default `delay: 10m` on metrics accounts for this; reduce it only after confirming CloudWatch's own lag for your region and metric source is consistently lower.
+- **Logs `poll_interval`.** Default `1m`. Each poll fetches new events since the last poll.
+- **Metrics `collection_interval`.** Default `5m`, lowered to `1m` in the example above for the smallest reasonable batch size.
+
+End-to-end first-event latency is typically 2 to 12 minutes depending on the AWS source and the receiver settings. If you need sub-minute latency, see the push alternative below.
+
+## Push alternative: Kinesis Data Firehose
+
+For sub-minute latency on metrics and logs, AWS supports two push paths that can avoid the receiver's poll lag:
+
+- **Metrics:** [CloudWatch Metric Streams](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Metric-Streams.html) to Firehose's HTTP endpoint, fronted by the [`awsfirehosereceiver`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awsfirehosereceiver) in alpha.
+- **Logs:** CloudWatch Logs subscription filter to Firehose with the same `awsfirehosereceiver` extension.
+
+This trades the simple pull config for an HTTPS endpoint, IAM for Firehose, and the Firehose record envelope. The advanced path is out of scope for this page; reach out via Slack if you want to validate it end-to-end.
 
 <Callout type="info">
-**Available on request.** AWS CloudWatch connectors are natively supported in GlassFlow Enterprise Edition. To get started, [join our GlassFlow Slack community](https://glassflowhub.slack.com/join/shared_invite/zt-349m7lenp-IFeKSGfQwpJfIiQ7oyFFKg) to chat directly with our team, or [reach out](https://www.glassflow.dev/integrations#contact) to us with your use case, expected volumes, and timeline.
+**Migration note.** The legacy `awscloudwatchmetricsreceiver` was removed from `opentelemetry-collector-contrib` in v0.134.0 ([deprecation tracking](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/38912)). Metrics now live inside `awscloudwatchreceiver` under the `metrics:` config key. If you have a pre-v0.134.0 Collector config, the new key shape is `metrics.queries[]` (or `metrics.discovery`), not the old top-level `metrics_named[]`.
 </Callout>
 
 ## Related
 
-- [Sources overview](/sources)
+- [Sources overview](/sources).
+- [OpenTelemetry (OTLP) source](/sources/otlp). The receiver this pattern uses.
+- [OTLP Schema Reference](/sources/otlp/schema-reference). All available OTLP source fields for sink mapping.
+- [OTLP Sending Data](/sources/otlp/sending-data). OpenTelemetry Collector configuration reference.
+- [Grafana Alloy](/sources/grafana-alloy). Sibling pattern; Alloy ships `otelcol.receiver.awscloudwatch` as a first-class wrapper.

--- a/docs/app/sources/otlp/page.mdx
+++ b/docs/app/sources/otlp/page.mdx
@@ -83,6 +83,7 @@ x-glassflow-pipeline-id: <your-pipeline-id>
 
 Any OTLP-capable client can talk to the GlassFlow OTLP receiver. The pages below cover the validated integrations for popular telemetry agents and forwarders, including tested configs, field mappings, and per-tool caveats.
 
+- [AWS CloudWatch](/sources/cloudwatch). Pull-based via an OpenTelemetry Collector relay (`awscloudwatchreceiver` then `otlp_http`); covers both logs and metrics with one Collector instance.
 - [Fluent Bit](/sources/fluent-bit). Direct OTLP HTTP forwarding for logs and host metrics, no Collector in between.
 - [Fluentd](/sources/fluentd). Routed through an OpenTelemetry Collector relay (`fluent_forward` then `otlp_http`); Fluentd itself has no OTLP output that supports custom headers.
 - [Grafana Alloy](/sources/grafana-alloy). Direct OTLP forwarding for logs, metrics, and traces via Alloy's OpenTelemetry-native exporters.

--- a/docs/app/sources/page.mdx
+++ b/docs/app/sources/page.mdx
@@ -15,6 +15,7 @@ Sources marked 'Enterprise' are delivered as part of GlassFlow's Enterprise Edit
 export const sources = [
   // Open Source — alphabetical by Source
   { name: 'Apache Kafka®',           slug: 'kafka',             category: 'Streaming',                         version: 'Open Source' },
+  { name: 'AWS CloudWatch',          slug: 'cloudwatch',        category: 'Telemetry',                         version: 'Open Source' },
   { name: 'AWS MSK',                 slug: 'aws-msk',           category: 'Streaming (Kafka-compatible)',      version: 'Open Source' },
   { name: 'Confluent Cloud',         slug: 'confluent',         category: 'Streaming (Kafka-compatible)',      version: 'Open Source' },
   { name: 'Fluent Bit',              slug: 'fluent-bit',        category: 'Telemetry collector',               version: 'Open Source' },
@@ -29,7 +30,6 @@ export const sources = [
   { name: 'Amazon S3',               slug: 's3',                category: 'Object storage',                    version: 'Enterprise' },
   { name: 'Apache Cassandra®',       slug: 'cassandra',         category: 'Database',                          version: 'Enterprise' },
   { name: 'Apache Iceberg®',         slug: 'iceberg',           category: 'Table format',                      version: 'Enterprise' },
-  { name: 'AWS CloudWatch',          slug: 'cloudwatch',        category: 'Telemetry',                         version: 'Enterprise' },
   { name: 'AWS Kinesis',             slug: 'kinesis',           category: 'Streaming',                         version: 'Enterprise' },
   { name: 'Azure Event Hubs',        slug: 'azure-event-hubs',  category: 'Streaming',                         version: 'Enterprise' },
   { name: 'Delta Lake',              slug: 'delta-lake',        category: 'Table format',                      version: 'Enterprise' },


### PR DESCRIPTION
## Summary

- Promotes `docs/app/sources/cloudwatch/page.mdx` from on-request Enterprise stub to a validated Open Source guide using the OpenTelemetry Collector relay pattern, mirroring the Fluentd (ETL-1133) and Logstash (ETL-1134) shape.
- The path is `awscloudwatchreceiver` (alpha, logs + metrics in one receiver) → `batch` → `otlp_http` exporter → GlassFlow OTLP receiver, with `compression: none` and `x-glassflow-pipeline-id` per signal.
- Flips the `cloudwatch` row in `/sources` from Enterprise to Open Source (alphabetical position between Apache Kafka and AWS MSK) and adds AWS CloudWatch to the Telemetry collectors cross-link list on `/sources/otlp` (alphabetical position before Fluent Bit).

## Validation against staging

End-to-end exercised against `do-ams3-staging-cluster` with pipelines `etl-1163-logs` (otlp.logs) and `etl-1163-metrics` (otlp.metrics), Collector running in Docker on `otel/opentelemetry-collector-contrib:0.153.0`, awscloudwatchreceiver polling a seeded log group `/glassflow/etl-1163-validation` and a custom metric in namespace `GlassFlow/Validation`.

| # | Case | Result |
|---|---|---|
| 1 | Smoke (logs + metrics land in ClickHouse) | PASS |
| 2 | Header propagation (`x-glassflow-pipeline-id` reaches receiver) | PASS — cross-pipeline routing confirms each header drives the correct sink |
| 3 | Per-signal coverage (logs + metrics; traces explicitly out of scope per ticket) | PASS |
| 4 | Missing header → 400 | PASS (`400 missing x-glassflow-pipeline-id`) |

## Doc content highlights

- **Why direct CloudWatch to GlassFlow isn't supported.** Two-sentence framing: AWS Marketplace destinations are a fixed partner list, Firehose HTTP endpoint can't inject per-record headers without a Lambda transform. Editorial framing on the relative work; happy to soften the "strictly more work" phrasing if it reads too strong.
- **Collector config** with both `awscloudwatch/logs` and `awscloudwatch/metrics` receivers, two `otlp_http` exporters keyed by `x-glassflow-pipeline-id`. The same gzip warning Callout from the Fluentd/Logstash pages.
- **Minimum IAM** JSON block, `logs:Describe*` / `logs:Filter*` / `logs:Get*` plus `cloudwatch:ListMetrics` / `cloudwatch:GetMetricData`. Validated against the in-cluster Collector run; confirmed the read-only policy is sufficient (no writes attempted by the receiver).
- **What lands in ClickHouse** tables for both signals. Documents the receiver's `amazonaws.com/<Namespace>/<MetricName>` naming convention (per CloudWatch Metric Streams OTel 1.0 format) and the Summary-vs-single-stat mapping nuance (default mode produces Summary with sum/count/min/max; explicit `stats: [Average]` produces Gauge with `value_double`).
