### PR TITLE
docs(ETL-718): Protobuf pipeline usage guide with enterprise badges

### DIFF
--- a/docs/app/configuration/_meta.tsx
+++ b/docs/app/configuration/_meta.tsx
@@ -1,6 +1,7 @@
 export default {
     'pipeline-config-reference': '',
     'data-format': '',
+    'protobuf': '',
     'metrics': '',
     'clickhouse-sink': '',
     'dlq': '',

--- a/docs/app/configuration/data-format/page.mdx
+++ b/docs/app/configuration/data-format/page.mdx
@@ -1,31 +1,15 @@
 ---
 title: 'Supported Data Formats'
-description: 'Learn about supported data formats — JSON (Open Source and Enterprise), Avro and Protobuf (Enterprise) — and nested JSON handling in GlassFlow'
-tier: 'both'
+description: 'Learn about supported data formats and nested JSON handling in GlassFlow'
 ---
-import { Callout } from 'nextra/components'
 
 # Supported Data Formats
 
-<Tier badge="both" />
-
-GlassFlow supports three data formats for Kafka sources:
-
-| Format | Edition | Notes |
-|--------|---------|-------|
-| **JSON** | Open Source and Enterprise | Default format. |
-| **Avro** | Enterprise only | Confluent wire format; inline `.avsc` or Schema Registry. |
-| **Protobuf** | Enterprise only | Confluent wire format; inline `.proto` or Schema Registry. |
-
-<Callout type="info">
-Avro and Protobuf format support require the Enterprise Edition. [Get in touch](https://www.glassflow.dev/integrations#contact) to request access.
-</Callout>
+GlassFlow currently supports **JSON** as the primary data format for all sources.
 
 ## JSON Format
 
-<Tier badge="oss" inline />
-
-JSON is the default format and is available in both Open Source and Enterprise. All messages consumed from Kafka sources must be valid JSON objects. For OTLP sources, the OTLP protobuf payload is automatically flattened to JSON by GlassFlow.
+GlassFlow exclusively supports JSON data format. All messages consumed from sources must be valid JSON objects. For Kafka sources, messages in topics must be JSON. For OTLP sources, the OTLP protobuf payload is automatically flattened to JSON by GlassFlow.
 
 **Example JSON Message:**
 ```json
@@ -160,20 +144,155 @@ GlassFlow supports comprehensive data type mappings from Kafka to ClickHouse. Th
 
 ## Avro Format <Tier badge="enterprise" inline />
 
-Avro is available in the Enterprise Edition. GlassFlow decodes messages using the **Confluent wire format** (`0x00` magic byte + 4-byte schema ID + Avro payload). Two schema sources are supported:
+Avro is available in the Enterprise Edition. GlassFlow decodes messages using the **Confluent wire format** (`0x00` magic byte + 4-byte schema ID + Avro payload).
 
-- **Inline** — embed the Avro schema (`.avsc` JSON) directly in the pipeline config under `schema`.
-- **Confluent Schema Registry** — add a `schema_registry` object; GlassFlow fetches the schema by the ID in each message envelope.
+Set `"format": "avro"` on the Kafka source and provide the schema via one of the two modes below.
 
-Set `"format": "avro"` on the Kafka source. The rest of the pipeline (transforms, sink mapping) works identically to JSON sources.
+### Avro — Inline schema
+
+Embed the full `.avsc` JSON object directly as the `schema` field (not a string — the object itself):
+
+```json
+{
+  "type": "kafka",
+  "source_id": "events",
+  "connection_params": { "..." },
+  "topic": "avro_events",
+  "format": "avro",
+  "schema": {
+    "type": "record",
+    "name": "Event",
+    "namespace": "com.example",
+    "fields": [
+      { "name": "id",      "type": "string" },
+      { "name": "user_id", "type": "string" },
+      { "name": "action",  "type": "string" },
+      { "name": "ts_ms",   "type": "long"   }
+    ]
+  }
+}
+```
+
+The inline schema is compiled at pipeline-creation time (limit: 64 KB). GlassFlow derives the field list automatically — `schema_fields` is not required.
+
+#### Nullable fields (union types)
+
+Avro nullable fields use a union of `["null", T]`. GlassFlow maps the non-null branch to the field type:
+
+```json
+{ "name": "country", "type": ["null", "string"], "default": null }
+```
+
+#### Nested record fields
+
+Avro nested records (fields whose type is itself a `record`) are decoded into the field map as `map[string]any` at runtime. GlassFlow registers them as type `object` at the top level. **Dot-notation sub-field access is not supported for Avro nested records** — map the entire nested record to a ClickHouse `String` column (it will be stored as JSON):
+
+```json
+{
+  "type": "record",
+  "name": "Event",
+  "fields": [
+    { "name": "id", "type": "string" },
+    {
+      "name": "metadata",
+      "type": {
+        "type": "record",
+        "name": "Metadata",
+        "fields": [
+          { "name": "source", "type": "string" },
+          { "name": "version", "type": "int" }
+        ]
+      }
+    }
+  ]
+}
+```
+
+Sink mapping for the nested field:
+
+```json
+{ "name": "metadata", "column_name": "metadata", "column_type": "String" }
+```
+
+The `metadata` column will contain `{"source":"...", "version":...}` as a JSON string.
+
+### Avro — Confluent Schema Registry
+
+Add a `schema_registry` object. GlassFlow fetches the schema by the ID in each message envelope. The `schema` field is optional — provide it as a seed if you want transforms and sink mapping validated at pipeline-creation time:
+
+```json
+{
+  "type": "kafka",
+  "source_id": "events",
+  "connection_params": { "..." },
+  "topic": "avro_events",
+  "format": "avro",
+  "schema_registry": {
+    "url": "https://<sr-host>",
+    "api_key": "<sr-api-key>",
+    "api_secret": "<sr-api-secret>"
+  },
+  "schema": {
+    "type": "record",
+    "name": "Event",
+    "namespace": "com.example",
+    "fields": [
+      { "name": "id",      "type": "string" },
+      { "name": "user_id", "type": "string" },
+      { "name": "action",  "type": "string" },
+      { "name": "ts_ms",   "type": "long"   }
+    ]
+  }
+}
+```
 
 ## Protobuf Format <Tier badge="enterprise" inline />
 
-Protobuf is available in the Enterprise Edition. GlassFlow decodes messages using the **Confluent wire format** (`0x00` magic byte + 4-byte schema ID + varint message-index array + serialized payload). Two schema sources are supported:
+Protobuf is available in the Enterprise Edition. GlassFlow decodes messages using the **Confluent wire format** (`0x00` magic byte + 4-byte schema ID + varint message-index array + serialized payload).
 
-- **Inline** — embed the `.proto` IDL text directly in the pipeline config under `schema.proto`. The compiled descriptor must be ≤ 256 KB; `import` is not supported (all types must be in a single file).
-- **Confluent Schema Registry** — add a `schema_registry` object; GlassFlow fetches the `FileDescriptorProto` by the ID in each message envelope, with optional schema evolution support.
+Set `"format": "protobuf"` on the Kafka source and provide the schema via one of the two modes below. Nested messages map to `object` (JSON-serialized in ClickHouse).
 
-Set `"format": "protobuf"` on the Kafka source. Protobuf scalar types are mapped to the same intermediate type system as JSON fields. Nested messages map to `object` (JSON-serialized).
+### Protobuf — Inline schema
+
+Embed the `.proto` IDL source as a string under `schema.proto`. Use `schema.name` to select the root message (defaults to the first declared message):
+
+```json
+{
+  "type": "kafka",
+  "source_id": "events",
+  "connection_params": { "..." },
+  "topic": "proto_events",
+  "format": "protobuf",
+  "schema": {
+    "proto": "syntax = \"proto3\";\npackage example;\nmessage Event {\n  string id = 1;\n  string user_id = 2;\n  string action = 3;\n  int64 ts_ms = 4;\n}",
+    "name": "Event"
+  }
+}
+```
+
+Compiled descriptor limit: 256 KB. `import` statements are not resolved — all types must be defined in a single `.proto` string.
+
+### Protobuf — Confluent Schema Registry
+
+Add a `schema_registry` object. GlassFlow fetches the `FileDescriptorProto` by the schema ID in each message envelope. Schema evolution is supported automatically. The `schema` field is optional as a seed:
+
+```json
+{
+  "type": "kafka",
+  "source_id": "events",
+  "connection_params": { "..." },
+  "topic": "proto_events",
+  "format": "protobuf",
+  "schema_registry": {
+    "url": "https://<sr-host>",
+    "api_key": "<sr-api-key>",
+    "api_secret": "<sr-api-secret>"
+  },
+  "schema": {
+    "proto": "syntax = \"proto3\";\npackage example;\nmessage Event {\n  string id = 1;\n  string user_id = 2;\n  string action = 3;\n  int64 ts_ms = 4;\n}",
+    "name": "Event"
+  }
+}
+```
 
 For full pipeline examples, field type mappings, and troubleshooting, see the [Protobuf Pipeline Usage](/configuration/protobuf) guide.

--- a/docs/app/configuration/data-format/page.mdx
+++ b/docs/app/configuration/data-format/page.mdx
@@ -217,7 +217,7 @@ Sink mapping using dot notation:
 
 ### Avro — Confluent Schema Registry
 
-Add a `schema_registry` object. GlassFlow fetches the schema by the ID in each message envelope. The `schema` field is optional — provide it as a seed if you want transforms and sink mapping validated at pipeline-creation time:
+Add a `schema_registry` object alongside a `schema` seed. The seed is **required**: GlassFlow stores it as the base schema version on pipeline creation. When a message arrives with a different schema ID, GlassFlow fetches the new version from the registry and validates it is backward-compatible with the seed. Without the seed there is no base version to compare against and the pipeline will fail on its first message.
 
 ```json
 {
@@ -273,7 +273,7 @@ Compiled descriptor limit: 256 KB. `import` statements are not resolved — all 
 
 ### Protobuf — Confluent Schema Registry
 
-Add a `schema_registry` object. GlassFlow fetches the `FileDescriptorProto` by the schema ID in each message envelope. Schema evolution is supported automatically. The `schema` field is optional as a seed:
+Add a `schema_registry` object alongside a `schema` seed. The seed is **required** for the same reason as Avro: it is stored as the base schema version at pipeline-creation time. GlassFlow uses it as the anchor when a new schema ID appears in an envelope — fetching the new descriptor from the registry and checking backward compatibility before accepting it.
 
 ```json
 {

--- a/docs/app/configuration/data-format/page.mdx
+++ b/docs/app/configuration/data-format/page.mdx
@@ -185,7 +185,7 @@ Avro nullable fields use a union of `["null", T]`. GlassFlow maps the non-null b
 
 #### Nested record fields
 
-Avro nested records (fields whose type is itself a `record`) are decoded into the field map as `map[string]any` at runtime. GlassFlow registers them as type `object` at the top level. **Dot-notation sub-field access is not supported for Avro nested records** — map the entire nested record to a ClickHouse `String` column (it will be stored as JSON):
+Avro nested records (fields whose type is itself a `record`) are supported. You can map sub-fields using dot notation (e.g. `metadata.source`) or map the entire nested record to a ClickHouse `String` column:
 
 ```json
 {
@@ -208,13 +208,12 @@ Avro nested records (fields whose type is itself a `record`) are decoded into th
 }
 ```
 
-Sink mapping for the nested field:
+Sink mapping using dot notation:
 
 ```json
-{ "name": "metadata", "column_name": "metadata", "column_type": "String" }
+{ "name": "metadata.source",  "column_name": "metadata_source",  "column_type": "String" },
+{ "name": "metadata.version", "column_name": "metadata_version", "column_type": "Int32"  }
 ```
-
-The `metadata` column will contain `{"source":"...", "version":...}` as a JSON string.
 
 ### Avro — Confluent Schema Registry
 

--- a/docs/app/configuration/data-format/page.mdx
+++ b/docs/app/configuration/data-format/page.mdx
@@ -1,15 +1,31 @@
 ---
 title: 'Supported Data Formats'
-description: 'Learn about supported data formats and nested JSON handling in GlassFlow'
+description: 'Learn about supported data formats — JSON (Open Source and Enterprise), Avro and Protobuf (Enterprise) — and nested JSON handling in GlassFlow'
+tier: 'both'
 ---
+import { Callout } from 'nextra/components'
 
 # Supported Data Formats
 
-GlassFlow currently supports **JSON** as the primary data format for all sources.
+<Tier badge="both" />
+
+GlassFlow supports three data formats for Kafka sources:
+
+| Format | Edition | Notes |
+|--------|---------|-------|
+| **JSON** | Open Source and Enterprise | Default format. |
+| **Avro** | Enterprise only | Confluent wire format; inline `.avsc` or Schema Registry. |
+| **Protobuf** | Enterprise only | Confluent wire format; inline `.proto` or Schema Registry. |
+
+<Callout type="info">
+Avro and Protobuf format support require the Enterprise Edition. [Get in touch](https://www.glassflow.dev/integrations#contact) to request access.
+</Callout>
 
 ## JSON Format
 
-GlassFlow exclusively supports JSON data format. All messages consumed from sources must be valid JSON objects. For Kafka sources, messages in topics must be JSON. For OTLP sources, the OTLP protobuf payload is automatically flattened to JSON by GlassFlow.
+<Tier badge="oss" inline />
+
+JSON is the default format and is available in both Open Source and Enterprise. All messages consumed from Kafka sources must be valid JSON objects. For OTLP sources, the OTLP protobuf payload is automatically flattened to JSON by GlassFlow.
 
 **Example JSON Message:**
 ```json
@@ -141,3 +157,23 @@ GlassFlow supports comprehensive data type mappings from Kafka to ClickHouse. Th
 - `string` - ISO 8601 format timestamps
 - `int64` - Unix timestamps
 - `float64` - Unix timestamps with fractional seconds
+
+## Avro Format <Tier badge="enterprise" inline />
+
+Avro is available in the Enterprise Edition. GlassFlow decodes messages using the **Confluent wire format** (`0x00` magic byte + 4-byte schema ID + Avro payload). Two schema sources are supported:
+
+- **Inline** — embed the Avro schema (`.avsc` JSON) directly in the pipeline config under `schema`.
+- **Confluent Schema Registry** — add a `schema_registry` object; GlassFlow fetches the schema by the ID in each message envelope.
+
+Set `"format": "avro"` on the Kafka source. The rest of the pipeline (transforms, sink mapping) works identically to JSON sources.
+
+## Protobuf Format <Tier badge="enterprise" inline />
+
+Protobuf is available in the Enterprise Edition. GlassFlow decodes messages using the **Confluent wire format** (`0x00` magic byte + 4-byte schema ID + varint message-index array + serialized payload). Two schema sources are supported:
+
+- **Inline** — embed the `.proto` IDL text directly in the pipeline config under `schema.proto`. The compiled descriptor must be ≤ 256 KB; `import` is not supported (all types must be in a single file).
+- **Confluent Schema Registry** — add a `schema_registry` object; GlassFlow fetches the `FileDescriptorProto` by the ID in each message envelope, with optional schema evolution support.
+
+Set `"format": "protobuf"` on the Kafka source. Protobuf scalar types are mapped to the same intermediate type system as JSON fields. Nested messages map to `object` (JSON-serialized).
+
+For full pipeline examples, field type mappings, and troubleshooting, see the [Protobuf Pipeline Usage](/configuration/protobuf) guide.

--- a/docs/app/configuration/protobuf/page.mdx
+++ b/docs/app/configuration/protobuf/page.mdx
@@ -1,0 +1,312 @@
+---
+title: 'Protobuf Pipeline Usage'
+description: 'Configure a Kafka → GlassFlow → ClickHouse pipeline to consume Protobuf-encoded messages — inline schema or Confluent Schema Registry.'
+tier: 'enterprise'
+---
+import { Callout, Tabs } from 'nextra/components'
+
+# Protobuf Pipeline Usage
+
+<Tier badge="enterprise" />
+
+GlassFlow supports [Protocol Buffers](https://protobuf.dev/) as a Kafka source format. Messages are decoded before entering the processing pipeline, so deduplication, filtering, stateless transformations, and the ClickHouse sink all work the same way as with JSON sources.
+
+<Callout type="info">
+Protobuf (and Avro) format support is available in the Enterprise Edition only. JSON sources are available in both Open Source and Enterprise. [Get in touch](https://www.glassflow.dev/integrations#contact) to request access.
+</Callout>
+
+## How it works
+
+GlassFlow treats Protobuf as an **external format**: the binary Confluent-envelope payload is decoded into a flat field map at ingestion time, and the rest of the pipeline operates on those fields just as it would with a JSON source. There is no change to the internal wire format.
+
+Two schema sources are supported:
+
+| Mode | When to use |
+|------|-------------|
+| **Inline** | You own the `.proto` definition and want to embed it directly in the pipeline config. |
+| **Confluent Schema Registry** | Your producers register schemas with a Confluent-compatible SR; GlassFlow fetches the schema by the ID embedded in each message. |
+
+In both modes every Kafka message must use the **Confluent wire format**:
+
+```
+[0x00 magic byte][4-byte big-endian schema ID][varint message-index array][serialized proto payload]
+```
+
+The message-index array selects the root message within the `FileDescriptor`. A single-message `.proto` file encodes this as `[0]` (one varint with value 0).
+
+## Inline schema
+
+Provide the `.proto` source text directly under `schema.proto`. GlassFlow compiles it at pipeline-creation time and stores the resulting `FileDescriptorProto`.
+
+**Limitations for inline schemas:**
+- The compiled `FileDescriptorProto` must be ≤ 256 KB.
+- `import` statements are not resolved — all message types used must be defined in the same file.
+- Nested messages are mapped to ClickHouse `String` columns (JSON-serialized) unless you map their scalar sub-fields individually using dot notation.
+
+### Minimal example (ingest-only)
+
+<Tabs items={['JSON']} storageKey="config_format">
+  <Tabs.Tab>
+    ```json
+    {
+      "version": "v3",
+      "pipeline_id": "proto-ingest-1",
+      "name": "protobuf-ingest-only",
+      "sources": [
+        {
+          "type": "kafka",
+          "source_id": "events",
+          "connection_params": {
+            "brokers": ["kafka:9094"],
+            "mechanism": "PLAIN",
+            "protocol": "SASL_PLAINTEXT",
+            "username": "<user>",
+            "password": "<password>"
+          },
+          "topic": "proto_events",
+          "format": "protobuf",
+          "schema": {
+            "proto": "syntax = \"proto3\";\npackage example;\nmessage Event {\n  string id = 1;\n  string user_id = 2;\n  string action = 3;\n  int64 ts_ms = 4;\n}",
+            "name": "Event"
+          },
+          "consumer_group_initial_offset": "earliest"
+        }
+      ],
+      "sink": {
+        "type": "clickhouse",
+        "connection_params": {
+          "host": "clickhouse.example.com",
+          "port": "9000",
+          "database": "default",
+          "username": "default",
+          "password": "<password>",
+          "secure": false
+        },
+        "table": "proto_events",
+        "max_batch_size": 100,
+        "max_delay_time": "5s",
+        "mapping": [
+          {"name": "id",      "column_name": "id",      "column_type": "String"},
+          {"name": "user_id", "column_name": "user_id", "column_type": "String"},
+          {"name": "action",  "column_name": "action",  "column_type": "String"},
+          {"name": "ts_ms",   "column_name": "ts_ms",   "column_type": "Int64"}
+        ]
+      }
+    }
+    ```
+  </Tabs.Tab>
+</Tabs>
+
+### With deduplication and filter
+
+<Tabs items={['JSON']} storageKey="config_format">
+  <Tabs.Tab>
+    ```json
+    {
+      "version": "v3",
+      "pipeline_id": "proto-dedup-filter-1",
+      "name": "protobuf-dedup-filter",
+      "sources": [
+        {
+          "type": "kafka",
+          "source_id": "events",
+          "connection_params": {
+            "brokers": ["kafka:9094"],
+            "mechanism": "PLAIN",
+            "protocol": "SASL_PLAINTEXT",
+            "username": "<user>",
+            "password": "<password>"
+          },
+          "topic": "proto_events",
+          "format": "protobuf",
+          "schema": {
+            "proto": "syntax = \"proto3\";\npackage example;\nmessage Event {\n  string id = 1;\n  string user_id = 2;\n  string action = 3;\n  int64 ts_ms = 4;\n}",
+            "name": "Event"
+          },
+          "consumer_group_initial_offset": "earliest"
+        }
+      ],
+      "transforms": [
+        {
+          "type": "dedup",
+          "source_id": "events",
+          "config": {
+            "key": "id",
+            "time_window": "5m"
+          }
+        },
+        {
+          "type": "filter",
+          "source_id": "events",
+          "config": {
+            "expression": "action != \"skip\""
+          }
+        }
+      ],
+      "sink": {
+        "type": "clickhouse",
+        "connection_params": {
+          "host": "clickhouse.example.com",
+          "port": "9000",
+          "database": "default",
+          "username": "default",
+          "password": "<password>",
+          "secure": false
+        },
+        "table": "proto_events",
+        "max_batch_size": 100,
+        "max_delay_time": "5s",
+        "mapping": [
+          {"name": "id",      "column_name": "id",      "column_type": "String"},
+          {"name": "user_id", "column_name": "user_id", "column_type": "String"},
+          {"name": "action",  "column_name": "action",  "column_type": "String"},
+          {"name": "ts_ms",   "column_name": "ts_ms",   "column_type": "Int64"}
+        ]
+      }
+    }
+    ```
+  </Tabs.Tab>
+</Tabs>
+
+## Confluent Schema Registry
+
+Add a `schema_registry` object to the source. GlassFlow reads the schema ID from the Confluent wire-format envelope of each message, fetches the corresponding `FileDescriptorProto` from the registry, and decodes the payload.
+
+You may optionally include a `schema` object with a seed `.proto`. GlassFlow compiles the seed at pipeline-creation time so the sink mapping and any transforms can be validated before the first message arrives. The seed is overridden at runtime by whatever schema ID the producer embeds.
+
+<Callout type="info">
+**Schema evolution.** When a producer registers a new schema version the ID in the envelope changes. GlassFlow fetches and caches the new descriptor automatically — no pipeline restart needed, as long as the evolution is backward-compatible (i.e. existing field numbers are not reused with a different type).
+</Callout>
+
+### Registry example (with seed schema)
+
+<Tabs items={['JSON']} storageKey="config_format">
+  <Tabs.Tab>
+    ```json
+    {
+      "version": "v3",
+      "pipeline_id": "proto-sr-1",
+      "name": "protobuf-schema-registry",
+      "sources": [
+        {
+          "type": "kafka",
+          "source_id": "events",
+          "connection_params": {
+            "brokers": ["kafka:9094"],
+            "mechanism": "PLAIN",
+            "protocol": "SASL_PLAINTEXT",
+            "username": "<user>",
+            "password": "<password>"
+          },
+          "topic": "proto_events",
+          "schema_registry": {
+            "url": "https://<sr-host>",
+            "api_key": "<sr-api-key>",
+            "api_secret": "<sr-api-secret>"
+          },
+          "format": "protobuf",
+          "schema": {
+            "proto": "syntax = \"proto3\";\npackage example;\nmessage Event {\n  string id = 1;\n  string user_id = 2;\n  string action = 3;\n  int64 ts_ms = 4;\n}",
+            "name": "Event"
+          },
+          "consumer_group_initial_offset": "earliest"
+        }
+      ],
+      "sink": {
+        "type": "clickhouse",
+        "connection_params": {
+          "host": "clickhouse.example.com",
+          "port": "9000",
+          "database": "default",
+          "username": "default",
+          "password": "<password>",
+          "secure": false
+        },
+        "table": "proto_events",
+        "max_batch_size": 100,
+        "max_delay_time": "5s",
+        "mapping": [
+          {"name": "id",      "column_name": "id",      "column_type": "String"},
+          {"name": "user_id", "column_name": "user_id", "column_type": "String"},
+          {"name": "action",  "column_name": "action",  "column_type": "String"},
+          {"name": "ts_ms",   "column_name": "ts_ms",   "column_type": "Int64"}
+        ]
+      }
+    }
+    ```
+  </Tabs.Tab>
+</Tabs>
+
+## Source configuration reference
+
+The `format`, `schema`, and `schema_registry` fields are added to the standard Kafka source object. All other source, transform, and sink fields work as documented in the [Pipeline Configuration Reference](/configuration/pipeline-config-reference).
+
+### `format`
+
+```
+"format": "protobuf"
+```
+
+Sets the message decoding format. Omit or set to `"json"` for plain JSON sources (Open Source and Enterprise). `"avro"` is also supported in the Enterprise Edition.
+
+### `schema` (inline mode)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `proto` | string | Yes (inline) | Full `.proto` IDL source text. All referenced types must be defined in the same file — `import` is not supported. |
+| `name` | string | No | Root message name. If omitted, the first message declared in the file is used. |
+
+### `schema_registry`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `url` | string | Yes | Base URL of the Confluent-compatible Schema Registry. |
+| `api_key` | string | No | API key for basic authentication. |
+| `api_secret` | string | No | API secret for basic authentication. |
+
+## Field type mapping
+
+GlassFlow maps Protobuf scalar types to the same intermediate type system used by JSON sources. The mapping follows the standard Protobuf → Go type rules:
+
+| Protobuf type | GlassFlow intermediate type |
+|---------------|----------------------------|
+| `string` | `string` |
+| `int32`, `sint32`, `sfixed32` | `int32` |
+| `int64`, `sint64`, `sfixed64` | `int64` |
+| `uint32`, `fixed32` | `uint32` |
+| `uint64`, `fixed64` | `uint64` |
+| `float` | `float32` |
+| `double` | `float64` |
+| `bool` | `bool` |
+| `bytes` | `bytes` |
+| `enum` | `int32` (numeric value) |
+| Nested `message` | `object` (JSON-serialized) |
+| `repeated` scalar | `array` |
+
+For the full list of supported ClickHouse target types, see [Supported Data Formats](/configuration/data-format).
+
+## Troubleshooting
+
+### `proto compilation error`
+
+The inline `.proto` text contains a syntax error or references a type from another file via `import`. Fix the syntax or inline all type definitions into a single `.proto` string.
+
+### `compiled descriptor is N bytes, exceeds 256 KB limit`
+
+The compiled `FileDescriptorProto` exceeds the 256 KB inline limit. This is rare for typical event schemas. Use a Schema Registry instead to avoid the size cap.
+
+### `message "X" not found in proto schema`
+
+The `schema.name` field does not match any message declared in the `.proto` source. Check capitalisation — Protobuf message names are case-sensitive.
+
+### `invalid Confluent magic byte: 0xNN`
+
+The Kafka message does not start with the `0x00` Confluent magic byte. Your producer is not using the Confluent wire format. Update the producer to serialize with `confluent-kafka` or a compatible library that wraps the payload with the schema-ID envelope.
+
+### `message too short (N bytes) for Confluent wire format`
+
+The message is shorter than the minimum 5-byte Confluent header. The topic likely contains non-Protobuf messages. Check the topic and consumer group offset settings.
+
+### Decode errors after schema evolution
+
+If a producer registers a new schema version that is not backward-compatible (e.g. a field number is reused with a different type), in-flight messages encoded with the old schema may fail to decode. Use the [Dead-Letter Queue](/configuration/dlq) to inspect and reprocess failed messages.

--- a/docs/app/configuration/protobuf/page.mdx
+++ b/docs/app/configuration/protobuf/page.mdx
@@ -169,15 +169,13 @@ Provide the `.proto` source text directly under `schema.proto`. GlassFlow compil
 
 ## Confluent Schema Registry
 
-Add a `schema_registry` object to the source. GlassFlow reads the schema ID from the Confluent wire-format envelope of each message, fetches the corresponding `FileDescriptorProto` from the registry, and decodes the payload.
-
-You may optionally include a `schema` object with a seed `.proto`. GlassFlow compiles the seed at pipeline-creation time so the sink mapping and any transforms can be validated before the first message arrives. The seed is overridden at runtime by whatever schema ID the producer embeds.
+Add a `schema_registry` object to the source alongside a `schema` seed. The seed is **required**: GlassFlow compiles it and stores the resulting descriptor as the base schema version at pipeline-creation time. When a message arrives with a different schema ID, GlassFlow fetches the new `FileDescriptorProto` from the registry and validates backward compatibility against the stored base. Without a seed there is no base version and the pipeline will fail on its first message.
 
 <Callout type="info">
 **Schema evolution.** When a producer registers a new schema version the ID in the envelope changes. GlassFlow fetches and caches the new descriptor automatically — no pipeline restart needed, as long as the evolution is backward-compatible (i.e. existing field numbers are not reused with a different type).
 </Callout>
 
-### Registry example (with seed schema)
+### Registry example
 
 <Tabs items={['JSON']} storageKey="config_format">
   <Tabs.Tab>
@@ -248,11 +246,11 @@ The `format`, `schema`, and `schema_registry` fields are added to the standard K
 
 Sets the message decoding format. Omit or set to `"json"` for plain JSON sources (Open Source and Enterprise). `"avro"` is also supported in the Enterprise Edition.
 
-### `schema` (inline mode)
+### `schema`
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `proto` | string | Yes (inline) | Full `.proto` IDL source text. All referenced types must be defined in the same file — `import` is not supported. |
+| `proto` | string | Yes | Full `.proto` IDL source text. All referenced types must be defined in the same file — `import` is not supported. Required in both inline and Schema Registry modes. |
 | `name` | string | No | Root message name. If omitted, the first message declared in the file is used. |
 
 ### `schema_registry`

--- a/docs/app/configuration/protobuf/page.mdx
+++ b/docs/app/configuration/protobuf/page.mdx
@@ -41,7 +41,6 @@ Provide the `.proto` source text directly under `schema.proto`. GlassFlow compil
 **Limitations for inline schemas:**
 - The compiled `FileDescriptorProto` must be ≤ 256 KB.
 - `import` statements are not resolved — all message types used must be defined in the same file.
-- Nested messages are mapped to ClickHouse `String` columns (JSON-serialized) unless you map their scalar sub-fields individually using dot notation.
 
 ### Minimal example (ingest-only)
 
@@ -280,7 +279,7 @@ GlassFlow maps Protobuf scalar types to the same intermediate type system used b
 | `bool` | `bool` |
 | `bytes` | `bytes` |
 | `enum` | `int32` (numeric value) |
-| Nested `message` | `object` (JSON-serialized) |
+| Nested `message` | `object` |
 | `repeated` scalar | `array` |
 
 For the full list of supported ClickHouse target types, see [Supported Data Formats](/configuration/data-format).

--- a/docs/app/sources/kafka/topic-configuration/page.mdx
+++ b/docs/app/sources/kafka/topic-configuration/page.mdx
@@ -17,7 +17,7 @@ Each Kafka source in the `sources` array defines a single topic to consume from.
 | `topic` | string | Yes | Kafka topic name |
 | `consumer_group_initial_offset` | string | No | Where to start reading: `earliest` or `latest` (default: `latest`) |
 | `format` | string | No | Message format: `"json"` (default, Open Source and Enterprise), `"avro"` or `"protobuf"` (Enterprise only). See [Supported Data Formats](/configuration/data-format). |
-| `schema` | object | Conditional | Schema definition for Avro (`.avsc` JSON) or Protobuf (`proto` text + `name`). Required for inline Avro/Protobuf; optional seed for Schema Registry mode. Not used for JSON. |
+| `schema` | object | Conditional | Schema definition for Avro (`.avsc` JSON) or Protobuf (`proto` text + `name`). Required for both inline and Schema Registry modes. Not used for JSON. |
 | `schema_registry` | object | No | Confluent Schema Registry connection (`url`, `api_key`, `api_secret`). When present, GlassFlow fetches the schema from the registry using the ID in each message envelope. Enterprise only. |
 | `schema_fields` | array | Conditional | Field definitions for this source. Required for JSON sources. Inferred from the schema for Avro and Protobuf. |
 

--- a/docs/app/sources/kafka/topic-configuration/page.mdx
+++ b/docs/app/sources/kafka/topic-configuration/page.mdx
@@ -16,7 +16,10 @@ Each Kafka source in the `sources` array defines a single topic to consume from.
 | `connection_params` | object | Yes | Kafka connection parameters. See [Connections](/sources/kafka/connections). |
 | `topic` | string | Yes | Kafka topic name |
 | `consumer_group_initial_offset` | string | No | Where to start reading: `earliest` or `latest` (default: `latest`) |
-| `schema_fields` | array | Yes | Field definitions for this source |
+| `format` | string | No | Message format: `"json"` (default, Open Source and Enterprise), `"avro"` or `"protobuf"` (Enterprise only). See [Supported Data Formats](/configuration/data-format). |
+| `schema` | object | Conditional | Schema definition for Avro (`.avsc` JSON) or Protobuf (`proto` text + `name`). Required for inline Avro/Protobuf; optional seed for Schema Registry mode. Not used for JSON. |
+| `schema_registry` | object | No | Confluent Schema Registry connection (`url`, `api_key`, `api_secret`). When present, GlassFlow fetches the schema from the registry using the ID in each message envelope. Enterprise only. |
+| `schema_fields` | array | Conditional | Field definitions for this source. Required for JSON sources. Inferred from the schema for Avro and Protobuf. |
 
 ## Consumer Group Offset
 


### PR DESCRIPTION
## Summary

- **New page** `docs/app/configuration/protobuf/page.mdx` — full Protobuf usage guide: inline schema, Confluent Schema Registry, Confluent wire-format envelope, field type mapping, schema evolution, and troubleshooting. Carries `tier: 'enterprise'` frontmatter and `<Tier badge="enterprise" />` badge.
- **`configuration/data-format`** — updated to list all three formats (JSON / Avro / Protobuf) with a comparison table and edition context. Avro and Protobuf sections added with `<Tier badge="enterprise" inline />` badges. Page now carries `tier: 'both'` frontmatter.
- **`sources/kafka/topic-configuration`** — source parameters table extended with `format`, `schema`, and `schema_registry` fields (Enterprise-only), with links to the data-format and protobuf pages.
- **`configuration/_meta.tsx`** — protobuf page registered in nav between data-format and metrics.

Pipeline config examples are derived from the `ee-etl` test fixtures in `glassflow-api/bin/` (inline, dedup, SR evolution).

## Test plan

- [ ] `format`, `schema`, `schema_registry` fields visible in kafka topic-configuration table
- [ ] Data-format page intro shows the format comparison table with edition column
- [ ] Avro and Protobuf sections appear with Enterprise badge
- [ ] Protobuf page renders with Enterprise badge at top
- [ ] Both inline and registry pipeline JSON examples render correctly
- [ ] Nav shows "Protobuf" entry under Configuration between Data Formats and Metrics
- [ ] Troubleshooting section covers all decode error scenarios from the implementation