### PR TITLE
docs(agents): add Agents section under usage-guide (ETL-1145)

### DIFF
--- a/docs/app/_meta.tsx
+++ b/docs/app/_meta.tsx
@@ -1,9 +1,9 @@
 export default {
     'getting-started': '',
+    'usage-guide': '',
     'installation': '',
     'sources': '',
     'transformations': '',
-    'usage-guide': '',
     'configuration': '',
     'architecture': '',
     'release-notes': '',

--- a/docs/app/usage-guide/_meta.tsx
+++ b/docs/app/usage-guide/_meta.tsx
@@ -1,4 +1,5 @@
 export default {
     'web-ui': '',
-    'python-sdk': ''
+    'python-sdk': '',
+    'agents': ''
 }

--- a/docs/app/usage-guide/agents/page.mdx
+++ b/docs/app/usage-guide/agents/page.mdx
@@ -1,0 +1,142 @@
+---
+title: 'Agents'
+description: 'Drive GlassFlow ETL from your AI coding assistant through curated agent skills.'
+---
+import { Callout, Tabs } from 'nextra/components'
+
+# Agents
+
+[GlassFlow Agent Skills](https://github.com/glassflow/agent-skills) let you create and operate GlassFlow pipelines from any AI coding assistant that reads SKILL.md files, including Claude Code, Cursor, and OpenAI Codex. Each skill is an instruction set the assistant loads when you describe a matching task. Skills are scoped to common GlassFlow workflows like creating a pipeline, sending test messages, or diagnosing a failing stage.
+
+The repository is open source and lives at [`glassflow/agent-skills`](https://github.com/glassflow/agent-skills).
+
+## Prerequisites
+
+- An AI coding assistant with skill or rule support. Install instructions for Claude Code, Cursor, OpenAI Codex, and other tools are in the [Installation](#installation) section below.
+- A reachable GlassFlow API. Local installs default to `http://localhost:8081`; remote installs point at whatever endpoint your team exposes.
+- Source and sink credentials handy. Skills will ask for them; they do not assume defaults.
+
+## Installation
+
+Pick your AI coding tool.
+
+<Tabs items={['Claude Code', 'Cursor', 'OpenAI Codex', 'Other tools']} storageKey="agent_tool">
+  <Tabs.Tab>
+
+Inside Claude Code:
+
+```
+/plugin marketplace add glassflow/agent-skills
+/plugin install glassflow-agent-skills@glassflow-agent-skills
+```
+
+Claude Code fetches the skills and loads their descriptions. Skills do not run automatically; Claude only invokes a skill when your prompt matches its description.
+
+To update later:
+
+```
+/plugin marketplace update glassflow-agent-skills
+```
+
+  </Tabs.Tab>
+  <Tabs.Tab>
+
+From your project root:
+
+```bash
+git clone https://github.com/glassflow/agent-skills.git /tmp/glassflow-agent-skills
+mkdir -p .cursor/skills
+cp -r /tmp/glassflow-agent-skills/skills/* .cursor/skills/
+```
+
+Reload Cursor (Cmd/Ctrl+Shift+P, "Developer: Reload Window") so it picks up the new files. Cursor reads SKILL.md frontmatter natively; no format conversion needed.
+
+To update later, pull and re-copy:
+
+```bash
+cd /tmp/glassflow-agent-skills && git pull
+cp -r /tmp/glassflow-agent-skills/skills/* .cursor/skills/
+```
+
+  </Tabs.Tab>
+  <Tabs.Tab>
+
+From your project root:
+
+```bash
+git clone https://github.com/glassflow/agent-skills.git /tmp/glassflow-agent-skills
+mkdir -p .codex/skills
+cp -r /tmp/glassflow-agent-skills/skills/* .codex/skills/
+```
+
+For global availability across all your projects, copy into `~/.codex/skills/` instead.
+
+  </Tabs.Tab>
+  <Tabs.Tab>
+
+The skills are plain SKILL.md files; any tool that reads markdown-with-frontmatter from a known directory can use them. Clone the repo and copy `skills/*` into the path your tool expects:
+
+| Tool | Path |
+|---|---|
+| Claude Code (manual, no plugin) | `.claude/skills/` |
+| Cursor | `.cursor/skills/` |
+| OpenAI Codex | `.codex/skills/` (or `~/.codex/skills/` for global) |
+| OpenCode | `.opencode/skills/` |
+| GitHub Copilot / VS Code | `.github/skills/` |
+
+```bash
+git clone https://github.com/glassflow/agent-skills.git /tmp/glassflow-agent-skills
+mkdir -p <tool-skill-path>
+cp -r /tmp/glassflow-agent-skills/skills/* <tool-skill-path>/
+```
+
+A community CLI also automates this across tools:
+
+```bash
+npx skills add glassflow/agent-skills
+```
+
+  </Tabs.Tab>
+</Tabs>
+
+## Available skills
+
+| Skill | Description |
+|---|---|
+| `create-pipeline` | Create a GlassFlow pipeline end to end. Walks through source configuration (Kafka or OTLP), optional dedup/filter/transform stages, ClickHouse sink mapping, then submits the v3 config to the GlassFlow API and waits for the pipeline to reach `Running`. |
+
+More skills are added as we surface common workflows. The canonical list lives in the repository.
+
+## Walkthrough: create your first pipeline
+
+Once installed, describe what you want and the assistant picks the right skill.
+
+> "Create a GlassFlow pipeline named `orders-prod` that reads from the `orders` Kafka topic on `kafka.local:9092` (SASL_PLAINTEXT, user `glassflow`, password in `KAFKA_PASSWORD`), deduplicates on `order_id` with a 1-hour window, and writes to the `analytics.orders` table on `clickhouse.local`."
+
+The `create-pipeline` skill activates and walks you through:
+
+1. Confirming the inputs it parsed and asking for anything missing (schema fields, ClickHouse credentials).
+2. Building a [v3 pipeline config](/configuration/pipeline-config-reference) and showing it back to you before submitting.
+3. Posting to `POST /api/v1/pipeline`.
+4. Polling `GET /api/v1/pipeline/<id>/health` until `overall_status` reaches `Running`.
+5. Suggesting a test-message recipe and a ClickHouse verification query.
+
+Skills always confirm before they touch your environment. Nothing is submitted without an explicit yes.
+
+## Example prompts
+
+Use these as starting points; the assistant infers the rest from your project state and recent context.
+
+- "Create an OTLP logs pipeline writing to `observability.app_logs` on the staging ClickHouse."
+- "Set up a Kafka pipeline for the `events` topic with deduplication on `event_id` over 30 seconds."
+- "Build a pipeline that filters events where `metadata.source == 'prod'` before writing to `analytics.prod_events`."
+
+## Contributing
+
+The `glassflow/agent-skills` repository carries skills that are useful to GlassFlow users in general. If you have a workflow you would like distilled into a skill, open an issue describing the user-visible task, the inputs the skill needs, and the steps the agent should take. Or open a PR with a draft `SKILL.md` under `skills/<skill-name>/` matching the structure of existing skills.
+
+## Related
+
+- [`glassflow/agent-skills` repository](https://github.com/glassflow/agent-skills). Source for every skill, license, and the install entry point.
+- [Pipeline configuration reference](/configuration/pipeline-config-reference). The v3 config shape skills emit.
+- [Claude Code plugin marketplaces](https://docs.claude.com/en/docs/claude-code/plugins). The underlying mechanism for distributing skills.

--- a/docs/app/usage-guide/agents/page.mdx
+++ b/docs/app/usage-guide/agents/page.mdx
@@ -1,10 +1,10 @@
 ---
-title: 'AI agents'
+title: 'AI Agents'
 description: 'Drive GlassFlow ETL from your AI coding assistant through curated agent skills.'
 ---
 import { Callout, Tabs } from 'nextra/components'
 
-# Agents
+# AI Agents
 
 [GlassFlow Agent Skills](https://github.com/glassflow/agent-skills) let you create and operate GlassFlow pipelines from any AI coding assistant that reads SKILL.md files, including Claude Code, Cursor, and OpenAI Codex. Each skill is an instruction set that the assistant loads when you describe a matching task. Skills are scoped to common GlassFlow workflows like creating a pipeline, sending test messages, or diagnosing a failing stage.
 

--- a/docs/app/usage-guide/agents/page.mdx
+++ b/docs/app/usage-guide/agents/page.mdx
@@ -1,12 +1,12 @@
 ---
-title: 'Agents'
+title: 'AI agents'
 description: 'Drive GlassFlow ETL from your AI coding assistant through curated agent skills.'
 ---
 import { Callout, Tabs } from 'nextra/components'
 
 # Agents
 
-[GlassFlow Agent Skills](https://github.com/glassflow/agent-skills) let you create and operate GlassFlow pipelines from any AI coding assistant that reads SKILL.md files, including Claude Code, Cursor, and OpenAI Codex. Each skill is an instruction set the assistant loads when you describe a matching task. Skills are scoped to common GlassFlow workflows like creating a pipeline, sending test messages, or diagnosing a failing stage.
+[GlassFlow Agent Skills](https://github.com/glassflow/agent-skills) let you create and operate GlassFlow pipelines from any AI coding assistant that reads SKILL.md files, including Claude Code, Cursor, and OpenAI Codex. Each skill is an instruction set that the assistant loads when you describe a matching task. Skills are scoped to common GlassFlow workflows like creating a pipeline, sending test messages, or diagnosing a failing stage.
 
 The repository is open source and lives at [`glassflow/agent-skills`](https://github.com/glassflow/agent-skills).
 
@@ -14,7 +14,7 @@ The repository is open source and lives at [`glassflow/agent-skills`](https://gi
 
 - An AI coding assistant with skill or rule support. Install instructions for Claude Code, Cursor, OpenAI Codex, and other tools are in the [Installation](#installation) section below.
 - A reachable GlassFlow API. Local installs default to `http://localhost:8081`; remote installs point at whatever endpoint your team exposes.
-- Source and sink credentials handy. Skills will ask for them; they do not assume defaults.
+- Source and sink credentials. Skills will ask for them; they do not assume defaults.
 
 ## Installation
 
@@ -99,39 +99,55 @@ npx skills add glassflow/agent-skills
   </Tabs.Tab>
 </Tabs>
 
+<Callout type="info">
+**Skills load at the start of each session.** If you edit a `SKILL.md` while the assistant is running, restart the session (or reload the window in Cursor) to pick up the change. To pull newer versions from this repository: run `/plugin marketplace update glassflow-agent-skills` in Claude Code, or `git pull` your local clone and re-copy `skills/*` for tools that use the file-drop install.
+</Callout>
+
 ## Available skills
 
 | Skill | Description |
 |---|---|
-| `create-pipeline` | Create a GlassFlow pipeline end to end. Walks through source configuration (Kafka or OTLP), optional dedup/filter/transform stages, ClickHouse sink mapping, then submits the v3 config to the GlassFlow API and waits for the pipeline to reach `Running`. |
+| `create-pipeline` | Create a GlassFlow pipeline end-to-end. Walks through source configuration (Kafka or OTLP), optional dedup/filter/transform stages, ClickHouse sink mapping, then submits the v3 config to the GlassFlow API and waits for the pipeline to reach `Running`. |
 | `debug-pipeline` | Localize a pipeline failure or missing-events problem. Starts with component logs (via kubectl or the OTel Collector's log backend) and cross-checks with metrics for silent failures, backpressure, and DLQ rate. |
 | `tune-pipeline` | Resolve sustained backpressure or sink-lag by reading GlassFlow's emitted metrics to confirm the bottleneck, proposing targeted changes to replicas, batch sizes, stream limits, or dedup storage, applying them via the appropriate API endpoint, and verifying by re-reading the same metrics. |
 
 More skills are added as we surface common workflows. The canonical list lives in the repository.
 
-## Walkthrough: create your first pipeline
+## Walkthrough: your first pipeline lifecycle
 
-Once installed, describe what you want and the assistant picks the right skill.
+Skills chain naturally across the pipeline lifecycle. Here is one end-to-end story that uses all three.
+
+### 1. Create the pipeline
 
 > "Create a GlassFlow pipeline named `orders-prod` that reads from the `orders` Kafka topic on `kafka.local:9092` (SASL_PLAINTEXT, user `glassflow`, password in `KAFKA_PASSWORD`), deduplicates on `order_id` with a 1-hour window, and writes to the `analytics.orders` table on `clickhouse.local`."
 
-The `create-pipeline` skill activates and walks you through:
+This invokes `create-pipeline`. The skill confirms the inputs it parsed, asks for anything missing (schema fields, ClickHouse credentials), builds a [v3 pipeline config](/configuration/pipeline-config-reference), submits it via `POST /api/v1/pipeline`, and polls until `overall_status` reaches `Running`. It finishes by suggesting a test-message recipe and a ClickHouse verification query.
 
-1. Confirming the inputs it parsed and asking for anything missing (schema fields, ClickHouse credentials).
-2. Building a [v3 pipeline config](/configuration/pipeline-config-reference) and showing it back to you before submitting.
-3. Posting to `POST /api/v1/pipeline`.
-4. Polling `GET /api/v1/pipeline/<id>/health` until `overall_status` reaches `Running`.
-5. Suggesting a test-message recipe and a ClickHouse verification query.
+### 2. Diagnose a problem when something looks off
+
+> "Diagnose pipeline `orders-prod`, the sink table stopped growing 30 minutes ago."
+
+This invokes `debug-pipeline`. The skill reads `/health` and `/dlq/state`, fetches sample DLQ records if any are present, and reports a structured diagnosis citing the verbatim error and a concrete next move. If the DLQ is clean, it picks the implicated component (sink, dedup, ingestor) and tails its logs via `kubectl` or the OTel Collector's log backend, then cross-checks metrics for silent failures.
+
+### 3. Tune for throughput once it is running
+
+> "Pipeline `orders-prod` has sustained sink lag, can you tune it?"
+
+This invokes `tune-pipeline`. The skill captures a baseline of the symptom metric, maps it to a specific tunable (sink replicas, batch size, NATS stream sizing, dedup storage, etc.), proposes a concrete diff tied to the measured value, applies it via `PUT /api/v1/pipeline/<id>/resources` or `POST /api/v1/pipeline/<id>/edit`, and re-pulls the same metric queries 5 minutes later to verify the change helped.
 
 Skills always confirm before they touch your environment. Nothing is submitted without an explicit yes.
 
 ## Example prompts
 
-Use these as starting points; the assistant infers the rest from your project state and recent context.
+Use the skills for any task you would normally run by hand against the GlassFlow API. The assistant infers which skill matches your prompt.
 
 - "Create an OTLP logs pipeline writing to `observability.app_logs` on the staging ClickHouse."
 - "Set up a Kafka pipeline for the `events` topic with deduplication on `event_id` over 30 seconds."
-- "Build a pipeline that filters events where `metadata.source == 'prod'` before writing to `analytics.prod_events`."
+- "Diagnose pipeline `orders-prod`, the sink table stopped growing 30 minutes ago."
+- "Check the DLQ for pipeline `orders-prod` and tell me what's failing."
+- "Pipeline `orders-prod` is showing ingestor backpressure, can you tune it?"
+- "Sink lag on `events-prod` is 2 minutes behind real time, please fix."
+- "Tune `orders-prod` so it can sustain 50,000 events per second."
 
 ## Contributing
 

--- a/docs/app/usage-guide/agents/page.mdx
+++ b/docs/app/usage-guide/agents/page.mdx
@@ -104,6 +104,8 @@ npx skills add glassflow/agent-skills
 | Skill | Description |
 |---|---|
 | `create-pipeline` | Create a GlassFlow pipeline end to end. Walks through source configuration (Kafka or OTLP), optional dedup/filter/transform stages, ClickHouse sink mapping, then submits the v3 config to the GlassFlow API and waits for the pipeline to reach `Running`. |
+| `debug-pipeline` | Localize a pipeline failure or missing-events problem. Starts with component logs (via kubectl or the OTel Collector's log backend) and cross-checks with metrics for silent failures, backpressure, and DLQ rate. |
+| `tune-pipeline` | Resolve sustained backpressure or sink-lag by reading GlassFlow's emitted metrics to confirm the bottleneck, proposing targeted changes to replicas, batch sizes, stream limits, or dedup storage, applying them via the appropriate API endpoint, and verifying by re-reading the same metrics. |
 
 More skills are added as we surface common workflows. The canonical list lives in the repository.
 

--- a/docs/app/usage-guide/page.mdx
+++ b/docs/app/usage-guide/page.mdx
@@ -18,7 +18,7 @@ Before creating your pipeline, ensure you have:
 
 ## Creating a Pipeline
 
-GlassFlow provides two ways to create a pipeline, each suited for different use cases and preferences:
+GlassFlow provides three ways to create a pipeline, each suited for different use cases and preferences:
 
 ### 1. Web UI (Recommended for Beginners)
 
@@ -53,7 +53,23 @@ The SDK provides:
 
 [Learn how to use the Python SDK →](/usage-guide/python-sdk)
 
-Both approaches create the same underlying pipeline configuration and can be used interchangeably based on your workflow preferences.
+### 3. AI Agents (Recommended for natural-language workflows)
+
+The **AI Agents** approach lets you create and operate pipelines from any AI coding assistant (Claude Code, Cursor, OpenAI Codex) via curated skills published in [`glassflow/agent-skills`](https://github.com/glassflow/agent-skills). This method is ideal for:
+
+- Teams already using AI coding assistants in their development workflow
+- Quick interactive pipeline creation through natural conversation
+- Operational tasks like diagnosing failures and tuning throughput
+
+The skills cover the full pipeline lifecycle:
+
+- `create-pipeline` walks you through source and sink configuration and submits the v3 config to the GlassFlow API
+- `debug-pipeline` localizes failures from logs, DLQ contents, and metrics
+- `tune-pipeline` proposes and applies targeted resource or config changes based on emitted metrics, then verifies the result
+
+[Learn how to use AI Agents →](/usage-guide/agents)
+
+All three approaches create the same underlying pipeline configuration and can be used interchangeably based on your workflow preferences.
 
 ## Scaling Pipelines
 


### PR DESCRIPTION
## Summary

- Introduces a new docs section at `/usage-guide/agents` documenting how to drive GlassFlow ETL from an AI coding assistant via the [glassflow/agent-skills](https://github.com/glassflow/agent-skills) repository.
- Framed tool-agnostically: the page describes what skills are, then uses tabs to show install commands for Claude Code (plugin marketplace), Cursor (`.cursor/skills/`), OpenAI Codex (`.codex/skills/`), and a fallback table for other tools that read SKILL.md files.
- Lists the current skills inventory (one entry today: `create-pipeline`), with a walkthrough and example prompts.
- Modeled on Estuary's [agent skills page](https://docs.estuary.dev/guides/agent-skills/) and inspired by ETL-1112's experience using Claude agents to drive load tests.

Linear: https://linear.app/glassflow/issue/ETL-1145/docs-how-to-use-claude-with-glassflow

## Companion repo

The actual skill content lives at https://github.com/glassflow/agent-skills (currently private). The repo will go public once the install flow has been reviewed and tested end to end across at least Claude Code and Cursor. The single skill shipping at launch is `create-pipeline`.

## Page changes

| File | Change |
|---|---|
| `docs/app/usage-guide/agents/page.mdx` | new, 143 lines, single page covering intro / prerequisites / installation (tabbed) / available skills / walkthrough / example prompts / contributing / related |
| `docs/app/usage-guide/_meta.tsx` | adds `'agents': ''` after `python-sdk` |
| `docs/app/_meta.tsx` | minor reorder (you also moved `usage-guide` to position 2 in your local edit) |

## Test plan

- [x] `pnpm dev` against `docs/` renders the new page at `/usage-guide/agents` without build errors
- [x] Tabs use the existing pattern from `docs/app/configuration/pipeline-config-reference/page.mdx`
- [x] No em-dashes in new prose
- [ ] Markos to review wording, especially the multi-tool install copy
- [ ] Optional: end-to-end test the install flow in Cursor against `glassflow/agent-skills` once that repo is public